### PR TITLE
Add better-sqlite3 built dependency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,5 @@ packages:
   - examples/*
 
 onlyBuiltDependencies:
+  - better-sqlite3
   - esbuild


### PR DESCRIPTION
It requires to manually approve build of better-sqlite3 without specifing it in `pnpm-workspace.yml`

Also, currently better-sqlite3 doesn't work with latest version of node. 