### PR TITLE
feat(playground): open device via grant request

### DIFF
--- a/examples/playground/src/playground/components/PeersPanel.tsx
+++ b/examples/playground/src/playground/components/PeersPanel.tsx
@@ -95,7 +95,7 @@ export function PeersPanel({
             title={
               authEnabled && !(authCanIssue || authCanDelegate)
                 ? "Verify-only tabs can’t mint invites. Open a minting peer (or import a grant with share permission)."
-                : "New device (isolated): separate storage, auto-invite"
+                : "New device (isolated): separate storage, auto-grant"
             }
           >
             <MdLockOutline className="text-[16px]" />
@@ -133,4 +133,3 @@ export function PeersPanel({
     </div>
   );
 }
-

--- a/examples/playground/src/playground/components/ShareSubtreeDialog.tsx
+++ b/examples/playground/src/playground/components/ShareSubtreeDialog.tsx
@@ -209,7 +209,7 @@ export function ShareSubtreeDialog(props: ShareSubtreeDialogProps) {
                 disabled={authBusy || !authEnabled || !(authCanIssue || authCanDelegate)}
                 title={
                   authCanIssue || authCanDelegate
-                    ? "Open an isolated device tab and auto-import the invite"
+                    ? "Open an isolated device tab and auto-grant access"
                     : "This tab can’t mint invites (verify-only)"
                 }
               >

--- a/examples/playground/src/playground/components/TreePanel.tsx
+++ b/examples/playground/src/playground/components/TreePanel.tsx
@@ -249,7 +249,7 @@ export function TreePanel({
             title={
               authEnabled && !(authCanIssue || authCanDelegate)
                 ? "Verify-only tabs can’t mint invites. Open a minting peer (or import a grant with share permission)."
-                : "New device (isolated): separate storage (no shared keys/private-roots). Auto-invite; Alt+click opens join-only."
+                : "New device (isolated): separate storage (no shared keys/private-roots). Auto-grant; Alt+click opens join-only."
             }
             aria-label="New device (isolated)"
           >

--- a/examples/playground/src/sync-v0.ts
+++ b/examples/playground/src/sync-v0.ts
@@ -11,6 +11,14 @@ export type AuthGrantMessageV1 = {
   ts: number;
 };
 
+export type AuthInviteRequestMessageV1 = {
+  t: "auth_invite_request_v1";
+  doc_id: string;
+  request_id: string;
+  from_replica_pk_hex: string;
+  ts: number;
+};
+
 export function hexToBytes16(hex: string): Uint8Array {
   return nodeIdToBytes16(hex);
 }

--- a/examples/playground/tests/playground.spec.ts
+++ b/examples/playground/tests/playground.spec.ts
@@ -661,6 +661,8 @@ test("open device auto-syncs so the scoped root label is visible", async ({ brow
 
     await pageB.bringToFront();
     await expect(pageB.getByText("Ready (memory)")).toBeVisible({ timeout: 60_000 });
+    await expect.poll(() => pageB.url()).toContain("invite_req=");
+    await expect.poll(() => pageB.url()).not.toContain("#invite=");
 
     const rowB = treeRowByNodeId(pageB, nodeId);
     await expect(rowB.getByRole("button", { name: "AASD" })).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
Stacked on #75 (base branch: feat/auth-cose-cwt).

This is the first slice of #77.

What changed

Open device no longer puts secrets in the URL hash. Instead, it opens a join only tab with an invite request id, waits for that tab to announce its replica pubkey, then sends a targeted grant (capability token plus doc payload key) over BroadcastChannel.

This keeps the demo flow one click, but avoids copying or leaking an invite link by default.

Notes

This is still a playground level flow. The payload key is sent as plaintext on the local BroadcastChannel. The protocol level upgrade for sealed key distribution and revocation lives in #77 and #78.