### PR TITLE
fix(ci): normalize ed25519 sha512 digest type

### DIFF
--- a/packages/treecrdt-auth/src/ed25519.ts
+++ b/packages/treecrdt-auth/src/ed25519.ts
@@ -8,9 +8,8 @@ import {
 import { sha512 } from '@noble/hashes/sha512';
 
 let ed25519Ready = false;
-function sha512ForEd25519(message: Uint8Array): Uint8Array {
-  return new Uint8Array(sha512(message));
-}
+const sha512ForEd25519: NonNullable<(typeof ed25519Hashes)['sha512']> = (message) =>
+  Uint8Array.from(sha512(message));
 
 export function ensureEd25519(): void {
   if (ed25519Ready) return;

--- a/packages/treecrdt-auth/src/ed25519.ts
+++ b/packages/treecrdt-auth/src/ed25519.ts
@@ -8,10 +8,13 @@ import {
 import { sha512 } from '@noble/hashes/sha512';
 
 let ed25519Ready = false;
+function sha512ForEd25519(message: Uint8Array): Uint8Array {
+  return new Uint8Array(sha512(message));
+}
 
 export function ensureEd25519(): void {
   if (ed25519Ready) return;
-  ed25519Hashes.sha512 = sha512;
+  ed25519Hashes.sha512 = sha512ForEd25519;
   ed25519Ready = true;
 }
 

--- a/packages/treecrdt-crypto/src/keystore.ts
+++ b/packages/treecrdt-crypto/src/keystore.ts
@@ -39,9 +39,13 @@ const SEALED_LOCAL_IDENTITY_V1_AAD_DOMAIN = utf8ToBytes('treecrdt/local-identity
 const SEALED_LOCAL_IDENTITY_V1_AAD_SEP = new Uint8Array([0]);
 
 let ed25519Ready = false;
+function sha512ForEd25519(message: Uint8Array): Uint8Array {
+  return new Uint8Array(sha512(message));
+}
+
 function ensureEd25519(): void {
   if (ed25519Ready) return;
-  ed25519Hashes.sha512 = sha512;
+  ed25519Hashes.sha512 = sha512ForEd25519;
   ed25519Ready = true;
 }
 

--- a/packages/treecrdt-crypto/src/keystore.ts
+++ b/packages/treecrdt-crypto/src/keystore.ts
@@ -39,9 +39,8 @@ const SEALED_LOCAL_IDENTITY_V1_AAD_DOMAIN = utf8ToBytes('treecrdt/local-identity
 const SEALED_LOCAL_IDENTITY_V1_AAD_SEP = new Uint8Array([0]);
 
 let ed25519Ready = false;
-function sha512ForEd25519(message: Uint8Array): Uint8Array {
-  return new Uint8Array(sha512(message));
-}
+const sha512ForEd25519: NonNullable<(typeof ed25519Hashes)['sha512']> = (message) =>
+  Uint8Array.from(sha512(message));
 
 function ensureEd25519(): void {
   if (ed25519Ready) return;


### PR DESCRIPTION
## Summary
- normalize the `sha512` adapter passed to `@noble/ed25519` so it always returns an `ArrayBuffer`-backed `Uint8Array`
- apply the fix in both auth and crypto package initialization paths

## Why
Recent dependency/type changes on `main` made the direct `sha512` assignment fail TypeScript in CI. Wrapping the digest preserves runtime behavior while satisfying the stricter signature that GitHub Actions is now enforcing.

## Verification
- `pnpm -C packages/treecrdt-auth exec tsc -p tsconfig.json --pretty false`
- `pnpm -C packages/treecrdt-crypto exec tsc -p tsconfig.json --pretty false`
- `pnpm -C packages/treecrdt-auth test`
- `pnpm -C packages/treecrdt-crypto test`
- `pnpm run fmt:check:ts`

## Notes
- a local full workspace build hit an unrelated `wasm-pack` metadata parse issue that does not match the GitHub CI failure being fixed here