### PR TITLE
Move persisted remote materialization pipeline into treecrdt-core

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -613,6 +613,7 @@ export default function App() {
     getMaxLamport,
     authEnabled,
     authMaterial,
+    // Pass the prepared auth object through so sync does not rebuild auth state from raw material.
     syncAuth,
     authError,
     joinMode,

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -613,6 +613,7 @@ export default function App() {
     getMaxLamport,
     authEnabled,
     authMaterial,
+    syncAuth,
     authError,
     joinMode,
     authCanSyncAll,

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -927,9 +927,9 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
       );
     }
 
-    // `syncAuth` is only published after the auth hook has preflighted hello capabilities against
-    // the capability store. Gating sync on that ready object avoids starting live/scoped sync in
-    // the brief window where tokens exist in UI state but are not yet recorded for auth replay.
+    // Reuse the auth hook's prepared sync auth instead of rebuilding auth from raw material here.
+    // `syncAuth` is only published after hello-capability preflight has touched the capability
+    // store, which avoids the open-device race where UI tokens exist before auth replay is ready.
     if (authEnabled && !syncAuth) {
       const waitingForInvite = joinMode && authMaterial.localTokensB64.length === 0;
       setSyncError(

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -1,13 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Operation } from '@treecrdt/interface';
 import { bytesToHex } from '@treecrdt/interface/ids';
-import {
-  base64urlDecode,
-  createTreecrdtCoseCwtAuth,
-  createTreecrdtIdentityChainCapabilityV1,
-  createTreecrdtSqliteSubtreeScopeEvaluator,
-  type TreecrdtIdentityChainV1,
-} from '@treecrdt/auth';
+import { type TreecrdtIdentityChainV1 } from '@treecrdt/auth';
 import {
   createStringStoreRouteCache,
   isDiscoveryBootstrapUrl,
@@ -20,13 +14,10 @@ import {
   SyncPeer,
   deriveOpRefV0,
   type Filter,
+  type SyncAuth,
   type SyncSubscription,
 } from '@treecrdt/sync';
-import {
-  createTreecrdtSyncBackendFromClient,
-  createCapabilityMaterialStore,
-  createOpAuthStore,
-} from '@treecrdt/sync-sqlite';
+import { createTreecrdtSyncBackendFromClient } from '@treecrdt/sync-sqlite';
 import type {
   BroadcastPresenceAckMessageV1,
   BroadcastPresenceMessageV1,
@@ -194,6 +185,7 @@ export type UsePlaygroundSyncOptions = {
   getMaxLamport: () => bigint;
   authEnabled: boolean;
   authMaterial: StoredAuthMaterial;
+  syncAuth: SyncAuth<Operation> | null;
   authError: string | null;
   joinMode: boolean;
   authCanSyncAll: boolean;
@@ -229,20 +221,15 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     getMaxLamport,
     authEnabled,
     authMaterial,
+    syncAuth,
     authError,
     joinMode,
     authCanSyncAll,
     viewRootId,
-    hardRevokedTokenIds,
-    revocationCutoverEnabled,
-    revocationCutoverTokenId,
-    revocationCutoverCounter,
     treeStateRef,
     refreshMeta,
     refreshParents,
     refreshNodeCount,
-    getLocalIdentityChain,
-    onPeerIdentityChain,
     onAuthGrantMessage,
     onRemoteOpsApplied,
   } = opts;
@@ -931,34 +918,6 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
       return;
     }
 
-    const peerAuthConfig =
-      authEnabled &&
-      authMaterial.issuerPkB64 &&
-      authMaterial.localSkB64 &&
-      authMaterial.localPkB64 &&
-      authMaterial.localTokensB64.length > 0
-        ? {
-            issuerPk: base64urlDecode(authMaterial.issuerPkB64),
-            localSk: base64urlDecode(authMaterial.localSkB64),
-            localPk: base64urlDecode(authMaterial.localPkB64),
-            localTokens: authMaterial.localTokensB64.map((t) => base64urlDecode(t)),
-            hardRevokedTokenIds: hardRevokedTokenIds.map((id) => hexToBytes16(id)),
-            cutoverRule: (() => {
-              if (!revocationCutoverEnabled) return null;
-              const tokenIdHex = revocationCutoverTokenId.trim().toLowerCase().replace(/^0x/, '');
-              if (!/^[0-9a-f]{32}$/.test(tokenIdHex)) return null;
-              const parsedCounter = Number(revocationCutoverCounter.trim());
-              if (!Number.isInteger(parsedCounter) || parsedCounter < 0) return null;
-              return { tokenIdHex, counter: parsedCounter };
-            })(),
-            opAuthStore: createOpAuthStore({ runner: client.runner, docId }),
-            capabilityStore: createCapabilityMaterialStore({ runner: client.runner, docId }),
-            scopeEvaluator: createTreecrdtSqliteSubtreeScopeEvaluator(client.runner),
-            getLocalIdentityChain,
-            onPeerIdentityChain,
-          }
-        : null;
-
     if (!authEnabled) {
       // If auth is off, clear any auth-gating error strings so the UI doesn't keep telling users to import invites.
       setSyncError((prev) =>
@@ -968,7 +927,10 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
       );
     }
 
-    if (authEnabled && !peerAuthConfig) {
+    // `syncAuth` is only published after the auth hook has preflighted hello capabilities against
+    // the capability store. Gating sync on that ready object avoids starting live/scoped sync in
+    // the brief window where tokens exist in UI state but are not yet recorded for auth replay.
+    if (authEnabled && !syncAuth) {
       const waitingForInvite = joinMode && authMaterial.localTokensB64.length === 0;
       setSyncError(
         waitingForInvite ? null : (authError ?? 'Auth enabled: initializing keys/tokens...'),
@@ -1019,7 +981,8 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
         if (debugSync && ops.length > 0) {
           console.debug(`[sync:${selfPeerId}] applyOps(${ops.length})`);
         }
-        const affected = ops.length > 0 ? (await client.ops.appendMany(ops)) as unknown as string[] : [];
+        const affected =
+          ops.length > 0 ? ((await client.ops.appendMany(ops)) as unknown as string[]) : [];
         await onRemoteOpsApplied(ops, affected);
       },
     };
@@ -1029,54 +992,9 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
       maxOpsPerBatch: PLAYGROUND_SYNC_MAX_OPS_PER_BATCH,
       deriveOpRef: (op, ctx) =>
         deriveOpRefV0(ctx.docId, { replica: op.meta.id.replica, counter: op.meta.id.counter }),
-      ...(peerAuthConfig
+      ...(syncAuth
         ? {
-            auth: (() => {
-              const baseAuth = createTreecrdtCoseCwtAuth({
-                issuerPublicKeys: [peerAuthConfig.issuerPk],
-                localPrivateKey: peerAuthConfig.localSk,
-                localPublicKey: peerAuthConfig.localPk,
-                localCapabilityTokens: peerAuthConfig.localTokens,
-                capabilityStore: peerAuthConfig.capabilityStore,
-                revokedCapabilityTokenIds: peerAuthConfig.hardRevokedTokenIds,
-                isCapabilityTokenRevoked: (ctx) => {
-                  if (ctx.stage !== 'runtime') return false;
-                  if (!peerAuthConfig.cutoverRule) return false;
-                  if (ctx.tokenIdHex !== peerAuthConfig.cutoverRule.tokenIdHex) return false;
-                  return ctx.op.meta.id.counter >= peerAuthConfig.cutoverRule.counter;
-                },
-                requireProofRef: true,
-                opAuthStore: peerAuthConfig.opAuthStore,
-                scopeEvaluator: peerAuthConfig.scopeEvaluator,
-                onPeerIdentityChain: peerAuthConfig.onPeerIdentityChain,
-              });
-
-              const withIdentity: typeof baseAuth = {
-                ...baseAuth,
-                helloCapabilities: async (ctx) => {
-                  const caps = (await baseAuth.helloCapabilities?.(ctx)) ?? [];
-                  try {
-                    const chain = await peerAuthConfig.getLocalIdentityChain();
-                    if (chain) caps.push(createTreecrdtIdentityChainCapabilityV1(chain));
-                  } catch {
-                    // Best-effort; identity chains are optional.
-                  }
-                  return caps;
-                },
-                onHello: async (hello, ctx) => {
-                  const ackCaps = (await baseAuth.onHello?.(hello, ctx)) ?? [];
-                  try {
-                    const chain = await peerAuthConfig.getLocalIdentityChain();
-                    if (chain) ackCaps.push(createTreecrdtIdentityChainCapabilityV1(chain));
-                  } catch {
-                    // Best-effort; identity chains are optional.
-                  }
-                  return ackCaps;
-                },
-              };
-
-              return withIdentity;
-            })(),
+            auth: syncAuth,
           }
         : {}),
     });
@@ -1310,21 +1228,12 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
   }, [
     authEnabled,
     // Avoid restarting the mesh when `authMaterial` is re-read with the same values.
-    authMaterial.issuerPkB64,
-    authMaterial.localPkB64,
-    authMaterial.localSkB64,
-    authMaterial.localTokensB64.join(','),
-    hardRevokedTokenIds.join(','),
-    revocationCutoverEnabled,
-    revocationCutoverTokenId,
-    revocationCutoverCounter,
+    syncAuth,
     client,
     docId,
-    getLocalIdentityChain,
     getMaxLamport,
     joinMode,
     onAuthGrantMessage,
-    onPeerIdentityChain,
     onRemoteOpsApplied,
     selfPeerId,
     syncServerUrl,

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -15,8 +15,11 @@ pub mod version_vector;
 pub use error::{Error, Result};
 pub use ids::{Lamport, NodeId, OperationId, ReplicaId};
 pub use materialization::{
-    apply_incremental_ops, apply_incremental_ops_with_delta, try_incremental_materialization,
-    IncrementalApplyResult, MaterializationCursor, MaterializationHead,
+    apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
+    commit_persisted_remote_result, materialize_persisted_remote_ops_with_delta,
+    try_incremental_materialization, IncrementalApplyResult, MaterializationCursor,
+    MaterializationHead, PersistedRemoteApplyResult, PersistedRemoteCommitPlan,
+    PersistedRemoteCommitStatus, PersistedRemoteOp,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -15,10 +15,9 @@ pub mod version_vector;
 pub use error::{Error, Result};
 pub use ids::{Lamport, NodeId, OperationId, ReplicaId};
 pub use materialization::{
-    apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    materialize_persisted_remote_ops_with_delta, try_incremental_materialization,
-    IncrementalApplyResult, MaterializationCursor, MaterializationHead, PersistedRemoteApplyResult,
-    PersistedRemoteStores,
+    apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
+    materialize_persisted_remote_ops_with_delta, IncrementalApplyResult, MaterializationCursor,
+    MaterializationHead, PersistedRemoteApplyResult, PersistedRemoteStores,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -16,10 +16,8 @@ pub use error::{Error, Result};
 pub use ids::{Lamport, NodeId, OperationId, ReplicaId};
 pub use materialization::{
     apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    commit_persisted_remote_result, materialize_persisted_remote_ops_with_delta,
-    try_incremental_materialization, IncrementalApplyResult, MaterializationCursor,
-    MaterializationHead, PersistedRemoteApplyResult, PersistedRemoteCommitPlan,
-    PersistedRemoteCommitStatus, PersistedRemoteOp,
+    materialize_persisted_remote_ops_with_delta, try_incremental_materialization,
+    IncrementalApplyResult, MaterializationCursor, MaterializationHead, PersistedRemoteApplyResult,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -18,6 +18,7 @@ pub use materialization::{
     apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     materialize_persisted_remote_ops_with_delta, try_incremental_materialization,
     IncrementalApplyResult, MaterializationCursor, MaterializationHead, PersistedRemoteApplyResult,
+    PersistedRemoteStores,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -26,12 +26,6 @@ pub struct IncrementalApplyResult {
     pub affected_nodes: Vec<NodeId>,
 }
 
-impl IncrementalApplyResult {
-    pub fn head(self) -> Option<MaterializationHead> {
-        self.head
-    }
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersistedRemoteApplyResult {
     /// Number of ops from the input batch that were actually inserted by adapter-side dedupe.
@@ -56,27 +50,6 @@ pub struct PersistedRemoteStores<C, N, P, I> {
     pub nodes: N,
     pub payloads: P,
     pub index: I,
-}
-
-/// Apply an incremental batch through core materialization semantics.
-///
-/// The batch is sorted in canonical op-key order, validated against the materialized head,
-/// and applied with parent-op index + tombstone maintenance.
-pub fn apply_incremental_ops<S, C, N, P, I, M>(
-    crdt: &mut TreeCrdt<S, C, N, P>,
-    index: &mut I,
-    meta: &M,
-    ops: Vec<Operation>,
-) -> Result<Option<MaterializationHead>>
-where
-    S: Storage,
-    C: Clock,
-    N: NodeStore,
-    P: PayloadStore,
-    I: ParentOpIndex,
-    M: MaterializationCursor,
-{
-    Ok(apply_incremental_ops_with_delta(crdt, index, meta, ops)?.head())
 }
 
 /// Apply an incremental batch and return both head metadata and full affected-node delta.
@@ -267,26 +240,4 @@ where
             }
         }
     }
-}
-
-/// Run incremental materialization when possible; otherwise mark the document as dirty.
-///
-/// Returns `true` when incremental materialization succeeded, `false` when the caller
-/// should rely on a full rebuild path later.
-pub fn try_incremental_materialization<E>(
-    already_dirty: bool,
-    incremental: impl FnOnce() -> std::result::Result<(), E>,
-    mut mark_dirty: impl FnMut(),
-) -> bool {
-    if already_dirty {
-        mark_dirty();
-        return false;
-    }
-
-    if incremental().is_err() {
-        mark_dirty();
-        return false;
-    }
-
-    true
 }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -1,7 +1,7 @@
 use crate::ops::{cmp_op_key, cmp_ops, Operation};
-use crate::traits::{Clock, NodeStore, ParentOpIndex, PayloadStore, Storage};
+use crate::traits::{Clock, NodeStore, NoopStorage, ParentOpIndex, PayloadStore, Storage};
 use crate::tree::TreeCrdt;
-use crate::{Error, Lamport, NodeId, Result};
+use crate::{Error, Lamport, NodeId, ReplicaId, Result};
 
 /// Snapshot of adapter-maintained materialization metadata.
 pub trait MaterializationCursor {
@@ -30,6 +30,33 @@ impl IncrementalApplyResult {
     pub fn head(self) -> Option<MaterializationHead> {
         self.head
     }
+}
+
+#[derive(Clone, Debug)]
+pub struct PersistedRemoteOp {
+    pub op: Operation,
+    pub inserted: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PersistedRemoteCommitPlan {
+    NoChange,
+    MarkDirty,
+    UpdateHead(MaterializationHead),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PersistedRemoteApplyResult {
+    pub inserted_count: u64,
+    pub affected_nodes: Vec<NodeId>,
+    pub commit: PersistedRemoteCommitPlan,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PersistedRemoteCommitStatus {
+    NoChange,
+    DirtyFallback,
+    Incremental,
 }
 
 /// Apply an incremental batch through core materialization semantics.
@@ -122,6 +149,133 @@ where
         }),
         affected_nodes,
     })
+}
+
+/// Materialize an already-persisted remote-op batch through a temporary [`TreeCrdt`].
+///
+/// Adapters provide backend-specific stores plus lightweight prepare/flush hooks, while core owns
+/// the canonical op ordering, replay semantics, and affected-node accumulation.
+pub fn materialize_persisted_remote_ops_with_delta<C, N, P, I, M, Prepare, FlushNodes, FlushIndex>(
+    replica_id: ReplicaId,
+    clock: C,
+    mut nodes: N,
+    payloads: P,
+    mut index: I,
+    meta: &M,
+    ops: Vec<Operation>,
+    mut prepare_nodes: Prepare,
+    mut flush_nodes: FlushNodes,
+    mut flush_index: FlushIndex,
+) -> Result<IncrementalApplyResult>
+where
+    C: Clock,
+    N: NodeStore,
+    P: PayloadStore,
+    I: ParentOpIndex,
+    M: MaterializationCursor,
+    Prepare: FnMut(&mut N, &[Operation]) -> Result<()>,
+    FlushNodes: FnMut(&mut N) -> Result<()>,
+    FlushIndex: FnMut(&mut I) -> Result<()>,
+{
+    if ops.is_empty() {
+        return Ok(IncrementalApplyResult {
+            head: None,
+            affected_nodes: Vec::new(),
+        });
+    }
+
+    prepare_nodes(&mut nodes, &ops)?;
+
+    let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
+    let result = apply_incremental_ops_with_delta(&mut crdt, &mut index, meta, ops)?;
+    flush_nodes(crdt.node_store_mut())?;
+    flush_index(&mut index)?;
+    Ok(result)
+}
+
+/// Turn an adapter-persisted remote batch into a materialization commit plan.
+///
+/// Only entries marked `inserted` are replayed. If the materialized doc is already dirty, or if
+/// incremental materialization fails, the result instructs adapters to keep the append and mark
+/// the document dirty for rebuild-on-read.
+pub fn apply_persisted_remote_ops_with_delta<M, E>(
+    meta: &M,
+    ops: Vec<PersistedRemoteOp>,
+    materialize_inserted: impl FnOnce(Vec<Operation>) -> std::result::Result<IncrementalApplyResult, E>,
+) -> PersistedRemoteApplyResult
+where
+    M: MaterializationCursor,
+{
+    let inserted_ops: Vec<Operation> =
+        ops.into_iter().filter(|entry| entry.inserted).map(|entry| entry.op).collect();
+    let inserted_count = inserted_ops.len().min(u64::MAX as usize) as u64;
+
+    if inserted_count == 0 {
+        return PersistedRemoteApplyResult {
+            inserted_count: 0,
+            affected_nodes: Vec::new(),
+            commit: PersistedRemoteCommitPlan::NoChange,
+        };
+    }
+
+    if meta.dirty() {
+        return PersistedRemoteApplyResult {
+            inserted_count,
+            affected_nodes: Vec::new(),
+            commit: PersistedRemoteCommitPlan::MarkDirty,
+        };
+    }
+
+    match materialize_inserted(inserted_ops) {
+        Ok(result) => {
+            let Some(head) = result.head else {
+                return PersistedRemoteApplyResult {
+                    inserted_count,
+                    affected_nodes: Vec::new(),
+                    commit: PersistedRemoteCommitPlan::MarkDirty,
+                };
+            };
+
+            PersistedRemoteApplyResult {
+                inserted_count,
+                affected_nodes: result.affected_nodes,
+                commit: PersistedRemoteCommitPlan::UpdateHead(head),
+            }
+        }
+        Err(_) => PersistedRemoteApplyResult {
+            inserted_count,
+            affected_nodes: Vec::new(),
+            commit: PersistedRemoteCommitPlan::MarkDirty,
+        },
+    }
+}
+
+/// Commit a persisted-remote materialization plan using adapter-owned metadata writes.
+///
+/// If updating the head fails, this falls back to `mark_dirty` and clears the exact
+/// `affected_nodes` delta because incremental state can no longer be trusted.
+pub fn commit_persisted_remote_result<E>(
+    result: &mut PersistedRemoteApplyResult,
+    update_head: impl FnOnce(&MaterializationHead) -> std::result::Result<(), E>,
+    mut mark_dirty: impl FnMut() -> std::result::Result<(), E>,
+) -> PersistedRemoteCommitStatus {
+    match &result.commit {
+        PersistedRemoteCommitPlan::NoChange => PersistedRemoteCommitStatus::NoChange,
+        PersistedRemoteCommitPlan::MarkDirty => {
+            let _ = mark_dirty();
+            result.affected_nodes.clear();
+            PersistedRemoteCommitStatus::DirtyFallback
+        }
+        PersistedRemoteCommitPlan::UpdateHead(head) => {
+            if update_head(head).is_ok() {
+                PersistedRemoteCommitStatus::Incremental
+            } else {
+                let _ = mark_dirty();
+                result.affected_nodes.clear();
+                PersistedRemoteCommitStatus::DirtyFallback
+            }
+        }
+    }
 }
 
 /// Run incremental materialization when possible; otherwise mark the document as dirty.

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -32,31 +32,11 @@ impl IncrementalApplyResult {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct PersistedRemoteOp {
-    pub op: Operation,
-    pub inserted: bool,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum PersistedRemoteCommitPlan {
-    NoChange,
-    MarkDirty,
-    UpdateHead(MaterializationHead),
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersistedRemoteApplyResult {
     pub inserted_count: u64,
     pub affected_nodes: Vec<NodeId>,
-    pub commit: PersistedRemoteCommitPlan,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum PersistedRemoteCommitStatus {
-    NoChange,
-    DirtyFallback,
-    Incremental,
+    pub dirty_fallback: bool,
 }
 
 /// Apply an incremental batch through core materialization semantics.
@@ -193,86 +173,72 @@ where
     Ok(result)
 }
 
-/// Turn an adapter-persisted remote batch into a materialization commit plan.
+/// Apply already-persisted inserted remote ops and commit adapter-owned metadata writes.
 ///
-/// Only entries marked `inserted` are replayed. If the materialized doc is already dirty, or if
-/// incremental materialization fails, the result instructs adapters to keep the append and mark
-/// the document dirty for rebuild-on-read.
+/// Adapters own persistence + dedupe and pass only the inserted subset here. If the materialized
+/// doc is already dirty, or if incremental materialization / head update fails, this marks the
+/// document dirty so rebuild-on-read can replay the full log later.
 pub fn apply_persisted_remote_ops_with_delta<M, E>(
     meta: &M,
-    ops: Vec<PersistedRemoteOp>,
+    inserted_ops: Vec<Operation>,
     materialize_inserted: impl FnOnce(Vec<Operation>) -> std::result::Result<IncrementalApplyResult, E>,
+    update_head: impl FnOnce(&MaterializationHead) -> std::result::Result<(), E>,
+    mut mark_dirty: impl FnMut() -> std::result::Result<(), E>,
 ) -> PersistedRemoteApplyResult
 where
     M: MaterializationCursor,
 {
-    let inserted_ops: Vec<Operation> =
-        ops.into_iter().filter(|entry| entry.inserted).map(|entry| entry.op).collect();
     let inserted_count = inserted_ops.len().min(u64::MAX as usize) as u64;
 
     if inserted_count == 0 {
         return PersistedRemoteApplyResult {
             inserted_count: 0,
             affected_nodes: Vec::new(),
-            commit: PersistedRemoteCommitPlan::NoChange,
+            dirty_fallback: false,
         };
     }
 
     if meta.dirty() {
+        let _ = mark_dirty();
         return PersistedRemoteApplyResult {
             inserted_count,
             affected_nodes: Vec::new(),
-            commit: PersistedRemoteCommitPlan::MarkDirty,
+            dirty_fallback: true,
         };
     }
 
     match materialize_inserted(inserted_ops) {
         Ok(result) => {
             let Some(head) = result.head else {
+                let _ = mark_dirty();
                 return PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: Vec::new(),
-                    commit: PersistedRemoteCommitPlan::MarkDirty,
+                    dirty_fallback: true,
                 };
             };
 
-            PersistedRemoteApplyResult {
-                inserted_count,
-                affected_nodes: result.affected_nodes,
-                commit: PersistedRemoteCommitPlan::UpdateHead(head),
-            }
-        }
-        Err(_) => PersistedRemoteApplyResult {
-            inserted_count,
-            affected_nodes: Vec::new(),
-            commit: PersistedRemoteCommitPlan::MarkDirty,
-        },
-    }
-}
-
-/// Commit a persisted-remote materialization plan using adapter-owned metadata writes.
-///
-/// If updating the head fails, this falls back to `mark_dirty` and clears the exact
-/// `affected_nodes` delta because incremental state can no longer be trusted.
-pub fn commit_persisted_remote_result<E>(
-    result: &mut PersistedRemoteApplyResult,
-    update_head: impl FnOnce(&MaterializationHead) -> std::result::Result<(), E>,
-    mut mark_dirty: impl FnMut() -> std::result::Result<(), E>,
-) -> PersistedRemoteCommitStatus {
-    match &result.commit {
-        PersistedRemoteCommitPlan::NoChange => PersistedRemoteCommitStatus::NoChange,
-        PersistedRemoteCommitPlan::MarkDirty => {
-            let _ = mark_dirty();
-            result.affected_nodes.clear();
-            PersistedRemoteCommitStatus::DirtyFallback
-        }
-        PersistedRemoteCommitPlan::UpdateHead(head) => {
-            if update_head(head).is_ok() {
-                PersistedRemoteCommitStatus::Incremental
+            if update_head(&head).is_ok() {
+                PersistedRemoteApplyResult {
+                    inserted_count,
+                    affected_nodes: result.affected_nodes,
+                    dirty_fallback: false,
+                }
             } else {
                 let _ = mark_dirty();
-                result.affected_nodes.clear();
-                PersistedRemoteCommitStatus::DirtyFallback
+                PersistedRemoteApplyResult {
+                    inserted_count,
+                    affected_nodes: Vec::new(),
+                    dirty_fallback: true,
+                }
+            }
+        }
+        Err(_) => {
+            let _ = mark_dirty();
+            PersistedRemoteApplyResult {
+                inserted_count,
+                affected_nodes: Vec::new(),
+                dirty_fallback: true,
             }
         }
     }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -41,6 +41,10 @@ pub struct PersistedRemoteApplyResult {
 
 /// Backend-owned stores used to replay already-persisted remote ops through core semantics.
 pub struct PersistedRemoteStores<C, N, P, I> {
+    /// Scratch replica id for the temporary `TreeCrdt` used during replay.
+    ///
+    /// The replayed operations keep their original replica ids; this is only the identity of the
+    /// in-memory materializer instance.
     pub replica_id: ReplicaId,
     pub clock: C,
     pub nodes: N,
@@ -179,6 +183,8 @@ where
 
     prepare_nodes(&mut nodes, &ops)?;
 
+    // This temporary TreeCrdt replays ops that the adapter already persisted and filtered to the
+    // inserted subset, so it needs core apply semantics but not a live op-log backend.
     let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
     let result = apply_incremental_ops_with_delta(&mut crdt, &mut index, meta, ops)?;
     flush_nodes(crdt.node_store_mut())?;

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -39,6 +39,15 @@ pub struct PersistedRemoteApplyResult {
     pub dirty_fallback: bool,
 }
 
+/// Backend-owned stores used to replay already-persisted remote ops through core semantics.
+pub struct PersistedRemoteStores<C, N, P, I> {
+    pub replica_id: ReplicaId,
+    pub clock: C,
+    pub nodes: N,
+    pub payloads: P,
+    pub index: I,
+}
+
 /// Apply an incremental batch through core materialization semantics.
 ///
 /// The batch is sorted in canonical op-key order, validated against the materialized head,
@@ -136,11 +145,7 @@ where
 /// Adapters provide backend-specific stores plus lightweight prepare/flush hooks, while core owns
 /// the canonical op ordering, replay semantics, and affected-node accumulation.
 pub fn materialize_persisted_remote_ops_with_delta<C, N, P, I, M, Prepare, FlushNodes, FlushIndex>(
-    replica_id: ReplicaId,
-    clock: C,
-    mut nodes: N,
-    payloads: P,
-    mut index: I,
+    stores: PersistedRemoteStores<C, N, P, I>,
     meta: &M,
     ops: Vec<Operation>,
     mut prepare_nodes: Prepare,
@@ -163,6 +168,14 @@ where
             affected_nodes: Vec::new(),
         });
     }
+
+    let PersistedRemoteStores {
+        replica_id,
+        clock,
+        mut nodes,
+        payloads,
+        mut index,
+    } = stores;
 
     prepare_nodes(&mut nodes, &ops)?;
 

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -34,8 +34,14 @@ impl IncrementalApplyResult {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersistedRemoteApplyResult {
+    /// Number of ops from the input batch that were actually inserted by adapter-side dedupe.
     pub inserted_count: u64,
+    /// Nodes changed by core materialization when incremental replay succeeded.
+    ///
+    /// This is empty when nothing was inserted or when the helper had to fall back to marking the
+    /// document dirty instead of trusting incremental materialization.
     pub affected_nodes: Vec<NodeId>,
+    /// True when adapters should rely on rebuild-on-read instead of the incremental replay result.
     pub dirty_fallback: bool,
 }
 

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -901,6 +901,10 @@ where
         self.head.as_ref()
     }
 
+    pub(crate) fn node_store_mut(&mut self) -> &mut N {
+        &mut self.nodes
+    }
+
     pub fn validate_invariants(&self) -> Result<()> {
         for pid in self.nodes.all_nodes()? {
             let pchildren = self.nodes.children(pid)?;

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -1,9 +1,9 @@
 use treecrdt_core::{
-    apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    materialize_persisted_remote_ops_with_delta, try_incremental_materialization, LamportClock,
-    MaterializationCursor, MaterializationHead, MemoryNodeStore, MemoryPayloadStore, MemoryStorage,
-    NodeId, NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PersistedRemoteStores,
-    ReplicaId, TreeCrdt,
+    apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
+    materialize_persisted_remote_ops_with_delta, LamportClock, MaterializationCursor,
+    MaterializationHead, MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId,
+    NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PersistedRemoteStores, ReplicaId,
+    TreeCrdt,
 };
 
 #[derive(Default)]
@@ -60,36 +60,6 @@ impl ParentOpIndex for RecordingIndex {
 }
 
 #[test]
-fn try_incremental_materialization_marks_dirty_on_failure() {
-    let mut marked_dirty = 0u64;
-    let ok = try_incremental_materialization(
-        false,
-        || -> Result<(), ()> { Err(()) },
-        || marked_dirty += 1,
-    );
-    assert!(!ok);
-    assert_eq!(marked_dirty, 1);
-}
-
-#[test]
-fn try_incremental_materialization_short_circuits_when_already_dirty() {
-    let mut incremental_runs = 0u64;
-    let mut marked_dirty = 0u64;
-
-    let ok = try_incremental_materialization(
-        true,
-        || -> Result<(), ()> {
-            incremental_runs += 1;
-            Ok(())
-        },
-        || marked_dirty += 1,
-    );
-    assert!(!ok);
-    assert_eq!(incremental_runs, 0);
-    assert_eq!(marked_dirty, 1);
-}
-
-#[test]
 fn finalize_local_materialization_records_unique_hints_and_extras() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"local"),
@@ -127,7 +97,7 @@ fn finalize_local_materialization_records_unique_hints_and_extras() {
 }
 
 #[test]
-fn apply_incremental_ops_sorts_and_returns_head() {
+fn apply_incremental_ops_with_delta_sorts_and_returns_head() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"local"),
         MemoryStorage::default(),
@@ -141,9 +111,11 @@ fn apply_incremental_ops_sorts_and_returns_head() {
     let first = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let second = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
 
-    let next = apply_incremental_ops(&mut crdt, &mut index, &cursor, vec![second, first])
-        .unwrap()
-        .unwrap();
+    let next =
+        apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![second, first])
+            .unwrap()
+            .head
+            .expect("expected materialization head");
 
     assert_eq!(next.lamport, 2);
     assert_eq!(next.replica, replica.as_bytes());
@@ -155,7 +127,7 @@ fn apply_incremental_ops_sorts_and_returns_head() {
 }
 
 #[test]
-fn apply_incremental_ops_rejects_before_materialized_head() {
+fn apply_incremental_ops_with_delta_rejects_before_materialized_head() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"local"),
         MemoryStorage::default(),
@@ -180,7 +152,7 @@ fn apply_incremental_ops_rejects_before_materialized_head() {
         vec![0x10],
     );
 
-    let res = apply_incremental_ops(&mut crdt, &mut index, &cursor, vec![op]);
+    let res = apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![op]);
     assert!(res.is_err());
 }
 

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -1,10 +1,8 @@
 use treecrdt_core::{
     apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    commit_persisted_remote_result, materialize_persisted_remote_ops_with_delta,
-    try_incremental_materialization, LamportClock, MaterializationCursor, MaterializationHead,
-    MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation,
-    OperationId, ParentOpIndex, PersistedRemoteCommitPlan, PersistedRemoteCommitStatus,
-    PersistedRemoteOp, ReplicaId, TreeCrdt,
+    materialize_persisted_remote_ops_with_delta, try_incremental_materialization, LamportClock,
+    MaterializationCursor, MaterializationHead, MemoryNodeStore, MemoryPayloadStore, MemoryStorage,
+    NodeId, NoopParentOpIndex, Operation, OperationId, ParentOpIndex, ReplicaId, TreeCrdt,
 };
 
 #[derive(Default)]
@@ -219,27 +217,14 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
 fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let op1 = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let op2 = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
     let op3 = Operation::set_payload(&replica, 3, 3, NodeId(2), vec![9]);
 
     let mut seen_counters = Vec::new();
+    let mut updated_head = None;
     let result = apply_persisted_remote_ops_with_delta(
         &cursor,
-        vec![
-            PersistedRemoteOp {
-                op: op1.clone(),
-                inserted: false,
-            },
-            PersistedRemoteOp {
-                op: op2.clone(),
-                inserted: true,
-            },
-            PersistedRemoteOp {
-                op: op3.clone(),
-                inserted: true,
-            },
-        ],
+        vec![op2.clone(), op3.clone()],
         |ops| {
             seen_counters = ops.iter().map(|op| op.meta.id.counter).collect();
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
@@ -252,14 +237,20 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
                 affected_nodes: vec![NodeId(2)],
             })
         },
+        |head| {
+            updated_head = Some(head.clone());
+            Ok::<_, ()>(())
+        },
+        || Ok::<_, ()>(()),
     );
 
     assert_eq!(seen_counters, vec![2, 3]);
     assert_eq!(result.inserted_count, 2);
     assert_eq!(result.affected_nodes, vec![NodeId(2)]);
+    assert!(!result.dirty_fallback);
     assert_eq!(
-        result.commit,
-        PersistedRemoteCommitPlan::UpdateHead(MaterializationHead {
+        updated_head,
+        Some(MaterializationHead {
             lamport: 3,
             replica: replica.as_bytes().to_vec(),
             counter: 3,
@@ -277,10 +268,11 @@ fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let mut runs = 0u64;
+    let mut marked_dirty = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
         &cursor,
-        vec![PersistedRemoteOp { op, inserted: true }],
+        vec![op],
         |_| {
             runs += 1;
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
@@ -288,30 +280,41 @@ fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
                 affected_nodes: Vec::new(),
             })
         },
+        |_| Ok::<_, ()>(()),
+        || {
+            marked_dirty += 1;
+            Ok::<_, ()>(())
+        },
     );
 
     assert_eq!(runs, 0);
+    assert_eq!(marked_dirty, 1);
     assert_eq!(result.inserted_count, 1);
     assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
-    assert_eq!(result.commit, PersistedRemoteCommitPlan::MarkDirty);
+    assert!(result.dirty_fallback);
 }
 
 #[test]
-fn commit_persisted_remote_result_clears_affected_nodes_on_dirty_fallback() {
-    let mut result = treecrdt_core::PersistedRemoteApplyResult {
-        inserted_count: 2,
-        affected_nodes: vec![NodeId(1), NodeId(2)],
-        commit: PersistedRemoteCommitPlan::UpdateHead(MaterializationHead {
-            lamport: 7,
-            replica: b"r".to_vec(),
-            counter: 4,
-            seq: 9,
-        }),
-    };
+fn apply_persisted_remote_ops_clears_affected_nodes_when_update_head_fails() {
+    let cursor = Cursor::default();
+    let replica = ReplicaId::new(b"remote");
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let mut marked_dirty = 0u64;
 
-    let status = commit_persisted_remote_result(
-        &mut result,
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![op],
+        |_| {
+            Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
+                head: Some(MaterializationHead {
+                    lamport: 7,
+                    replica: b"r".to_vec(),
+                    counter: 4,
+                    seq: 9,
+                }),
+                affected_nodes: vec![NodeId(1), NodeId(2)],
+            })
+        },
         |_| Err::<(), ()>(()),
         || {
             marked_dirty += 1;
@@ -319,9 +322,10 @@ fn commit_persisted_remote_result_clears_affected_nodes_on_dirty_fallback() {
         },
     );
 
-    assert_eq!(status, PersistedRemoteCommitStatus::DirtyFallback);
     assert_eq!(marked_dirty, 1);
+    assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
+    assert!(result.dirty_fallback);
 }
 
 #[test]

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -2,7 +2,8 @@ use treecrdt_core::{
     apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     materialize_persisted_remote_ops_with_delta, try_incremental_materialization, LamportClock,
     MaterializationCursor, MaterializationHead, MemoryNodeStore, MemoryPayloadStore, MemoryStorage,
-    NodeId, NoopParentOpIndex, Operation, OperationId, ParentOpIndex, ReplicaId, TreeCrdt,
+    NodeId, NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PersistedRemoteStores,
+    ReplicaId, TreeCrdt,
 };
 
 #[derive(Default)]
@@ -340,11 +341,13 @@ fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
     let mut flushed_index = 0u64;
 
     let result = materialize_persisted_remote_ops_with_delta(
-        ReplicaId::new(b"adapter"),
-        LamportClock::default(),
-        MemoryNodeStore::default(),
-        MemoryPayloadStore::default(),
-        NoopParentOpIndex,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"adapter"),
+            clock: LamportClock::default(),
+            nodes: MemoryNodeStore::default(),
+            payloads: MemoryPayloadStore::default(),
+            index: NoopParentOpIndex,
+        },
         &cursor,
         vec![child, parent],
         |_, ops| {

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -1,7 +1,10 @@
 use treecrdt_core::{
-    apply_incremental_ops, apply_incremental_ops_with_delta, try_incremental_materialization,
-    LamportClock, MaterializationCursor, MemoryStorage, NodeId, Operation, OperationId,
-    ParentOpIndex, ReplicaId, TreeCrdt,
+    apply_incremental_ops, apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
+    commit_persisted_remote_result, materialize_persisted_remote_ops_with_delta,
+    try_incremental_materialization, LamportClock, MaterializationCursor, MaterializationHead,
+    MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation,
+    OperationId, ParentOpIndex, PersistedRemoteCommitPlan, PersistedRemoteCommitStatus,
+    PersistedRemoteOp, ReplicaId, TreeCrdt,
 };
 
 #[derive(Default)]
@@ -210,4 +213,158 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
     let head = res.head.expect("expected materialization head");
     assert_eq!(head.counter, 2);
     assert_eq!(res.affected_nodes, vec![NodeId::ROOT, parent, child],);
+}
+
+#[test]
+fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
+    let cursor = Cursor::default();
+    let replica = ReplicaId::new(b"remote");
+    let op1 = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let op2 = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
+    let op3 = Operation::set_payload(&replica, 3, 3, NodeId(2), vec![9]);
+
+    let mut seen_counters = Vec::new();
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![
+            PersistedRemoteOp {
+                op: op1.clone(),
+                inserted: false,
+            },
+            PersistedRemoteOp {
+                op: op2.clone(),
+                inserted: true,
+            },
+            PersistedRemoteOp {
+                op: op3.clone(),
+                inserted: true,
+            },
+        ],
+        |ops| {
+            seen_counters = ops.iter().map(|op| op.meta.id.counter).collect();
+            Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
+                head: Some(MaterializationHead {
+                    lamport: op3.meta.lamport,
+                    replica: op3.meta.id.replica.as_bytes().to_vec(),
+                    counter: op3.meta.id.counter,
+                    seq: 2,
+                }),
+                affected_nodes: vec![NodeId(2)],
+            })
+        },
+    );
+
+    assert_eq!(seen_counters, vec![2, 3]);
+    assert_eq!(result.inserted_count, 2);
+    assert_eq!(result.affected_nodes, vec![NodeId(2)]);
+    assert_eq!(
+        result.commit,
+        PersistedRemoteCommitPlan::UpdateHead(MaterializationHead {
+            lamport: 3,
+            replica: replica.as_bytes().to_vec(),
+            counter: 3,
+            seq: 2,
+        })
+    );
+}
+
+#[test]
+fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
+    let cursor = Cursor {
+        dirty: true,
+        ..Cursor::default()
+    };
+    let replica = ReplicaId::new(b"remote");
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let mut runs = 0u64;
+
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![PersistedRemoteOp { op, inserted: true }],
+        |_| {
+            runs += 1;
+            Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
+                head: None,
+                affected_nodes: Vec::new(),
+            })
+        },
+    );
+
+    assert_eq!(runs, 0);
+    assert_eq!(result.inserted_count, 1);
+    assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
+    assert_eq!(result.commit, PersistedRemoteCommitPlan::MarkDirty);
+}
+
+#[test]
+fn commit_persisted_remote_result_clears_affected_nodes_on_dirty_fallback() {
+    let mut result = treecrdt_core::PersistedRemoteApplyResult {
+        inserted_count: 2,
+        affected_nodes: vec![NodeId(1), NodeId(2)],
+        commit: PersistedRemoteCommitPlan::UpdateHead(MaterializationHead {
+            lamport: 7,
+            replica: b"r".to_vec(),
+            counter: 4,
+            seq: 9,
+        }),
+    };
+    let mut marked_dirty = 0u64;
+
+    let status = commit_persisted_remote_result(
+        &mut result,
+        |_| Err::<(), ()>(()),
+        || {
+            marked_dirty += 1;
+            Ok::<(), ()>(())
+        },
+    );
+
+    assert_eq!(status, PersistedRemoteCommitStatus::DirtyFallback);
+    assert_eq!(marked_dirty, 1);
+    assert!(result.affected_nodes.is_empty());
+}
+
+#[test]
+fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
+    let cursor = Cursor::default();
+    let replica = ReplicaId::new(b"remote");
+    let parent = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(10), vec![0x10]);
+    let child = Operation::insert(&replica, 2, 2, NodeId(10), NodeId(11), vec![0x20]);
+
+    let mut prepared = 0u64;
+    let mut flushed_nodes = 0u64;
+    let mut flushed_index = 0u64;
+
+    let result = materialize_persisted_remote_ops_with_delta(
+        ReplicaId::new(b"adapter"),
+        LamportClock::default(),
+        MemoryNodeStore::default(),
+        MemoryPayloadStore::default(),
+        NoopParentOpIndex,
+        &cursor,
+        vec![child, parent],
+        |_, ops| {
+            prepared += ops.len() as u64;
+            Ok(())
+        },
+        |_| {
+            flushed_nodes += 1;
+            Ok(())
+        },
+        |_| {
+            flushed_index += 1;
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    let head = result.head.expect("expected head");
+    assert_eq!(prepared, 2);
+    assert_eq!(flushed_nodes, 1);
+    assert_eq!(flushed_index, 1);
+    assert_eq!(head.counter, 2);
+    assert_eq!(
+        result.affected_nodes,
+        vec![NodeId::ROOT, NodeId(10), NodeId(11)]
+    );
 }

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -8,8 +8,8 @@ use postgres::{Client, Row, Statement};
 use treecrdt_core::{
     apply_persisted_remote_ops_with_delta, materialize_persisted_remote_ops_with_delta, Error,
     Lamport, LamportClock, MaterializationCursor, NodeId, NodeStore, Operation, OperationId,
-    OperationKind, ParentOpIndex, PayloadStore, ReplicaId, Result, Storage, TreeCrdt,
-    VersionVector,
+    OperationKind, ParentOpIndex, PayloadStore, PersistedRemoteStores, ReplicaId, Result, Storage,
+    TreeCrdt, VersionVector,
 };
 
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
@@ -1486,11 +1486,13 @@ fn materialize_inserted_ops(
     // At this point treecrdt_ops already contains the inserted operations. This temporary
     // TreeCrdt exists only to replay those ops through core semantics and update derived tables.
     materialize_persisted_remote_ops_with_delta(
-        ReplicaId::new(b"postgres"),
-        LamportClock::default(),
-        PgNodeStore::new(ctx.clone()),
-        PgPayloadStore::new(ctx.clone()),
-        PgParentOpIndex::new(ctx.clone()),
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"postgres"),
+            clock: LamportClock::default(),
+            nodes: PgNodeStore::new(ctx.clone()),
+            payloads: PgPayloadStore::new(ctx.clone()),
+            index: PgParentOpIndex::new(ctx.clone()),
+        },
         meta,
         ops,
         |nodes, ops| {

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -6,10 +6,11 @@ use std::time::Instant;
 use postgres::{Client, Row, Statement};
 
 use treecrdt_core::{
-    apply_incremental_ops_with_delta, try_incremental_materialization, Error, Lamport,
-    LamportClock, MaterializationCursor, NodeId, NodeStore, NoopStorage, Operation, OperationId,
-    OperationKind, ParentOpIndex, PayloadStore, ReplicaId, Result, Storage, TreeCrdt,
-    VersionVector,
+    apply_persisted_remote_ops_with_delta, commit_persisted_remote_result,
+    materialize_persisted_remote_ops_with_delta, Error, Lamport, LamportClock,
+    MaterializationCursor, NodeId, NodeStore, Operation, OperationId, OperationKind, ParentOpIndex,
+    PayloadStore, PersistedRemoteCommitStatus, PersistedRemoteOp, ReplicaId, Result, Storage,
+    TreeCrdt, VersionVector,
 };
 
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
@@ -1440,16 +1441,23 @@ fn bulk_insert_ops_in_tx(ctx: &PgCtx, c: &mut Client, ops: &[Operation]) -> Resu
     Ok(inserted)
 }
 
-fn select_inserted_ops(
+fn mark_persisted_remote_ops(
     ctx: &PgCtx,
     ops: &[Operation],
     inserted_op_refs: Vec<Vec<u8>>,
-) -> Vec<Operation> {
+) -> Vec<PersistedRemoteOp> {
     if inserted_op_refs.is_empty() {
-        return Vec::new();
+        return ops
+            .iter()
+            .cloned()
+            .map(|op| PersistedRemoteOp {
+                op,
+                inserted: false,
+            })
+            .collect();
     }
     if inserted_op_refs.len() == ops.len() {
-        return ops.to_vec();
+        return ops.iter().cloned().map(|op| PersistedRemoteOp { op, inserted: true }).collect();
     }
 
     // bulk_insert_ops_in_tx returns exactly the op_refs Postgres accepted.
@@ -1460,81 +1468,52 @@ fn select_inserted_ops(
         *remaining_by_ref.entry(op_ref).or_insert(0) += 1;
     }
 
-    let mut inserted_ops = Vec::new();
+    let mut persisted_ops = Vec::with_capacity(ops.len());
     for op in ops {
         let replica = op.meta.id.replica.as_bytes();
         let counter = op.meta.id.counter;
         let op_ref = derive_op_ref_v0(&ctx.doc_id, replica, counter);
-        let Some(remaining) = remaining_by_ref.get_mut(op_ref.as_slice()) else {
-            continue;
+        let inserted = match remaining_by_ref.get_mut(op_ref.as_slice()) {
+            Some(remaining) if *remaining > 0 => {
+                *remaining -= 1;
+                true
+            }
+            _ => false,
         };
-        if *remaining == 0 {
-            continue;
-        }
-        *remaining -= 1;
-        inserted_ops.push(op.clone());
+        persisted_ops.push(PersistedRemoteOp {
+            op: op.clone(),
+            inserted,
+        });
     }
 
-    inserted_ops
+    persisted_ops
 }
 
-fn materialize_ops_in_order(
+fn materialize_inserted_ops(
     ctx: PgCtx,
     meta: &TreeMeta,
     ops: Vec<Operation>,
-) -> Result<Vec<NodeId>> {
-    if ops.is_empty() {
-        return Ok(Vec::new());
-    }
-
+) -> Result<treecrdt_core::IncrementalApplyResult> {
     // At this point treecrdt_ops already contains the inserted operations. This temporary
     // TreeCrdt exists only to replay those ops through core semantics and update derived tables.
-    let nodes = PgNodeStore::new(ctx.clone());
-    if ops.iter().any(|op| matches!(op.kind, OperationKind::Payload { .. })) {
-        // Payload ops can depend on the current node row, so front-load the reads here.
-        nodes.preload_for_ops(&ops)?;
-    }
-    let node_flush = nodes.clone();
-    let payloads = PgPayloadStore::new(ctx.clone());
-    let mut index = PgParentOpIndex::new(ctx.clone());
-
-    // NoopStorage is intentional: append_ops_in_tx already persisted the op log, and this pass is
-    // only responsible for materialized state (nodes/payload/index/head) through treecrdt-core.
-    let mut crdt = TreeCrdt::with_stores(
+    materialize_persisted_remote_ops_with_delta(
         ReplicaId::new(b"postgres"),
-        NoopStorage,
         LamportClock::default(),
-        nodes,
-        payloads,
-    )?;
-
-    let materialize_started_at = Instant::now();
-    // This is the main handoff into treecrdt-core for remote/bulk append batches:
-    // defensive delete + revival, payload LWW, tombstone refresh, and oprefs_children updates.
-    let apply_result = apply_incremental_ops_with_delta(&mut crdt, &mut index, meta, ops)?;
-    let next = apply_result
-        .head
-        .ok_or_else(|| Error::Storage("expected head op after materialization".into()))?;
-    node_flush.flush_last_change()?;
-    index.flush()?;
-    if let Some(profile) = &ctx.append_profile {
-        profile.borrow_mut().materialize_ms +=
-            materialize_started_at.elapsed().as_secs_f64() * 1000.0;
-    }
-    let update_head_started_at = Instant::now();
-    update_tree_meta_head(
-        &ctx.client,
-        &ctx.doc_id,
-        next.lamport,
-        &next.replica,
-        next.counter,
-        next.seq,
-    )?;
-    if let Some(profile) = &ctx.append_profile {
-        profile.borrow_mut().update_head_ms +=
-            update_head_started_at.elapsed().as_secs_f64() * 1000.0;
-    }
-    Ok(apply_result.affected_nodes)
+        PgNodeStore::new(ctx.clone()),
+        PgPayloadStore::new(ctx.clone()),
+        PgParentOpIndex::new(ctx.clone()),
+        meta,
+        ops,
+        |nodes, ops| {
+            if ops.iter().any(|op| matches!(op.kind, OperationKind::Payload { .. })) {
+                // Payload ops can depend on the current node row, so front-load the reads here.
+                nodes.preload_for_ops(ops)?;
+            }
+            Ok(())
+        },
+        |nodes| nodes.flush_last_change(),
+        |index| index.flush(),
+    )
 }
 
 pub fn append_ops(client: &Rc<RefCell<Client>>, doc_id: &str, ops: &[Operation]) -> Result<u64> {
@@ -1610,38 +1589,6 @@ fn append_ops_in_tx(
     });
     let ctx = PgCtx::new_with_profile(client.clone(), doc_id, append_profile.clone())?;
 
-    // treecrdt_ops is the source of truth. This function first appends/dedupes the op log in SQL
-    // and only then decides whether it can replay the inserted subset through core materialization.
-    //
-    // If the doc is already dirty, derived tables are stale, so we only append to the op log and
-    // leave full reconstruction to ensure_materialized_in_tx on a later read.
-    if meta.dirty {
-        let bulk_insert_started_at = Instant::now();
-        let inserted = {
-            let mut c = client.borrow_mut();
-            bulk_insert_ops_in_tx(&ctx, &mut c, ops)?
-        };
-        if let Some(profile) = &append_profile {
-            let mut profile = profile.borrow_mut();
-            profile.bulk_insert_ms += bulk_insert_started_at.elapsed().as_secs_f64() * 1000.0;
-            profile.bulk_inserted_ops += inserted.len();
-        }
-        if !inserted.is_empty() {
-            set_tree_meta_dirty(client, doc_id, true)?;
-            if let Some(profile) = &append_profile {
-                profile.borrow_mut().fallback_mark_dirty = true;
-            }
-        }
-        let inserted_count = inserted.len().min(u64::MAX as usize) as u64;
-        if let Some(profile) = &append_profile {
-            profile.borrow().log(doc_id, inserted_count as usize);
-        }
-        return Ok(AppendOpsResult {
-            inserted_count,
-            affected_nodes: Vec::new(),
-        });
-    }
-
     let bulk_insert_started_at = Instant::now();
     let inserted_op_refs = {
         let mut c = client.borrow_mut();
@@ -1653,57 +1600,52 @@ fn append_ops_in_tx(
         profile.bulk_inserted_ops += inserted_op_refs.len();
     }
 
-    if inserted_op_refs.is_empty() {
-        if let Some(profile) = &append_profile {
-            profile.borrow().log(doc_id, 0);
-        }
-        return Ok(AppendOpsResult::default());
-    }
-
     let dedupe_filter_started_at = Instant::now();
     // Only materialize the ops Postgres actually inserted. This keeps duplicate opRefs in the
     // input batch from being replayed twice through core materialization.
-    let inserted_ops = select_inserted_ops(&ctx, ops, inserted_op_refs);
+    let persisted_ops = mark_persisted_remote_ops(&ctx, ops, inserted_op_refs);
     if let Some(profile) = &append_profile {
         profile.borrow_mut().dedupe_filter_ms +=
             dedupe_filter_started_at.elapsed().as_secs_f64() * 1000.0;
     }
 
-    if inserted_ops.is_empty() {
-        if let Some(profile) = &append_profile {
-            profile.borrow().log(doc_id, 0);
-        }
-        return Ok(AppendOpsResult::default());
-    }
-
-    let inserted = inserted_ops.len();
-    let mut affected_nodes: Vec<NodeId> = Vec::new();
-    // If incremental materialization fails, keep the op-log append and mark the doc dirty so the
-    // next rebuild replays the full log through the same core semantics.
-    let materialized = try_incremental_materialization(
-        false,
-        || {
-            affected_nodes = materialize_ops_in_order(ctx, &meta, inserted_ops)?;
-            Ok::<(), Error>(())
-        },
-        || {
-            let _ = set_tree_meta_dirty(client, doc_id, true);
-            if let Some(profile) = &append_profile {
-                profile.borrow_mut().fallback_mark_dirty = true;
-            }
-        },
-    );
-    if !materialized {
-        affected_nodes.clear();
-    }
-
+    let materialize_started_at = Instant::now();
+    let mut apply_result =
+        apply_persisted_remote_ops_with_delta(&meta, persisted_ops, |inserted| {
+            materialize_inserted_ops(ctx.clone(), &meta, inserted)
+        });
     if let Some(profile) = &append_profile {
-        profile.borrow().log(doc_id, inserted);
+        profile.borrow_mut().materialize_ms +=
+            materialize_started_at.elapsed().as_secs_f64() * 1000.0;
+    }
+
+    let update_head_started_at = Instant::now();
+    let commit_status = commit_persisted_remote_result(
+        &mut apply_result,
+        |head| {
+            update_tree_meta_head(
+                &ctx.client,
+                &ctx.doc_id,
+                head.lamport,
+                &head.replica,
+                head.counter,
+                head.seq,
+            )
+        },
+        || set_tree_meta_dirty(client, doc_id, true),
+    );
+    if let Some(profile) = &append_profile {
+        profile.borrow_mut().update_head_ms +=
+            update_head_started_at.elapsed().as_secs_f64() * 1000.0;
+        if commit_status == PersistedRemoteCommitStatus::DirtyFallback {
+            profile.borrow_mut().fallback_mark_dirty = true;
+        }
+        profile.borrow().log(doc_id, apply_result.inserted_count as usize);
     }
 
     Ok(AppendOpsResult {
-        inserted_count: inserted.min(u64::MAX as usize) as u64,
-        affected_nodes,
+        inserted_count: apply_result.inserted_count,
+        affected_nodes: apply_result.affected_nodes,
     })
 }
 

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -1487,6 +1487,7 @@ fn materialize_inserted_ops(
     // TreeCrdt exists only to replay those ops through core semantics and update derived tables.
     materialize_persisted_remote_ops_with_delta(
         PersistedRemoteStores {
+            // Scratch identity for the temporary TreeCrdt; replayed ops keep their own ids.
             replica_id: ReplicaId::new(b"postgres"),
             clock: LamportClock::default(),
             nodes: PgNodeStore::new(ctx.clone()),

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -6,11 +6,10 @@ use std::time::Instant;
 use postgres::{Client, Row, Statement};
 
 use treecrdt_core::{
-    apply_persisted_remote_ops_with_delta, commit_persisted_remote_result,
-    materialize_persisted_remote_ops_with_delta, Error, Lamport, LamportClock,
-    MaterializationCursor, NodeId, NodeStore, Operation, OperationId, OperationKind, ParentOpIndex,
-    PayloadStore, PersistedRemoteCommitStatus, PersistedRemoteOp, ReplicaId, Result, Storage,
-    TreeCrdt, VersionVector,
+    apply_persisted_remote_ops_with_delta, materialize_persisted_remote_ops_with_delta, Error,
+    Lamport, LamportClock, MaterializationCursor, NodeId, NodeStore, Operation, OperationId,
+    OperationKind, ParentOpIndex, PayloadStore, ReplicaId, Result, Storage, TreeCrdt,
+    VersionVector,
 };
 
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
@@ -1441,23 +1440,16 @@ fn bulk_insert_ops_in_tx(ctx: &PgCtx, c: &mut Client, ops: &[Operation]) -> Resu
     Ok(inserted)
 }
 
-fn mark_persisted_remote_ops(
+fn select_inserted_ops(
     ctx: &PgCtx,
     ops: &[Operation],
     inserted_op_refs: Vec<Vec<u8>>,
-) -> Vec<PersistedRemoteOp> {
+) -> Vec<Operation> {
     if inserted_op_refs.is_empty() {
-        return ops
-            .iter()
-            .cloned()
-            .map(|op| PersistedRemoteOp {
-                op,
-                inserted: false,
-            })
-            .collect();
+        return Vec::new();
     }
     if inserted_op_refs.len() == ops.len() {
-        return ops.iter().cloned().map(|op| PersistedRemoteOp { op, inserted: true }).collect();
+        return ops.to_vec();
     }
 
     // bulk_insert_ops_in_tx returns exactly the op_refs Postgres accepted.
@@ -1468,25 +1460,22 @@ fn mark_persisted_remote_ops(
         *remaining_by_ref.entry(op_ref).or_insert(0) += 1;
     }
 
-    let mut persisted_ops = Vec::with_capacity(ops.len());
+    let mut inserted_ops = Vec::new();
     for op in ops {
         let replica = op.meta.id.replica.as_bytes();
         let counter = op.meta.id.counter;
         let op_ref = derive_op_ref_v0(&ctx.doc_id, replica, counter);
-        let inserted = match remaining_by_ref.get_mut(op_ref.as_slice()) {
-            Some(remaining) if *remaining > 0 => {
-                *remaining -= 1;
-                true
-            }
-            _ => false,
+        let Some(remaining) = remaining_by_ref.get_mut(op_ref.as_slice()) else {
+            continue;
         };
-        persisted_ops.push(PersistedRemoteOp {
-            op: op.clone(),
-            inserted,
-        });
+        if *remaining == 0 {
+            continue;
+        }
+        *remaining -= 1;
+        inserted_ops.push(op.clone());
     }
 
-    persisted_ops
+    inserted_ops
 }
 
 fn materialize_inserted_ops(
@@ -1603,41 +1592,41 @@ fn append_ops_in_tx(
     let dedupe_filter_started_at = Instant::now();
     // Only materialize the ops Postgres actually inserted. This keeps duplicate opRefs in the
     // input batch from being replayed twice through core materialization.
-    let persisted_ops = mark_persisted_remote_ops(&ctx, ops, inserted_op_refs);
+    let inserted_ops = select_inserted_ops(&ctx, ops, inserted_op_refs);
     if let Some(profile) = &append_profile {
         profile.borrow_mut().dedupe_filter_ms +=
             dedupe_filter_started_at.elapsed().as_secs_f64() * 1000.0;
     }
 
     let materialize_started_at = Instant::now();
-    let mut apply_result =
-        apply_persisted_remote_ops_with_delta(&meta, persisted_ops, |inserted| {
-            materialize_inserted_ops(ctx.clone(), &meta, inserted)
-        });
-    if let Some(profile) = &append_profile {
-        profile.borrow_mut().materialize_ms +=
-            materialize_started_at.elapsed().as_secs_f64() * 1000.0;
-    }
-
-    let update_head_started_at = Instant::now();
-    let commit_status = commit_persisted_remote_result(
-        &mut apply_result,
+    let mut update_head_ms = 0.0;
+    let apply_result = apply_persisted_remote_ops_with_delta(
+        &meta,
+        inserted_ops,
+        |inserted| materialize_inserted_ops(ctx.clone(), &meta, inserted),
         |head| {
-            update_tree_meta_head(
+            let started_at = Instant::now();
+            let result = update_tree_meta_head(
                 &ctx.client,
                 &ctx.doc_id,
                 head.lamport,
                 &head.replica,
                 head.counter,
                 head.seq,
-            )
+            );
+            update_head_ms += started_at.elapsed().as_secs_f64() * 1000.0;
+            result
         },
         || set_tree_meta_dirty(client, doc_id, true),
     );
     if let Some(profile) = &append_profile {
-        profile.borrow_mut().update_head_ms +=
-            update_head_started_at.elapsed().as_secs_f64() * 1000.0;
-        if commit_status == PersistedRemoteCommitStatus::DirtyFallback {
+        profile.borrow_mut().materialize_ms +=
+            materialize_started_at.elapsed().as_secs_f64() * 1000.0;
+    }
+
+    if let Some(profile) = &append_profile {
+        profile.borrow_mut().update_head_ms += update_head_ms;
+        if apply_result.dirty_fallback {
             profile.borrow_mut().fallback_mark_dirty = true;
         }
         profile.borrow().log(doc_id, apply_result.inserted_count as usize);

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -7,9 +7,10 @@ use uuid::Uuid;
 
 use treecrdt_core::{NodeId, Operation, ReplicaId, VersionVector};
 use treecrdt_postgres::{
-    append_ops, ensure_materialized, ensure_schema, get_ops_by_op_refs, list_op_refs_all,
-    list_op_refs_children, local_delete, local_insert, local_move, local_payload, max_lamport,
-    replica_max_counter, reset_doc_for_tests, tree_children,
+    append_ops, append_ops_with_affected_nodes, ensure_materialized, ensure_schema,
+    get_ops_by_op_refs, list_op_refs_all, list_op_refs_children, local_delete, local_insert,
+    local_move, local_payload, max_lamport, replica_max_counter, reset_doc_for_tests,
+    tree_children, tree_payload,
 };
 
 fn order_key_from_position(position: u16) -> Vec<u8> {
@@ -19,6 +20,25 @@ fn order_key_from_position(position: u16) -> Vec<u8> {
 
 fn node(n: u128) -> NodeId {
     NodeId(n)
+}
+
+fn representative_remote_batch(replica: &ReplicaId) -> (NodeId, NodeId, NodeId, Vec<Operation>) {
+    let p1 = node(1);
+    let p2 = node(2);
+    let child = node(3);
+    (
+        p1,
+        p2,
+        child,
+        vec![
+            Operation::insert(replica, 1, 1, NodeId::ROOT, p1, order_key_from_position(0)),
+            Operation::insert(replica, 2, 2, NodeId::ROOT, p2, order_key_from_position(1)),
+            Operation::insert(replica, 3, 3, p1, child, order_key_from_position(0)),
+            Operation::set_payload(replica, 4, 4, child, vec![7]),
+            Operation::move_node(replica, 5, 5, child, p2, order_key_from_position(0)),
+            Operation::set_payload(replica, 6, 6, child, vec![8]),
+        ],
+    )
 }
 
 fn connect() -> Option<Rc<RefCell<Client>>> {
@@ -104,6 +124,119 @@ fn postgres_backend_append_batch_materializes_only_inserted_ops() {
         row.get::<_, i64>(0).max(0) as u64
     };
     assert_eq!(head_seq, 2);
+}
+
+#[test]
+fn postgres_backend_append_with_affected_nodes_matches_representative_remote_batch() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    {
+        let mut c = client.borrow_mut();
+        reset_doc_for_tests(&mut c, &doc_id).unwrap();
+    }
+
+    let replica = ReplicaId::new(b"rep");
+    let (p1, p2, child, ops) = representative_remote_batch(&replica);
+
+    let affected = append_ops_with_affected_nodes(&client, &doc_id, &ops).unwrap();
+    assert_eq!(affected, vec![NodeId::ROOT, p1, p2, child]);
+    assert_eq!(
+        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
+        vec![p1, p2]
+    );
+    assert_eq!(tree_children(&client, &doc_id, p2).unwrap(), vec![child]);
+    assert_eq!(
+        tree_payload(&client, &doc_id, child).unwrap(),
+        Some(vec![8])
+    );
+
+    let refs_p2 = list_op_refs_children(&client, &doc_id, p2).unwrap();
+    let ops_p2 = get_ops_by_op_refs(&client, &doc_id, &refs_p2).unwrap();
+    assert!(ops_p2
+        .iter()
+        .any(|op| matches!(op.kind, treecrdt_core::OperationKind::Move { .. })));
+    assert!(ops_p2
+        .iter()
+        .any(|op| matches!(op.kind, treecrdt_core::OperationKind::Payload { .. })));
+}
+
+#[test]
+fn postgres_backend_dirty_append_falls_back_to_rebuild_on_read() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    {
+        let mut c = client.borrow_mut();
+        reset_doc_for_tests(&mut c, &doc_id).unwrap();
+    }
+
+    let replica = ReplicaId::new(b"dirty");
+    let first = Operation::insert(
+        &replica,
+        1,
+        1,
+        NodeId::ROOT,
+        node(1),
+        order_key_from_position(0),
+    );
+    let second = Operation::insert(
+        &replica,
+        2,
+        2,
+        NodeId::ROOT,
+        node(2),
+        order_key_from_position(1),
+    );
+
+    append_ops(&client, &doc_id, &[first]).unwrap();
+    {
+        let mut c = client.borrow_mut();
+        c.execute(
+            "UPDATE treecrdt_meta SET dirty = TRUE WHERE doc_id = $1",
+            &[&doc_id],
+        )
+        .unwrap();
+    }
+
+    let affected = append_ops_with_affected_nodes(&client, &doc_id, &[second]).unwrap();
+    assert!(affected.is_empty());
+
+    let dirty_before_read = {
+        let mut c = client.borrow_mut();
+        let row = c
+            .query_one(
+                "SELECT dirty FROM treecrdt_meta WHERE doc_id = $1",
+                &[&doc_id],
+            )
+            .unwrap();
+        row.get::<_, bool>(0)
+    };
+    assert!(dirty_before_read);
+
+    assert_eq!(
+        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
+        vec![node(1), node(2)]
+    );
+
+    let dirty_after_read = {
+        let mut c = client.borrow_mut();
+        let row = c
+            .query_one(
+                "SELECT dirty, head_seq FROM treecrdt_meta WHERE doc_id = $1",
+                &[&doc_id],
+            )
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(1).max(0) as u64, 2);
+        row.get::<_, bool>(0)
+    };
+    assert!(!dirty_after_read);
 }
 
 #[test]

--- a/packages/treecrdt-sqlite-ext/src/extension/functions.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions.rs
@@ -36,7 +36,7 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::ptr::null_mut;
 use std::slice;
 
-pub(super) use treecrdt_core::{Lamport, NodeId, NoopStorage, VersionVector};
+pub(super) use treecrdt_core::{Lamport, NodeId, VersionVector};
 
 #[cfg(any(feature = "ext-sqlite", feature = "static-link"))]
 use serde_json;

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
@@ -261,12 +261,9 @@ pub(super) unsafe extern "C" fn treecrdt_append_ops(
     }
 
     match append_ops_impl(db, &doc_id, "treecrdt_append_ops", &ops) {
-        Ok(result) => {
-            let out: Vec<Vec<u8>> = result
-                .affected_nodes
-                .into_iter()
-                .map(|id| id.0.to_be_bytes().to_vec())
-                .collect();
+        Ok(affected_nodes) => {
+            let out: Vec<Vec<u8>> =
+                affected_nodes.into_iter().map(|id| id.0.to_be_bytes().to_vec()).collect();
             sqlite_result_json(ctx, &out);
         }
         Err(rc) => sqlite_result_error_code(ctx, rc),

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -108,14 +108,19 @@ fn materialize_inserted_ops(
     meta: &TreeMeta,
     ops: &[treecrdt_core::Operation],
 ) -> Result<treecrdt_core::IncrementalApplyResult, c_int> {
-    use treecrdt_core::{materialize_persisted_remote_ops_with_delta, LamportClock, ReplicaId};
+    use treecrdt_core::{
+        materialize_persisted_remote_ops_with_delta, LamportClock, PersistedRemoteStores, ReplicaId,
+    };
 
     materialize_persisted_remote_ops_with_delta(
-        ReplicaId::new(b"sqlite-ext"),
-        LamportClock::default(),
-        SqliteNodeStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
-        SqlitePayloadStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
-        SqliteParentOpIndex::prepare(db, doc_id.to_vec()).map_err(|_| SQLITE_ERROR as c_int)?,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"sqlite-ext"),
+            clock: LamportClock::default(),
+            nodes: SqliteNodeStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
+            payloads: SqlitePayloadStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
+            index: SqliteParentOpIndex::prepare(db, doc_id.to_vec())
+                .map_err(|_| SQLITE_ERROR as c_int)?,
+        },
         meta,
         ops.to_vec(),
         |_, _| Ok(()),

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -232,19 +232,14 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     Ok(())
 }
 
-#[derive(Clone, Debug, Default)]
-pub(super) struct AppendOpsResult {
-    pub(super) affected_nodes: Vec<NodeId>,
-}
-
 pub(super) fn append_ops_impl(
     db: *mut sqlite3,
     doc_id: &[u8],
     savepoint_name: &str,
     ops: &[JsonAppendOp],
-) -> Result<AppendOpsResult, c_int> {
+) -> Result<Vec<NodeId>, c_int> {
     if ops.is_empty() {
-        return Ok(AppendOpsResult::default());
+        return Ok(Vec::new());
     }
 
     let meta = load_tree_meta(db)?;
@@ -261,7 +256,7 @@ pub(super) fn append_ops_impl(
     }
 
     let mut storage = super::op_storage::SqliteOpStorage::with_doc_id(db, doc_id.to_vec());
-    let mut persisted_ops: Vec<treecrdt_core::PersistedRemoteOp> = Vec::with_capacity(ops.len());
+    let mut inserted_ops: Vec<treecrdt_core::Operation> = Vec::with_capacity(ops.len());
 
     for op in ops {
         let operation = match json_append_op_to_operation(op) {
@@ -279,23 +274,18 @@ pub(super) fn append_ops_impl(
                 return Err(sqlite_err_from_core(err));
             }
         };
-        persisted_ops.push(treecrdt_core::PersistedRemoteOp {
-            op: operation,
-            inserted: inserted_now,
-        });
+        if inserted_now {
+            inserted_ops.push(operation);
+        }
     }
 
-    let mut apply_result =
-        treecrdt_core::apply_persisted_remote_ops_with_delta(&meta, persisted_ops, |inserted| {
-            materialize_inserted_ops(db, doc_id, &meta, &inserted)
-        });
-    let _ = treecrdt_core::commit_persisted_remote_result(
-        &mut apply_result,
+    let apply_result = treecrdt_core::apply_persisted_remote_ops_with_delta(
+        &meta,
+        inserted_ops,
+        |inserted| materialize_inserted_ops(db, doc_id, &meta, &inserted),
         |head| update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq),
         || set_tree_meta_dirty(db, true),
     );
-
-    let affected_nodes = apply_result.affected_nodes;
 
     let commit_rc = sqlite_exec(db, commit.as_ptr(), None, null_mut(), null_mut());
     if commit_rc != SQLITE_OK as c_int {
@@ -303,5 +293,5 @@ pub(super) fn append_ops_impl(
         return Err(commit_rc);
     }
 
-    Ok(AppendOpsResult { affected_nodes })
+    Ok(apply_result.affected_nodes)
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -102,35 +102,27 @@ impl treecrdt_core::MaterializationCursor for TreeMeta {
     }
 }
 
-fn materialize_ops_in_order(
+fn materialize_inserted_ops(
     db: *mut sqlite3,
     doc_id: &[u8],
     meta: &TreeMeta,
     ops: &[treecrdt_core::Operation],
-) -> Result<Vec<NodeId>, c_int> {
-    if ops.is_empty() {
-        return Ok(Vec::new());
-    }
+) -> Result<treecrdt_core::IncrementalApplyResult, c_int> {
+    use treecrdt_core::{materialize_persisted_remote_ops_with_delta, LamportClock, ReplicaId};
 
-    use treecrdt_core::{apply_incremental_ops_with_delta, LamportClock, ReplicaId, TreeCrdt};
-    let node_store = SqliteNodeStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?;
-    let payload_store = SqlitePayloadStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?;
-    let mut op_index =
-        SqliteParentOpIndex::prepare(db, doc_id.to_vec()).map_err(|_| SQLITE_ERROR as c_int)?;
-    let mut crdt = TreeCrdt::with_stores(
+    materialize_persisted_remote_ops_with_delta(
         ReplicaId::new(b"sqlite-ext"),
-        NoopStorage,
         LamportClock::default(),
-        node_store,
-        payload_store,
+        SqliteNodeStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
+        SqlitePayloadStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,
+        SqliteParentOpIndex::prepare(db, doc_id.to_vec()).map_err(|_| SQLITE_ERROR as c_int)?,
+        meta,
+        ops.to_vec(),
+        |_, _| Ok(()),
+        |_| Ok(()),
+        |_| Ok(()),
     )
-    .map_err(|_| SQLITE_ERROR as c_int)?;
-
-    let next = apply_incremental_ops_with_delta(&mut crdt, &mut op_index, meta, ops.to_vec())
-        .map_err(|_| SQLITE_ERROR as c_int)?;
-    let head = next.head.ok_or(SQLITE_ERROR as c_int)?;
-    update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq)?;
-    Ok(next.affected_nodes)
+    .map_err(|_| SQLITE_ERROR as c_int)
 }
 
 pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
@@ -242,7 +234,6 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
 
 #[derive(Clone, Debug, Default)]
 pub(super) struct AppendOpsResult {
-    pub(super) inserted: i64,
     pub(super) affected_nodes: Vec<NodeId>,
 }
 
@@ -270,9 +261,7 @@ pub(super) fn append_ops_impl(
     }
 
     let mut storage = super::op_storage::SqliteOpStorage::with_doc_id(db, doc_id.to_vec());
-    let mut inserted: i64 = 0;
-    let mut materialize_ops: Vec<treecrdt_core::Operation> = Vec::with_capacity(ops.len());
-    let mut affected_nodes: Vec<NodeId> = Vec::new();
+    let mut persisted_ops: Vec<treecrdt_core::PersistedRemoteOp> = Vec::with_capacity(ops.len());
 
     for op in ops {
         let operation = match json_append_op_to_operation(op) {
@@ -290,30 +279,23 @@ pub(super) fn append_ops_impl(
                 return Err(sqlite_err_from_core(err));
             }
         };
-        if !inserted_now {
-            continue;
-        }
-
-        inserted += 1;
-        materialize_ops.push(operation);
+        persisted_ops.push(treecrdt_core::PersistedRemoteOp {
+            op: operation,
+            inserted: inserted_now,
+        });
     }
 
-    if inserted > 0 {
-        let materialized = treecrdt_core::try_incremental_materialization(
-            meta.dirty,
-            || {
-                affected_nodes = materialize_ops_in_order(db, doc_id, &meta, &materialize_ops[..])?;
-                Ok::<(), c_int>(())
-            },
-            || {
-                let _ = set_tree_meta_dirty(db, true);
-            },
-        );
-        if !materialized {
-            // Exact incremental delta is unavailable when materialization was skipped/failed.
-            affected_nodes.clear();
-        }
-    }
+    let mut apply_result =
+        treecrdt_core::apply_persisted_remote_ops_with_delta(&meta, persisted_ops, |inserted| {
+            materialize_inserted_ops(db, doc_id, &meta, &inserted)
+        });
+    let _ = treecrdt_core::commit_persisted_remote_result(
+        &mut apply_result,
+        |head| update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq),
+        || set_tree_meta_dirty(db, true),
+    );
+
+    let affected_nodes = apply_result.affected_nodes;
 
     let commit_rc = sqlite_exec(db, commit.as_ptr(), None, null_mut(), null_mut());
     if commit_rc != SQLITE_OK as c_int {
@@ -321,8 +303,5 @@ pub(super) fn append_ops_impl(
         return Err(commit_rc);
     }
 
-    Ok(AppendOpsResult {
-        inserted,
-        affected_nodes,
-    })
+    Ok(AppendOpsResult { affected_nodes })
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -114,6 +114,7 @@ fn materialize_inserted_ops(
 
     materialize_persisted_remote_ops_with_delta(
         PersistedRemoteStores {
+            // Scratch identity for the temporary TreeCrdt; replayed ops keep their own ids.
             replica_id: ReplicaId::new(b"sqlite-ext"),
             clock: LamportClock::default(),
             nodes: SqliteNodeStore::prepare(db).map_err(|_| SQLITE_ERROR as c_int)?,

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -3,10 +3,10 @@ use std::env;
 use std::path::PathBuf;
 
 use rusqlite::Connection;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use treecrdt_core::{order_key::allocate_between, ReplicaId, VersionVector};
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize, Serialize)]
 struct JsonOp {
     replica: Vec<u8>,
     counter: u64,
@@ -27,6 +27,157 @@ fn read_tree_meta(conn: &Connection) -> (i64, i64, Vec<u8>, i64, i64) {
         |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
     )
     .unwrap()
+}
+
+fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (Vec<Vec<u8>>, i64) {
+    let json = serde_json::to_string(ops).unwrap();
+    let affected_json: String = conn
+        .query_row(
+            "SELECT treecrdt_append_ops(?1)",
+            rusqlite::params![json],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let affected: Vec<Vec<u8>> = serde_json::from_str(&affected_json).unwrap();
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0)).unwrap();
+    (affected, count)
+}
+
+fn visible_children(conn: &Connection, parent: &[u8]) -> Vec<Vec<u8>> {
+    let parent_arr = <[u8; 16]>::try_from(parent).unwrap();
+    let mut stmt = conn
+        .prepare(
+            "SELECT node FROM tree_nodes \
+             WHERE parent = ?1 AND tombstone = 0 \
+             ORDER BY order_key, node",
+        )
+        .unwrap();
+    let rows = stmt
+        .query_map(rusqlite::params![parent_arr], |row| {
+            row.get::<_, Vec<u8>>(0)
+        })
+        .unwrap();
+    rows.map(|row| row.unwrap()).collect()
+}
+
+fn payload_bytes(conn: &Connection, node: &[u8]) -> Option<Vec<u8>> {
+    let node_arr = <[u8; 16]>::try_from(node).unwrap();
+    conn.query_row(
+        "SELECT payload FROM tree_payload WHERE node = ?1 LIMIT 1",
+        rusqlite::params![node_arr],
+        |row| row.get(0),
+    )
+    .unwrap()
+}
+
+fn oprefs_children(conn: &Connection, parent: &[u8]) -> Vec<Vec<u8>> {
+    let parent_arr = <[u8; 16]>::try_from(parent).unwrap();
+    let refs_json: String = conn
+        .query_row(
+            "SELECT treecrdt_oprefs_children(?1)",
+            rusqlite::params![parent_arr],
+            |row| row.get(0),
+        )
+        .unwrap();
+    serde_json::from_str(&refs_json).unwrap()
+}
+
+fn ops_by_oprefs(conn: &Connection, refs: &[Vec<u8>]) -> Vec<JsonOp> {
+    let refs_json = serde_json::to_string(refs).unwrap();
+    let ops_json: String = conn
+        .query_row(
+            "SELECT treecrdt_ops_by_oprefs(?1)",
+            rusqlite::params![refs_json],
+            |row| row.get(0),
+        )
+        .unwrap();
+    serde_json::from_str(&ops_json).unwrap()
+}
+
+fn representative_remote_batch(replica: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<u8>, Vec<JsonOp>) {
+    let root = node_bytes(0);
+    let p1 = node_bytes(1);
+    let p2 = node_bytes(2);
+    let child = node_bytes(3);
+    (
+        p1.clone(),
+        p2.clone(),
+        child.clone(),
+        vec![
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 1,
+                lamport: 1,
+                kind: "insert".into(),
+                parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+                node: <[u8; 16]>::try_from(p1.as_slice()).unwrap(),
+                new_parent: None,
+                order_key: Some((1u16).to_be_bytes().to_vec()),
+                known_state: None,
+                payload: None,
+            },
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 2,
+                lamport: 2,
+                kind: "insert".into(),
+                parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+                node: <[u8; 16]>::try_from(p2.as_slice()).unwrap(),
+                new_parent: None,
+                order_key: Some((2u16).to_be_bytes().to_vec()),
+                known_state: None,
+                payload: None,
+            },
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 3,
+                lamport: 3,
+                kind: "insert".into(),
+                parent: Some(<[u8; 16]>::try_from(p1.as_slice()).unwrap()),
+                node: <[u8; 16]>::try_from(child.as_slice()).unwrap(),
+                new_parent: None,
+                order_key: Some((1u16).to_be_bytes().to_vec()),
+                known_state: None,
+                payload: None,
+            },
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 4,
+                lamport: 4,
+                kind: "payload".into(),
+                parent: None,
+                node: <[u8; 16]>::try_from(child.as_slice()).unwrap(),
+                new_parent: None,
+                order_key: None,
+                known_state: None,
+                payload: Some(vec![7]),
+            },
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 5,
+                lamport: 5,
+                kind: "move".into(),
+                parent: None,
+                node: <[u8; 16]>::try_from(child.as_slice()).unwrap(),
+                new_parent: Some(<[u8; 16]>::try_from(p2.as_slice()).unwrap()),
+                order_key: Some((1u16).to_be_bytes().to_vec()),
+                known_state: None,
+                payload: None,
+            },
+            JsonOp {
+                replica: replica.to_vec(),
+                counter: 6,
+                lamport: 6,
+                kind: "payload".into(),
+                parent: None,
+                node: <[u8; 16]>::try_from(child.as_slice()).unwrap(),
+                new_parent: None,
+                order_key: None,
+                known_state: None,
+                payload: Some(vec![8]),
+            },
+        ],
+    )
 }
 
 #[test]
@@ -150,6 +301,120 @@ fn local_insert_returns_appended_insert_op() {
     assert_eq!(head_replica, b"r1".to_vec());
     assert_eq!(head_counter, 1);
     assert_eq!(head_seq, 1);
+}
+
+#[test]
+fn remote_append_materializes_only_inserted_ops() {
+    let conn = setup_conn();
+
+    let replica = b"dup".to_vec();
+    let root = node_bytes(0);
+    let node = node_bytes(1);
+    let insert = JsonOp {
+        replica: replica.clone(),
+        counter: 1,
+        lamport: 1,
+        kind: "insert".into(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node.as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some((1u16).to_be_bytes().to_vec()),
+        known_state: None,
+        payload: None,
+    };
+    let payload = JsonOp {
+        replica,
+        counter: 2,
+        lamport: 2,
+        kind: "payload".into(),
+        parent: None,
+        node: <[u8; 16]>::try_from(node.as_slice()).unwrap(),
+        new_parent: None,
+        order_key: None,
+        known_state: None,
+        payload: Some(vec![9]),
+    };
+
+    let (affected, op_count) = append_ops_json(&conn, &[insert.clone(), insert, payload]);
+    assert_eq!(affected, vec![root.clone(), node.clone()]);
+    assert_eq!(op_count, 2);
+    assert_eq!(visible_children(&conn, &root), vec![node]);
+
+    let (_, _, _, _, head_seq) = read_tree_meta(&conn);
+    assert_eq!(head_seq, 2);
+}
+
+#[test]
+fn remote_append_representative_batch_matches_postgres_shape() {
+    let conn = setup_conn();
+
+    let root = node_bytes(0);
+    let (p1, p2, child, ops) = representative_remote_batch(b"rep");
+    let (affected, _) = append_ops_json(&conn, &ops);
+
+    assert_eq!(
+        affected,
+        vec![root.clone(), p1.clone(), p2.clone(), child.clone()]
+    );
+    assert_eq!(visible_children(&conn, &root), vec![p1.clone(), p2.clone()]);
+    assert_eq!(visible_children(&conn, &p2), vec![child.clone()]);
+    assert_eq!(payload_bytes(&conn, &child), Some(vec![8]));
+
+    let ops_p2 = ops_by_oprefs(&conn, &oprefs_children(&conn, &p2));
+    assert!(ops_p2.iter().any(|op| op.kind == "move"));
+    assert!(ops_p2.iter().any(|op| op.kind == "payload"));
+}
+
+#[test]
+fn remote_append_dirty_fallback_rebuilds_on_ensure_materialized() {
+    let conn = setup_conn();
+
+    let root = node_bytes(0);
+    let first = JsonOp {
+        replica: b"dirty".to_vec(),
+        counter: 1,
+        lamport: 1,
+        kind: "insert".into(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node_bytes(1).as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some((1u16).to_be_bytes().to_vec()),
+        known_state: None,
+        payload: None,
+    };
+    let second = JsonOp {
+        replica: b"dirty".to_vec(),
+        counter: 2,
+        lamport: 2,
+        kind: "insert".into(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node_bytes(2).as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some((2u16).to_be_bytes().to_vec()),
+        known_state: None,
+        payload: None,
+    };
+
+    append_ops_json(&conn, &[first]);
+    conn.execute("UPDATE tree_meta SET dirty = 1 WHERE id = 1", []).unwrap();
+
+    let (affected, _) = append_ops_json(&conn, &[second]);
+    assert!(affected.is_empty());
+    assert_eq!(read_tree_meta(&conn).0, 1);
+
+    let _: i64 = conn
+        .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+
+    assert_eq!(
+        visible_children(&conn, &root),
+        vec![node_bytes(1), node_bytes(2)]
+    );
+    let (dirty, _, _, _, head_seq) = read_tree_meta(&conn);
+    assert_eq!(dirty, 0);
+    assert_eq!(head_seq, 2);
 }
 
 #[test]


### PR DESCRIPTION
## What changed
- Added a core helper for already-persisted remote ops.
- Postgres and sqlite now keep persistence, dedupe, transactions, and metadata writes in the adapter, then hand only the inserted ops to core for canonical replay and materialization.
- Postgres still returns affected node ids.
- SQLite still falls back to dirty/rebuild-on-read when incremental materialization cannot be trusted.

## Why
This removes duplicated remote materialization logic from both adapters and keeps replay semantics in one place.

## Tests
- cargo test -p treecrdt-core --test materialization_helpers
- cargo test -p treecrdt-sqlite-ext --test extension_roundtrip --features rusqlite-storage,ext-sqlite
- cargo test -p treecrdt-postgres --test postgres_test

## CI follow-up
- Playground sync now reuses the prepared `syncAuth` object instead of rebuilding auth state in the sync hook. That fixes the open-device auth race that showed up in CI.

Closes #114.