### PR TITLE
feat(core): replace dirty materialization with replay frontier

### DIFF
--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -16,8 +16,9 @@ pub use error::{Error, Result};
 pub use ids::{Lamport, NodeId, OperationId, ReplicaId};
 pub use materialization::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    materialize_persisted_remote_ops_with_delta, IncrementalApplyResult, MaterializationCursor,
-    MaterializationHead, PersistedRemoteApplyResult, PersistedRemoteStores,
+    catch_up_materialized_state, materialize_persisted_remote_ops_with_delta,
+    IncrementalApplyResult, MaterializationCursor, MaterializationFrontier, MaterializationHead,
+    PersistedRemoteApplyResult, PersistedRemoteStores,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -18,7 +18,7 @@ pub use materialization::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     catch_up_materialized_state, materialize_persisted_remote_ops_with_delta,
     IncrementalApplyResult, MaterializationCursor, MaterializationFrontier, MaterializationHead,
-    PersistedRemoteApplyResult, PersistedRemoteStores,
+    MaterializationKey, MaterializationState, PersistedRemoteApplyResult, PersistedRemoteStores,
 };
 pub use ops::{cmp_op_key, cmp_ops, Operation, OperationKind, OperationMetadata};
 pub use traits::{

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -90,7 +90,7 @@ pub struct PersistedRemoteApplyResult {
     pub affected_nodes: Vec<NodeId>,
     /// True when the helper recorded a replay frontier instead of advancing materialization head
     /// immediately.
-    pub replay_deferred: bool,
+    pub frontier_recorded: bool,
 }
 
 /// Backend-owned stores used to replay already-persisted remote ops through core semantics.
@@ -355,7 +355,7 @@ fn build_prefix_snapshot<S: Storage>(
                 Ok(())
             }
             None => Err(Error::Storage(
-                "prefix replay unexpectedly required nested rebuild".into(),
+                "prefix replay unexpectedly required nested catch-up".into(),
             )),
         }
     })?;
@@ -480,7 +480,7 @@ where
                 Ok(())
             }
             None => Err(Error::Storage(
-                "catch-up replay unexpectedly required nested rebuild".into(),
+                "catch-up replay unexpectedly required nested catch-up".into(),
             )),
         }
     })?;
@@ -519,7 +519,7 @@ where
         return Ok(PersistedRemoteApplyResult {
             inserted_count: 0,
             affected_nodes: Vec::new(),
-            replay_deferred: false,
+            frontier_recorded: false,
         });
     }
 
@@ -528,7 +528,7 @@ where
         return Ok(PersistedRemoteApplyResult {
             inserted_count,
             affected_nodes: Vec::new(),
-            replay_deferred: true,
+            frontier_recorded: true,
         });
     }
 
@@ -539,7 +539,7 @@ where
                 return Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: Vec::new(),
-                    replay_deferred: true,
+                    frontier_recorded: true,
                 });
             };
 
@@ -547,14 +547,14 @@ where
                 Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: result.affected_nodes,
-                    replay_deferred: false,
+                    frontier_recorded: false,
                 })
             } else {
                 schedule_replay(&start_replay_frontier())?;
                 Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: Vec::new(),
-                    replay_deferred: true,
+                    frontier_recorded: true,
                 })
             }
         }
@@ -563,7 +563,7 @@ where
             Ok(PersistedRemoteApplyResult {
                 inserted_count,
                 affected_nodes: Vec::new(),
-                replay_deferred: true,
+                frontier_recorded: true,
             })
         }
     }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -15,6 +15,16 @@ pub struct MaterializationKey<R = Vec<u8>> {
     pub counter: u64,
 }
 
+impl<R: AsRef<[u8]>> MaterializationKey<R> {
+    pub fn as_borrowed(&self) -> MaterializationKey<&[u8]> {
+        MaterializationKey {
+            lamport: self.lamport,
+            replica: self.replica.as_ref(),
+            counter: self.counter,
+        }
+    }
+}
+
 pub type MaterializationFrontier = MaterializationKey<Vec<u8>>;
 pub type MaterializationFrontierRef<'a> = MaterializationKey<&'a [u8]>;
 
@@ -22,6 +32,15 @@ pub type MaterializationFrontierRef<'a> = MaterializationKey<&'a [u8]>;
 pub struct MaterializationHead<R = Vec<u8>> {
     pub at: MaterializationKey<R>,
     pub seq: u64,
+}
+
+impl<R: AsRef<[u8]>> MaterializationHead<R> {
+    pub fn as_borrowed(&self) -> MaterializationHead<&[u8]> {
+        MaterializationHead {
+            at: self.at.as_borrowed(),
+            seq: self.seq,
+        }
+    }
 }
 
 pub type MaterializationHeadRef<'a> = MaterializationHead<&'a [u8]>;
@@ -37,6 +56,15 @@ pub type MaterializationStateRef<'a> = MaterializationState<&'a [u8]>;
 impl<R> MaterializationState<R> {
     pub fn head_seq(&self) -> u64 {
         self.head.as_ref().map_or(0, |head| head.seq)
+    }
+}
+
+impl<R: AsRef<[u8]>> MaterializationState<R> {
+    pub fn as_borrowed(&self) -> MaterializationState<&[u8]> {
+        MaterializationState {
+            head: self.head.as_ref().map(MaterializationHead::as_borrowed),
+            replay_from: self.replay_from.as_ref().map(MaterializationKey::as_borrowed),
+        }
     }
 }
 

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -1,15 +1,40 @@
+use std::cmp::Ordering;
+
 use crate::ops::{cmp_op_key, cmp_ops, Operation};
-use crate::traits::{Clock, NodeStore, NoopStorage, ParentOpIndex, PayloadStore, Storage};
+use crate::traits::{
+    Clock, LamportClock, MemoryNodeStore, MemoryPayloadStore, NodeStore, NoopStorage,
+    ParentOpIndex, PayloadStore, Storage,
+};
 use crate::tree::TreeCrdt;
-use crate::{Error, Lamport, NodeId, ReplicaId, Result};
+use crate::{Error, Lamport, NodeId, OperationId, ReplicaId, Result};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaterializationFrontier {
+    pub lamport: Lamport,
+    pub replica: Vec<u8>,
+    pub counter: u64,
+}
 
 /// Snapshot of adapter-maintained materialization metadata.
 pub trait MaterializationCursor {
+    /// Exceptional recovery/corruption fallback.
+    ///
+    /// This no longer means the normal out-of-order remote path; adapters should reserve it for
+    /// states that require a full rebuild from the beginning.
     fn dirty(&self) -> bool;
     fn head_lamport(&self) -> Lamport;
     fn head_replica(&self) -> &[u8];
     fn head_counter(&self) -> u64;
     fn head_seq(&self) -> u64;
+    fn replay_lamport(&self) -> Option<Lamport> {
+        None
+    }
+    fn replay_replica(&self) -> Option<&[u8]> {
+        None
+    }
+    fn replay_counter(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -33,9 +58,10 @@ pub struct PersistedRemoteApplyResult {
     /// Nodes changed by core materialization when incremental replay succeeded.
     ///
     /// This is empty when nothing was inserted or when the helper had to fall back to marking the
-    /// document dirty instead of trusting incremental materialization.
+    /// document for replay/recovery instead of trusting incremental materialization.
     pub affected_nodes: Vec<NodeId>,
-    /// True when adapters should rely on rebuild-on-read instead of the incremental replay result.
+    /// True when adapters should rely on the exceptional recovery path instead of the replay
+    /// frontier / incremental materialization result.
     pub dirty_fallback: bool,
 }
 
@@ -50,6 +76,111 @@ pub struct PersistedRemoteStores<C, N, P, I> {
     pub nodes: N,
     pub payloads: P,
     pub index: I,
+}
+
+#[derive(Default)]
+struct RecordingIndex {
+    records: Vec<(NodeId, OperationId, u64)>,
+}
+
+impl ParentOpIndex for RecordingIndex {
+    fn reset(&mut self) -> Result<()> {
+        self.records.clear();
+        Ok(())
+    }
+
+    fn record(&mut self, parent: NodeId, op_id: &OperationId, seq: u64) -> Result<()> {
+        self.records.push((parent, op_id.clone(), seq));
+        Ok(())
+    }
+}
+
+struct PrefixSnapshot {
+    crdt: TreeCrdt<NoopStorage, LamportClock, MemoryNodeStore, MemoryPayloadStore>,
+    index: RecordingIndex,
+    head: Option<Operation>,
+    seq: u64,
+}
+
+fn frontier_from_op(op: &Operation) -> MaterializationFrontier {
+    MaterializationFrontier {
+        lamport: op.meta.lamport,
+        replica: op.meta.id.replica.as_bytes().to_vec(),
+        counter: op.meta.id.counter,
+    }
+}
+
+fn cmp_frontiers(a: &MaterializationFrontier, b: &MaterializationFrontier) -> Ordering {
+    cmp_op_key(
+        a.lamport,
+        a.replica.as_slice(),
+        a.counter,
+        b.lamport,
+        b.replica.as_slice(),
+        b.counter,
+    )
+}
+
+fn cursor_head<M: MaterializationCursor>(meta: &M) -> Option<MaterializationFrontier> {
+    if meta.head_seq() == 0
+        && meta.head_lamport() == 0
+        && meta.head_replica().is_empty()
+        && meta.head_counter() == 0
+    {
+        return None;
+    }
+
+    Some(MaterializationFrontier {
+        lamport: meta.head_lamport(),
+        replica: meta.head_replica().to_vec(),
+        counter: meta.head_counter(),
+    })
+}
+
+fn cursor_replay_frontier<M: MaterializationCursor>(meta: &M) -> Option<MaterializationFrontier> {
+    Some(MaterializationFrontier {
+        lamport: meta.replay_lamport()?,
+        replica: meta.replay_replica()?.to_vec(),
+        counter: meta.replay_counter()?,
+    })
+}
+
+fn earlier_frontier(
+    left: MaterializationFrontier,
+    right: MaterializationFrontier,
+) -> MaterializationFrontier {
+    if cmp_frontiers(&left, &right) == Ordering::Greater {
+        right
+    } else {
+        left
+    }
+}
+
+fn start_replay_frontier() -> MaterializationFrontier {
+    MaterializationFrontier {
+        lamport: 0,
+        replica: Vec::new(),
+        counter: 0,
+    }
+}
+
+fn next_replay_frontier<M: MaterializationCursor>(
+    meta: &M,
+    inserted_ops: &[Operation],
+) -> Option<MaterializationFrontier> {
+    let earliest_inserted = inserted_ops.iter().map(frontier_from_op).min_by(cmp_frontiers)?;
+    let existing = cursor_replay_frontier(meta);
+
+    if let Some(existing) = existing {
+        return Some(earlier_frontier(existing, earliest_inserted));
+    }
+
+    let head = cursor_head(meta)?;
+    if cmp_frontiers(&earliest_inserted, &head) == Ordering::Less {
+        Some(earliest_inserted)
+    } else {
+        None
+    }
 }
 
 /// Apply an incremental batch and return both head metadata and full affected-node delta.
@@ -77,6 +208,11 @@ where
     }
     if meta.dirty() {
         return Err(Error::Storage("materialize called while dirty".into()));
+    }
+    if cursor_replay_frontier(meta).is_some() {
+        return Err(Error::Storage(
+            "materialize called while replay frontier pending".into(),
+        ));
     }
 
     ops.sort_by(cmp_ops);
@@ -171,16 +307,186 @@ where
     Ok(result)
 }
 
+fn build_prefix_snapshot<S: Storage>(
+    storage: &S,
+    frontier: &MaterializationFrontier,
+    replica_id: &ReplicaId,
+) -> Result<PrefixSnapshot> {
+    let mut crdt = TreeCrdt::with_stores(
+        replica_id.clone(),
+        NoopStorage,
+        LamportClock::default(),
+        MemoryNodeStore::default(),
+        MemoryPayloadStore::default(),
+    )?;
+    let mut index = RecordingIndex::default();
+    let mut seq = 0u64;
+    let mut head: Option<Operation> = None;
+
+    storage.scan_since(0, &mut |op| {
+        if cmp_frontiers(&frontier_from_op(&op), frontier) != Ordering::Less {
+            return Ok(());
+        }
+
+        match crdt.apply_remote_with_materialization_seq(op.clone(), &mut index, &mut seq)? {
+            Some(_) => {
+                head = Some(op);
+                Ok(())
+            }
+            None => Err(Error::Storage(
+                "prefix replay unexpectedly required nested rebuild".into(),
+            )),
+        }
+    })?;
+
+    Ok(PrefixSnapshot {
+        crdt,
+        index,
+        head,
+        seq,
+    })
+}
+
+fn restore_prefix_snapshot<N: NodeStore, P: PayloadStore, I: ParentOpIndex>(
+    prefix: &mut PrefixSnapshot,
+    nodes: &mut N,
+    payloads: &mut P,
+    index: &mut I,
+) -> Result<()> {
+    let mut all_nodes = prefix.crdt.node_store_mut().all_nodes()?;
+    all_nodes.sort();
+
+    for node in &all_nodes {
+        nodes.ensure_node(*node)?;
+    }
+
+    for node in &all_nodes {
+        if *node == NodeId::ROOT {
+            continue;
+        }
+        let parent = prefix.crdt.node_store_mut().parent(*node)?;
+        let order_key = prefix.crdt.node_store_mut().order_key(*node)?;
+        if let Some(parent) = parent {
+            nodes.attach(*node, parent, order_key.unwrap_or_default())?;
+        } else {
+            nodes.detach(*node)?;
+        }
+    }
+
+    for node in &all_nodes {
+        nodes.set_tombstone(*node, prefix.crdt.node_store_mut().tombstone(*node)?)?;
+
+        let last_change = prefix.crdt.node_store_mut().last_change(*node)?;
+        if !last_change.is_empty() {
+            nodes.merge_last_change(*node, &last_change)?;
+        }
+
+        if let Some(deleted_at) = prefix.crdt.node_store_mut().deleted_at(*node)? {
+            nodes.merge_deleted_at(*node, &deleted_at)?;
+        }
+
+        if let Some(writer) = prefix.crdt.payload_last_writer(*node)? {
+            payloads.set_payload(*node, prefix.crdt.payload(*node)?, writer)?;
+        }
+    }
+
+    let mut records = prefix.index.records.clone();
+    records.sort_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.cmp(&b.0)).then_with(|| a.1.cmp(&b.1)));
+    for (parent, op_id, seq) in records {
+        index.record(parent, &op_id, seq)?;
+    }
+
+    Ok(())
+}
+
+/// Catch backend materialized state up to the persisted op log using the replay frontier when
+/// available, or a full rebuild when `meta.dirty()` is set.
+pub fn catch_up_materialized_state<S, C, N, P, I, M, FlushNodes, FlushIndex>(
+    storage: S,
+    stores: PersistedRemoteStores<C, N, P, I>,
+    meta: &M,
+    mut flush_nodes: FlushNodes,
+    mut flush_index: FlushIndex,
+) -> Result<Option<MaterializationHead>>
+where
+    S: Storage,
+    C: Clock,
+    N: NodeStore,
+    P: PayloadStore,
+    I: ParentOpIndex,
+    M: MaterializationCursor,
+    FlushNodes: FnMut(&mut N) -> Result<()>,
+    FlushIndex: FnMut(&mut I) -> Result<()>,
+{
+    let replay_frontier = if meta.dirty() {
+        None
+    } else {
+        cursor_replay_frontier(meta)
+    };
+
+    let PersistedRemoteStores {
+        replica_id,
+        clock,
+        mut nodes,
+        mut payloads,
+        mut index,
+    } = stores;
+
+    nodes.reset()?;
+    payloads.reset()?;
+    index.reset()?;
+
+    let mut head: Option<Operation> = None;
+    let mut seq = 0u64;
+
+    if let Some(frontier) = replay_frontier.as_ref() {
+        let mut prefix = build_prefix_snapshot(&storage, frontier, &replica_id)?;
+        restore_prefix_snapshot(&mut prefix, &mut nodes, &mut payloads, &mut index)?;
+        head = prefix.head;
+        seq = prefix.seq;
+    }
+
+    let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
+    storage.scan_since(0, &mut |op| {
+        if let Some(frontier) = replay_frontier.as_ref() {
+            if cmp_frontiers(&frontier_from_op(&op), frontier) == Ordering::Less {
+                return Ok(());
+            }
+        }
+
+        match crdt.apply_remote_with_materialization_seq(op.clone(), &mut index, &mut seq)? {
+            Some(_) => {
+                head = Some(op);
+                Ok(())
+            }
+            None => Err(Error::Storage(
+                "catch-up replay unexpectedly required nested rebuild".into(),
+            )),
+        }
+    })?;
+
+    flush_nodes(crdt.node_store_mut())?;
+    flush_index(&mut index)?;
+
+    Ok(head.map(|head| MaterializationHead {
+        lamport: head.meta.lamport,
+        replica: head.meta.id.replica.as_bytes().to_vec(),
+        counter: head.meta.id.counter,
+        seq,
+    }))
+}
+
 /// Apply already-persisted inserted remote ops and commit adapter-owned metadata writes.
 ///
 /// Adapters own persistence + dedupe and pass only the inserted subset here. If the materialized
-/// doc is already dirty, or if incremental materialization / head update fails, this marks the
-/// document dirty so rebuild-on-read can replay the full log later.
+/// doc is already in exceptional recovery, or if incremental materialization / metadata updates
+/// fail, this marks the document dirty so rebuild-on-read can replay the full log later.
 pub fn apply_persisted_remote_ops_with_delta<M, E>(
     meta: &M,
     inserted_ops: Vec<Operation>,
     materialize_inserted: impl FnOnce(Vec<Operation>) -> std::result::Result<IncrementalApplyResult, E>,
     update_head: impl FnOnce(&MaterializationHead) -> std::result::Result<(), E>,
+    mut schedule_replay: impl FnMut(&MaterializationFrontier) -> std::result::Result<(), E>,
     mut mark_dirty: impl FnMut() -> std::result::Result<(), E>,
 ) -> PersistedRemoteApplyResult
 where
@@ -197,6 +503,30 @@ where
     }
 
     if meta.dirty() {
+        if schedule_replay(&start_replay_frontier()).is_ok() {
+            return PersistedRemoteApplyResult {
+                inserted_count,
+                affected_nodes: Vec::new(),
+                dirty_fallback: false,
+            };
+        }
+        let _ = mark_dirty();
+        return PersistedRemoteApplyResult {
+            inserted_count,
+            affected_nodes: Vec::new(),
+            dirty_fallback: true,
+        };
+    }
+
+    if let Some(frontier) = next_replay_frontier(meta, &inserted_ops) {
+        if schedule_replay(&frontier).is_ok() {
+            return PersistedRemoteApplyResult {
+                inserted_count,
+                affected_nodes: Vec::new(),
+                dirty_fallback: false,
+            };
+        }
+
         let _ = mark_dirty();
         return PersistedRemoteApplyResult {
             inserted_count,
@@ -208,6 +538,13 @@ where
     match materialize_inserted(inserted_ops) {
         Ok(result) => {
             let Some(head) = result.head else {
+                if schedule_replay(&start_replay_frontier()).is_ok() {
+                    return PersistedRemoteApplyResult {
+                        inserted_count,
+                        affected_nodes: Vec::new(),
+                        dirty_fallback: false,
+                    };
+                }
                 let _ = mark_dirty();
                 return PersistedRemoteApplyResult {
                     inserted_count,
@@ -223,6 +560,13 @@ where
                     dirty_fallback: false,
                 }
             } else {
+                if schedule_replay(&start_replay_frontier()).is_ok() {
+                    return PersistedRemoteApplyResult {
+                        inserted_count,
+                        affected_nodes: Vec::new(),
+                        dirty_fallback: false,
+                    };
+                }
                 let _ = mark_dirty();
                 PersistedRemoteApplyResult {
                     inserted_count,
@@ -232,6 +576,13 @@ where
             }
         }
         Err(_) => {
+            if schedule_replay(&start_replay_frontier()).is_ok() {
+                return PersistedRemoteApplyResult {
+                    inserted_count,
+                    affected_nodes: Vec::new(),
+                    dirty_fallback: false,
+                };
+            }
             let _ = mark_dirty();
             PersistedRemoteApplyResult {
                 inserted_count,

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -9,35 +9,40 @@ use crate::tree::TreeCrdt;
 use crate::{Error, Lamport, NodeId, OperationId, ReplicaId, Result};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MaterializationFrontier {
+pub struct MaterializationKey<R = Vec<u8>> {
     pub lamport: Lamport,
-    pub replica: Vec<u8>,
+    pub replica: R,
     pub counter: u64,
+}
+
+pub type MaterializationFrontier = MaterializationKey<Vec<u8>>;
+pub type MaterializationFrontierRef<'a> = MaterializationKey<&'a [u8]>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaterializationHead<R = Vec<u8>> {
+    pub at: MaterializationKey<R>,
+    pub seq: u64,
+}
+
+pub type MaterializationHeadRef<'a> = MaterializationHead<&'a [u8]>;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MaterializationState<R = Vec<u8>> {
+    pub head: Option<MaterializationHead<R>>,
+    pub replay_from: Option<MaterializationKey<R>>,
+}
+
+pub type MaterializationStateRef<'a> = MaterializationState<&'a [u8]>;
+
+impl<R> MaterializationState<R> {
+    pub fn head_seq(&self) -> u64 {
+        self.head.as_ref().map_or(0, |head| head.seq)
+    }
 }
 
 /// Snapshot of adapter-maintained materialization metadata.
 pub trait MaterializationCursor {
-    fn head_lamport(&self) -> Lamport;
-    fn head_replica(&self) -> &[u8];
-    fn head_counter(&self) -> u64;
-    fn head_seq(&self) -> u64;
-    fn replay_lamport(&self) -> Option<Lamport> {
-        None
-    }
-    fn replay_replica(&self) -> Option<&[u8]> {
-        None
-    }
-    fn replay_counter(&self) -> Option<u64> {
-        None
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct MaterializationHead {
-    pub lamport: Lamport,
-    pub replica: Vec<u8>,
-    pub counter: u64,
-    pub seq: u64,
+    fn state(&self) -> MaterializationStateRef<'_>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -105,39 +110,26 @@ fn frontier_from_op(op: &Operation) -> MaterializationFrontier {
     }
 }
 
-fn cmp_frontiers(a: &MaterializationFrontier, b: &MaterializationFrontier) -> Ordering {
+fn owned_frontier<R: AsRef<[u8]>>(frontier: &MaterializationKey<R>) -> MaterializationFrontier {
+    MaterializationFrontier {
+        lamport: frontier.lamport,
+        replica: frontier.replica.as_ref().to_vec(),
+        counter: frontier.counter,
+    }
+}
+
+fn cmp_frontiers<R1: AsRef<[u8]>, R2: AsRef<[u8]>>(
+    a: &MaterializationKey<R1>,
+    b: &MaterializationKey<R2>,
+) -> Ordering {
     cmp_op_key(
         a.lamport,
-        a.replica.as_slice(),
+        a.replica.as_ref(),
         a.counter,
         b.lamport,
-        b.replica.as_slice(),
+        b.replica.as_ref(),
         b.counter,
     )
-}
-
-fn cursor_head<M: MaterializationCursor>(meta: &M) -> Option<MaterializationFrontier> {
-    if meta.head_seq() == 0
-        && meta.head_lamport() == 0
-        && meta.head_replica().is_empty()
-        && meta.head_counter() == 0
-    {
-        return None;
-    }
-
-    Some(MaterializationFrontier {
-        lamport: meta.head_lamport(),
-        replica: meta.head_replica().to_vec(),
-        counter: meta.head_counter(),
-    })
-}
-
-fn cursor_replay_frontier<M: MaterializationCursor>(meta: &M) -> Option<MaterializationFrontier> {
-    Some(MaterializationFrontier {
-        lamport: meta.replay_lamport()?,
-        replica: meta.replay_replica()?.to_vec(),
-        counter: meta.replay_counter()?,
-    })
 }
 
 fn earlier_frontier(
@@ -164,14 +156,17 @@ fn next_replay_frontier<M: MaterializationCursor>(
     inserted_ops: &[Operation],
 ) -> Option<MaterializationFrontier> {
     let earliest_inserted = inserted_ops.iter().map(frontier_from_op).min_by(cmp_frontiers)?;
-    let existing = cursor_replay_frontier(meta);
+    let state = meta.state();
 
-    if let Some(existing) = existing {
-        return Some(earlier_frontier(existing, earliest_inserted));
+    if let Some(existing) = state.replay_from.as_ref() {
+        return Some(earlier_frontier(
+            owned_frontier(existing),
+            earliest_inserted,
+        ));
     }
 
-    let head = cursor_head(meta)?;
-    if cmp_frontiers(&earliest_inserted, &head) == Ordering::Less {
+    let head = state.head.as_ref()?;
+    if cmp_frontiers(&earliest_inserted, &head.at) == Ordering::Less {
         Some(earliest_inserted)
     } else {
         None
@@ -195,13 +190,15 @@ where
     I: ParentOpIndex,
     M: MaterializationCursor,
 {
+    let state = meta.state();
+
     if ops.is_empty() {
         return Ok(IncrementalApplyResult {
             head: None,
             affected_nodes: Vec::new(),
         });
     }
-    if cursor_replay_frontier(meta).is_some() {
+    if state.replay_from.is_some() {
         return Err(Error::Storage(
             "materialize called while replay frontier pending".into(),
         ));
@@ -210,22 +207,24 @@ where
     ops.sort_by(cmp_ops);
 
     if let Some(first) = ops.first() {
-        if cmp_op_key(
-            first.meta.lamport,
-            first.meta.id.replica.as_bytes(),
-            first.meta.id.counter,
-            meta.head_lamport(),
-            meta.head_replica(),
-            meta.head_counter(),
-        ) == std::cmp::Ordering::Less
-        {
-            return Err(Error::Storage(
-                "out-of-order op before materialized head".into(),
-            ));
+        if let Some(head) = state.head.as_ref() {
+            if cmp_op_key(
+                first.meta.lamport,
+                first.meta.id.replica.as_bytes(),
+                first.meta.id.counter,
+                head.at.lamport,
+                head.at.replica,
+                head.at.counter,
+            ) == std::cmp::Ordering::Less
+            {
+                return Err(Error::Storage(
+                    "out-of-order op before materialized head".into(),
+                ));
+            }
         }
     }
 
-    let mut seq = meta.head_seq();
+    let mut seq = state.head_seq();
     let mut affected = std::collections::HashSet::new();
     for op in ops {
         if let Some(delta) = crdt.apply_remote_with_materialization_seq(op, index, &mut seq)? {
@@ -242,9 +241,11 @@ where
 
     Ok(IncrementalApplyResult {
         head: Some(MaterializationHead {
-            lamport: last.meta.lamport,
-            replica: last.meta.id.replica.as_bytes().to_vec(),
-            counter: last.meta.id.counter,
+            at: MaterializationKey {
+                lamport: last.meta.lamport,
+                replica: last.meta.id.replica.as_bytes().to_vec(),
+                counter: last.meta.id.counter,
+            },
             seq,
         }),
         affected_nodes,
@@ -410,7 +411,10 @@ where
     FlushNodes: FnMut(&mut N) -> Result<()>,
     FlushIndex: FnMut(&mut I) -> Result<()>,
 {
-    let replay_frontier = cursor_replay_frontier(meta);
+    let replay_frontier = {
+        let state = meta.state();
+        state.replay_from.as_ref().map(owned_frontier)
+    };
 
     let PersistedRemoteStores {
         replica_id,
@@ -457,9 +461,11 @@ where
     flush_index(&mut index)?;
 
     Ok(head.map(|head| MaterializationHead {
-        lamport: head.meta.lamport,
-        replica: head.meta.id.replica.as_bytes().to_vec(),
-        counter: head.meta.id.counter,
+        at: MaterializationKey {
+            lamport: head.meta.lamport,
+            replica: head.meta.id.replica.as_bytes().to_vec(),
+            counter: head.meta.id.counter,
+        },
         seq,
     }))
 }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -17,11 +17,6 @@ pub struct MaterializationFrontier {
 
 /// Snapshot of adapter-maintained materialization metadata.
 pub trait MaterializationCursor {
-    /// Exceptional recovery/corruption fallback.
-    ///
-    /// This no longer means the normal out-of-order remote path; adapters should reserve it for
-    /// states that require a full rebuild from the beginning.
-    fn dirty(&self) -> bool;
     fn head_lamport(&self) -> Lamport;
     fn head_replica(&self) -> &[u8];
     fn head_counter(&self) -> u64;
@@ -57,12 +52,12 @@ pub struct PersistedRemoteApplyResult {
     pub inserted_count: u64,
     /// Nodes changed by core materialization when incremental replay succeeded.
     ///
-    /// This is empty when nothing was inserted or when the helper had to fall back to marking the
-    /// document for replay/recovery instead of trusting incremental materialization.
+    /// This is empty when nothing was inserted or when the helper had to defer catch-up by
+    /// recording a replay frontier instead of trusting incremental materialization.
     pub affected_nodes: Vec<NodeId>,
-    /// True when adapters should rely on the exceptional recovery path instead of the replay
-    /// frontier / incremental materialization result.
-    pub dirty_fallback: bool,
+    /// True when the helper recorded a replay frontier instead of advancing materialization head
+    /// immediately.
+    pub replay_deferred: bool,
 }
 
 /// Backend-owned stores used to replay already-persisted remote ops through core semantics.
@@ -205,9 +200,6 @@ where
             head: None,
             affected_nodes: Vec::new(),
         });
-    }
-    if meta.dirty() {
-        return Err(Error::Storage("materialize called while dirty".into()));
     }
     if cursor_replay_frontier(meta).is_some() {
         return Err(Error::Storage(
@@ -400,7 +392,7 @@ fn restore_prefix_snapshot<N: NodeStore, P: PayloadStore, I: ParentOpIndex>(
 }
 
 /// Catch backend materialized state up to the persisted op log using the replay frontier when
-/// available, or a full rebuild when `meta.dirty()` is set.
+/// available.
 pub fn catch_up_materialized_state<S, C, N, P, I, M, FlushNodes, FlushIndex>(
     storage: S,
     stores: PersistedRemoteStores<C, N, P, I>,
@@ -418,11 +410,7 @@ where
     FlushNodes: FnMut(&mut N) -> Result<()>,
     FlushIndex: FnMut(&mut I) -> Result<()>,
 {
-    let replay_frontier = if meta.dirty() {
-        None
-    } else {
-        cursor_replay_frontier(meta)
-    };
+    let replay_frontier = cursor_replay_frontier(meta);
 
     let PersistedRemoteStores {
         replica_id,
@@ -479,116 +467,70 @@ where
 /// Apply already-persisted inserted remote ops and commit adapter-owned metadata writes.
 ///
 /// Adapters own persistence + dedupe and pass only the inserted subset here. If the materialized
-/// doc is already in exceptional recovery, or if incremental materialization / metadata updates
-/// fail, this marks the document dirty so rebuild-on-read can replay the full log later.
+/// doc is already behind a replay frontier, or if incremental materialization / metadata updates
+/// fail, this records a replay frontier so catch-up can repair materialized state later.
 pub fn apply_persisted_remote_ops_with_delta<M, E>(
     meta: &M,
     inserted_ops: Vec<Operation>,
     materialize_inserted: impl FnOnce(Vec<Operation>) -> std::result::Result<IncrementalApplyResult, E>,
     update_head: impl FnOnce(&MaterializationHead) -> std::result::Result<(), E>,
     mut schedule_replay: impl FnMut(&MaterializationFrontier) -> std::result::Result<(), E>,
-    mut mark_dirty: impl FnMut() -> std::result::Result<(), E>,
-) -> PersistedRemoteApplyResult
+) -> std::result::Result<PersistedRemoteApplyResult, E>
 where
     M: MaterializationCursor,
 {
     let inserted_count = inserted_ops.len().min(u64::MAX as usize) as u64;
 
     if inserted_count == 0 {
-        return PersistedRemoteApplyResult {
+        return Ok(PersistedRemoteApplyResult {
             inserted_count: 0,
             affected_nodes: Vec::new(),
-            dirty_fallback: false,
-        };
-    }
-
-    if meta.dirty() {
-        if schedule_replay(&start_replay_frontier()).is_ok() {
-            return PersistedRemoteApplyResult {
-                inserted_count,
-                affected_nodes: Vec::new(),
-                dirty_fallback: false,
-            };
-        }
-        let _ = mark_dirty();
-        return PersistedRemoteApplyResult {
-            inserted_count,
-            affected_nodes: Vec::new(),
-            dirty_fallback: true,
-        };
+            replay_deferred: false,
+        });
     }
 
     if let Some(frontier) = next_replay_frontier(meta, &inserted_ops) {
-        if schedule_replay(&frontier).is_ok() {
-            return PersistedRemoteApplyResult {
-                inserted_count,
-                affected_nodes: Vec::new(),
-                dirty_fallback: false,
-            };
-        }
-
-        let _ = mark_dirty();
-        return PersistedRemoteApplyResult {
+        schedule_replay(&frontier)?;
+        return Ok(PersistedRemoteApplyResult {
             inserted_count,
             affected_nodes: Vec::new(),
-            dirty_fallback: true,
-        };
+            replay_deferred: true,
+        });
     }
 
     match materialize_inserted(inserted_ops) {
         Ok(result) => {
             let Some(head) = result.head else {
-                if schedule_replay(&start_replay_frontier()).is_ok() {
-                    return PersistedRemoteApplyResult {
-                        inserted_count,
-                        affected_nodes: Vec::new(),
-                        dirty_fallback: false,
-                    };
-                }
-                let _ = mark_dirty();
-                return PersistedRemoteApplyResult {
+                schedule_replay(&start_replay_frontier())?;
+                return Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: Vec::new(),
-                    dirty_fallback: true,
-                };
+                    replay_deferred: true,
+                });
             };
 
             if update_head(&head).is_ok() {
-                PersistedRemoteApplyResult {
+                Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: result.affected_nodes,
-                    dirty_fallback: false,
-                }
+                    replay_deferred: false,
+                })
             } else {
-                if schedule_replay(&start_replay_frontier()).is_ok() {
-                    return PersistedRemoteApplyResult {
-                        inserted_count,
-                        affected_nodes: Vec::new(),
-                        dirty_fallback: false,
-                    };
-                }
-                let _ = mark_dirty();
-                PersistedRemoteApplyResult {
+                schedule_replay(&start_replay_frontier())?;
+                Ok(PersistedRemoteApplyResult {
                     inserted_count,
                     affected_nodes: Vec::new(),
-                    dirty_fallback: true,
-                }
+                    replay_deferred: true,
+                })
             }
         }
         Err(_) => {
-            if schedule_replay(&start_replay_frontier()).is_ok() {
-                return PersistedRemoteApplyResult {
-                    inserted_count,
-                    affected_nodes: Vec::new(),
-                    dirty_fallback: false,
-                };
-            }
-            let _ = mark_dirty();
-            PersistedRemoteApplyResult {
+            schedule_replay(&start_replay_frontier())?;
+            Ok(PersistedRemoteApplyResult {
                 inserted_count,
                 affected_nodes: Vec::new(),
-                dirty_fallback: true,
-            }
+                replay_deferred: true,
+            })
         }
     }
 }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -487,7 +487,7 @@ where
             }));
         }
 
-        // Out-of-order operation: rebuild derived state from storage.
+        // Out-of-order operation: catch derived state up from storage.
         self.replay_from_storage()?;
         Ok(None)
     }

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -183,7 +183,6 @@ fn apply_incremental_ops_with_delta_rejects_pending_replay_frontier() {
         replay_lamport: Some(4),
         replay_replica: Some(b"r".to_vec()),
         replay_counter: Some(2),
-        ..Cursor::default()
     };
     let op = Operation::insert(
         &ReplicaId::new(b"r"),
@@ -400,7 +399,6 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
         replay_lamport: Some(2),
         replay_replica: Some(b"r".to_vec()),
         replay_counter: Some(2),
-        ..Cursor::default()
     };
     let replica = ReplicaId::new(b"r");
     let later = Operation::insert(&replica, 4, 4, NodeId::ROOT, NodeId(4), vec![0x40]);

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -18,6 +18,9 @@ struct Cursor {
     head_replica: Vec<u8>,
     head_counter: u64,
     head_seq: u64,
+    replay_lamport: Option<u64>,
+    replay_replica: Option<Vec<u8>>,
+    replay_counter: Option<u64>,
 }
 
 impl MaterializationCursor for Cursor {
@@ -39,6 +42,18 @@ impl MaterializationCursor for Cursor {
 
     fn head_seq(&self) -> u64 {
         self.head_seq
+    }
+
+    fn replay_lamport(&self) -> Option<u64> {
+        self.replay_lamport
+    }
+
+    fn replay_replica(&self) -> Option<&[u8]> {
+        self.replay_replica.as_deref()
+    }
+
+    fn replay_counter(&self) -> Option<u64> {
+        self.replay_counter
     }
 }
 
@@ -141,12 +156,45 @@ fn apply_incremental_ops_with_delta_rejects_before_materialized_head() {
         head_replica: b"r".to_vec(),
         head_counter: 3,
         head_seq: 12,
+        ..Cursor::default()
     };
 
     let op = Operation::insert(
         &ReplicaId::new(b"r"),
         2,
         4,
+        NodeId::ROOT,
+        NodeId(9),
+        vec![0x10],
+    );
+
+    let res = apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![op]);
+    assert!(res.is_err());
+}
+
+#[test]
+fn apply_incremental_ops_with_delta_rejects_pending_replay_frontier() {
+    let mut crdt = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut index = RecordingIndex::default();
+    let cursor = Cursor {
+        head_lamport: 5,
+        head_replica: b"r".to_vec(),
+        head_counter: 3,
+        head_seq: 12,
+        replay_lamport: Some(4),
+        replay_replica: Some(b"r".to_vec()),
+        replay_counter: Some(2),
+        ..Cursor::default()
+    };
+    let op = Operation::insert(
+        &ReplicaId::new(b"r"),
+        4,
+        6,
         NodeId::ROOT,
         NodeId(9),
         vec![0x10],
@@ -214,6 +262,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
             updated_head = Some(head.clone());
             Ok::<_, ()>(())
         },
+        |_| Ok::<_, ()>(()),
         || Ok::<_, ()>(()),
     );
 
@@ -233,7 +282,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
 }
 
 #[test]
-fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
+fn apply_persisted_remote_ops_turns_legacy_dirty_into_replay_from_start() {
     let cursor = Cursor {
         dirty: true,
         ..Cursor::default()
@@ -241,6 +290,7 @@ fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let mut runs = 0u64;
+    let mut scheduled_replay = 0u64;
     let mut marked_dirty = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
@@ -254,6 +304,10 @@ fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
             })
         },
         |_| Ok::<_, ()>(()),
+        |_| {
+            scheduled_replay += 1;
+            Ok::<_, ()>(())
+        },
         || {
             marked_dirty += 1;
             Ok::<_, ()>(())
@@ -261,17 +315,19 @@ fn apply_persisted_remote_ops_short_circuits_to_dirty_when_cursor_dirty() {
     );
 
     assert_eq!(runs, 0);
-    assert_eq!(marked_dirty, 1);
+    assert_eq!(scheduled_replay, 1);
+    assert_eq!(marked_dirty, 0);
     assert_eq!(result.inserted_count, 1);
     assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
-    assert!(result.dirty_fallback);
+    assert!(!result.dirty_fallback);
 }
 
 #[test]
-fn apply_persisted_remote_ops_clears_affected_nodes_when_update_head_fails() {
+fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let mut scheduled_replay = 0u64;
     let mut marked_dirty = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
@@ -289,16 +345,109 @@ fn apply_persisted_remote_ops_clears_affected_nodes_when_update_head_fails() {
             })
         },
         |_| Err::<(), ()>(()),
+        |_| {
+            scheduled_replay += 1;
+            Ok::<(), ()>(())
+        },
         || {
             marked_dirty += 1;
             Ok::<(), ()>(())
         },
     );
 
-    assert_eq!(marked_dirty, 1);
+    assert_eq!(scheduled_replay, 1);
+    assert_eq!(marked_dirty, 0);
     assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
-    assert!(result.dirty_fallback);
+    assert!(!result.dirty_fallback);
+}
+
+#[test]
+fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
+    let cursor = Cursor {
+        head_lamport: 5,
+        head_replica: b"r".to_vec(),
+        head_counter: 5,
+        head_seq: 5,
+        ..Cursor::default()
+    };
+    let replica = ReplicaId::new(b"r");
+    let out_of_order = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
+    let later = Operation::insert(&replica, 6, 6, NodeId::ROOT, NodeId(6), vec![0x60]);
+    let mut materialize_runs = 0u64;
+    let mut replay_frontier = None;
+
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![later, out_of_order.clone()],
+        |_| {
+            materialize_runs += 1;
+            Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
+                head: None,
+                affected_nodes: Vec::new(),
+            })
+        },
+        |_| Ok::<_, ()>(()),
+        |frontier| {
+            replay_frontier = Some(frontier.clone());
+            Ok::<_, ()>(())
+        },
+        || Ok::<_, ()>(()),
+    );
+
+    assert_eq!(materialize_runs, 0);
+    assert_eq!(result.inserted_count, 2);
+    assert!(result.affected_nodes.is_empty());
+    assert!(!result.dirty_fallback);
+    assert_eq!(
+        replay_frontier,
+        Some(treecrdt_core::MaterializationFrontier {
+            lamport: out_of_order.meta.lamport,
+            replica: out_of_order.meta.id.replica.as_bytes().to_vec(),
+            counter: out_of_order.meta.id.counter,
+        })
+    );
+}
+
+#[test]
+fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
+    let cursor = Cursor {
+        head_lamport: 5,
+        head_replica: b"r".to_vec(),
+        head_counter: 5,
+        head_seq: 5,
+        replay_lamport: Some(2),
+        replay_replica: Some(b"r".to_vec()),
+        replay_counter: Some(2),
+        ..Cursor::default()
+    };
+    let replica = ReplicaId::new(b"r");
+    let later = Operation::insert(&replica, 4, 4, NodeId::ROOT, NodeId(4), vec![0x40]);
+    let mut replay_frontier = None;
+
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![later],
+        |_| unreachable!("pending replay frontier should bypass incremental materialization"),
+        |_| Ok::<_, ()>(()),
+        |frontier| {
+            replay_frontier = Some(frontier.clone());
+            Ok::<_, ()>(())
+        },
+        || Ok::<_, ()>(()),
+    );
+
+    assert_eq!(result.inserted_count, 1);
+    assert!(result.affected_nodes.is_empty());
+    assert!(!result.dirty_fallback);
+    assert_eq!(
+        replay_frontier,
+        Some(treecrdt_core::MaterializationFrontier {
+            lamport: 2,
+            replica: b"r".to_vec(),
+            counter: 2,
+        })
+    );
 }
 
 #[test]

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -13,7 +13,6 @@ struct RecordingIndex {
 
 #[derive(Default)]
 struct Cursor {
-    dirty: bool,
     head_lamport: u64,
     head_replica: Vec<u8>,
     head_counter: u64,
@@ -24,10 +23,6 @@ struct Cursor {
 }
 
 impl MaterializationCursor for Cursor {
-    fn dirty(&self) -> bool {
-        self.dirty
-    }
-
     fn head_lamport(&self) -> u64 {
         self.head_lamport
     }
@@ -151,7 +146,6 @@ fn apply_incremental_ops_with_delta_rejects_before_materialized_head() {
     .unwrap();
     let mut index = RecordingIndex::default();
     let cursor = Cursor {
-        dirty: false,
         head_lamport: 5,
         head_replica: b"r".to_vec(),
         head_counter: 3,
@@ -263,13 +257,13 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
             Ok::<_, ()>(())
         },
         |_| Ok::<_, ()>(()),
-        || Ok::<_, ()>(()),
-    );
+    )
+    .unwrap();
 
     assert_eq!(seen_counters, vec![2, 3]);
     assert_eq!(result.inserted_count, 2);
     assert_eq!(result.affected_nodes, vec![NodeId(2)]);
-    assert!(!result.dirty_fallback);
+    assert!(!result.replay_deferred);
     assert_eq!(
         updated_head,
         Some(MaterializationHead {
@@ -282,16 +276,12 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
 }
 
 #[test]
-fn apply_persisted_remote_ops_turns_legacy_dirty_into_replay_from_start() {
-    let cursor = Cursor {
-        dirty: true,
-        ..Cursor::default()
-    };
+fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing() {
+    let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let mut runs = 0u64;
     let mut scheduled_replay = 0u64;
-    let mut marked_dirty = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
         &cursor,
@@ -308,18 +298,14 @@ fn apply_persisted_remote_ops_turns_legacy_dirty_into_replay_from_start() {
             scheduled_replay += 1;
             Ok::<_, ()>(())
         },
-        || {
-            marked_dirty += 1;
-            Ok::<_, ()>(())
-        },
-    );
+    )
+    .unwrap();
 
-    assert_eq!(runs, 0);
+    assert_eq!(runs, 1);
     assert_eq!(scheduled_replay, 1);
-    assert_eq!(marked_dirty, 0);
     assert_eq!(result.inserted_count, 1);
     assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
-    assert!(!result.dirty_fallback);
+    assert!(result.replay_deferred);
 }
 
 #[test]
@@ -328,7 +314,6 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
     let mut scheduled_replay = 0u64;
-    let mut marked_dirty = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
         &cursor,
@@ -349,17 +334,13 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
             scheduled_replay += 1;
             Ok::<(), ()>(())
         },
-        || {
-            marked_dirty += 1;
-            Ok::<(), ()>(())
-        },
-    );
+    )
+    .unwrap();
 
     assert_eq!(scheduled_replay, 1);
-    assert_eq!(marked_dirty, 0);
     assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
-    assert!(!result.dirty_fallback);
+    assert!(result.replay_deferred);
 }
 
 #[test]
@@ -392,13 +373,13 @@ fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
             replay_frontier = Some(frontier.clone());
             Ok::<_, ()>(())
         },
-        || Ok::<_, ()>(()),
-    );
+    )
+    .unwrap();
 
     assert_eq!(materialize_runs, 0);
     assert_eq!(result.inserted_count, 2);
     assert!(result.affected_nodes.is_empty());
-    assert!(!result.dirty_fallback);
+    assert!(result.replay_deferred);
     assert_eq!(
         replay_frontier,
         Some(treecrdt_core::MaterializationFrontier {
@@ -434,12 +415,12 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
             replay_frontier = Some(frontier.clone());
             Ok::<_, ()>(())
         },
-        || Ok::<_, ()>(()),
-    );
+    )
+    .unwrap();
 
     assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
-    assert!(!result.dirty_fallback);
+    assert!(result.replay_deferred);
     assert_eq!(
         replay_frontier,
         Some(treecrdt_core::MaterializationFrontier {

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -1,9 +1,9 @@
 use treecrdt_core::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     materialize_persisted_remote_ops_with_delta, LamportClock, MaterializationCursor,
-    MaterializationHead, MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId,
-    NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PersistedRemoteStores, ReplicaId,
-    TreeCrdt,
+    MaterializationHead, MaterializationKey, MaterializationState, MemoryNodeStore,
+    MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation, OperationId,
+    ParentOpIndex, PersistedRemoteStores, ReplicaId, TreeCrdt,
 };
 
 #[derive(Default)]
@@ -23,32 +23,37 @@ struct Cursor {
 }
 
 impl MaterializationCursor for Cursor {
-    fn head_lamport(&self) -> u64 {
-        self.head_lamport
-    }
+    fn state(&self) -> MaterializationState<&[u8]> {
+        let head = if self.head_seq == 0
+            && self.head_lamport == 0
+            && self.head_replica.is_empty()
+            && self.head_counter == 0
+        {
+            None
+        } else {
+            Some(MaterializationHead {
+                at: MaterializationKey {
+                    lamport: self.head_lamport,
+                    replica: self.head_replica.as_slice(),
+                    counter: self.head_counter,
+                },
+                seq: self.head_seq,
+            })
+        };
+        let replay_from = match (
+            self.replay_lamport,
+            self.replay_replica.as_deref(),
+            self.replay_counter,
+        ) {
+            (Some(lamport), Some(replica), Some(counter)) => Some(MaterializationKey {
+                lamport,
+                replica,
+                counter,
+            }),
+            _ => None,
+        };
 
-    fn head_replica(&self) -> &[u8] {
-        &self.head_replica
-    }
-
-    fn head_counter(&self) -> u64 {
-        self.head_counter
-    }
-
-    fn head_seq(&self) -> u64 {
-        self.head_seq
-    }
-
-    fn replay_lamport(&self) -> Option<u64> {
-        self.replay_lamport
-    }
-
-    fn replay_replica(&self) -> Option<&[u8]> {
-        self.replay_replica.as_deref()
-    }
-
-    fn replay_counter(&self) -> Option<u64> {
-        self.replay_counter
+        MaterializationState { head, replay_from }
     }
 }
 
@@ -127,9 +132,9 @@ fn apply_incremental_ops_with_delta_sorts_and_returns_head() {
             .head
             .expect("expected materialization head");
 
-    assert_eq!(next.lamport, 2);
-    assert_eq!(next.replica, replica.as_bytes());
-    assert_eq!(next.counter, 2);
+    assert_eq!(next.at.lamport, 2);
+    assert_eq!(next.at.replica, replica.as_bytes());
+    assert_eq!(next.at.counter, 2);
     assert_eq!(next.seq, 2);
     assert_eq!(index.records.len(), 2);
     assert_eq!(index.records[0].2, 1);
@@ -223,7 +228,7 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
     .unwrap();
 
     let head = res.head.expect("expected materialization head");
-    assert_eq!(head.counter, 2);
+    assert_eq!(head.at.counter, 2);
     assert_eq!(res.affected_nodes, vec![NodeId::ROOT, parent, child],);
 }
 
@@ -243,9 +248,11 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
             seen_counters = ops.iter().map(|op| op.meta.id.counter).collect();
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
                 head: Some(MaterializationHead {
-                    lamport: op3.meta.lamport,
-                    replica: op3.meta.id.replica.as_bytes().to_vec(),
-                    counter: op3.meta.id.counter,
+                    at: MaterializationKey {
+                        lamport: op3.meta.lamport,
+                        replica: op3.meta.id.replica.as_bytes().to_vec(),
+                        counter: op3.meta.id.counter,
+                    },
                     seq: 2,
                 }),
                 affected_nodes: vec![NodeId(2)],
@@ -266,9 +273,11 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
     assert_eq!(
         updated_head,
         Some(MaterializationHead {
-            lamport: 3,
-            replica: replica.as_bytes().to_vec(),
-            counter: 3,
+            at: MaterializationKey {
+                lamport: 3,
+                replica: replica.as_bytes().to_vec(),
+                counter: 3,
+            },
             seq: 2,
         })
     );
@@ -320,9 +329,11 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
         |_| {
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
                 head: Some(MaterializationHead {
-                    lamport: 7,
-                    replica: b"r".to_vec(),
-                    counter: 4,
+                    at: MaterializationKey {
+                        lamport: 7,
+                        replica: b"r".to_vec(),
+                        counter: 4,
+                    },
                     seq: 9,
                 }),
                 affected_nodes: vec![NodeId(1), NodeId(2)],
@@ -469,7 +480,7 @@ fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
     assert_eq!(prepared, 2);
     assert_eq!(flushed_nodes, 1);
     assert_eq!(flushed_index, 1);
-    assert_eq!(head.counter, 2);
+    assert_eq!(head.at.counter, 2);
     assert_eq!(
         result.affected_nodes,
         vec![NodeId::ROOT, NodeId(10), NodeId(11)]

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -269,7 +269,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
     assert_eq!(seen_counters, vec![2, 3]);
     assert_eq!(result.inserted_count, 2);
     assert_eq!(result.affected_nodes, vec![NodeId(2)]);
-    assert!(!result.replay_deferred);
+    assert!(!result.frontier_recorded);
     assert_eq!(
         updated_head,
         Some(MaterializationHead {
@@ -313,7 +313,7 @@ fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing()
     assert_eq!(scheduled_replay, 1);
     assert_eq!(result.inserted_count, 1);
     assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
-    assert!(result.replay_deferred);
+    assert!(result.frontier_recorded);
 }
 
 #[test]
@@ -350,7 +350,7 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
     assert_eq!(scheduled_replay, 1);
     assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
-    assert!(result.replay_deferred);
+    assert!(result.frontier_recorded);
 }
 
 #[test]
@@ -389,7 +389,7 @@ fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
     assert_eq!(materialize_runs, 0);
     assert_eq!(result.inserted_count, 2);
     assert!(result.affected_nodes.is_empty());
-    assert!(result.replay_deferred);
+    assert!(result.frontier_recorded);
     assert_eq!(
         replay_frontier,
         Some(treecrdt_core::MaterializationFrontier {
@@ -429,7 +429,7 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
 
     assert_eq!(result.inserted_count, 1);
     assert!(result.affected_nodes.is_empty());
-    assert!(result.replay_deferred);
+    assert!(result.frontier_recorded);
     assert_eq!(
         replay_frontier,
         Some(treecrdt_core::MaterializationFrontier {

--- a/packages/treecrdt-core/tests/out_of_order.rs
+++ b/packages/treecrdt-core/tests/out_of_order.rs
@@ -51,7 +51,7 @@ fn move_applied_after_insert_when_delivered_out_of_order() {
 }
 
 #[test]
-fn replay_rebuilds_state_and_advanced_clock() {
+fn replay_from_storage_catches_up_state_and_advanced_clock() {
     let mut storage = MemoryStorage::default();
     let replica = ReplicaId::new(b"r1");
     let parent = NodeId(10);

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -9,9 +9,9 @@ use treecrdt_core::{
 };
 
 use crate::store::{
-    ensure_materialized_in_tx, load_tree_meta_for_update, set_tree_meta_dirty,
-    set_tree_meta_replay_frontier, update_tree_meta_head, PgCtx, PgNodeStore, PgOpStorage,
-    PgParentOpIndex, PgPayloadStore, TreeMeta,
+    ensure_materialized_in_tx, load_tree_meta_for_update, set_tree_meta_replay_frontier,
+    update_tree_meta_head, PgCtx, PgNodeStore, PgOpStorage, PgParentOpIndex, PgPayloadStore,
+    TreeMeta,
 };
 
 type LocalCrdt = TreeCrdt<PgOpStorage, LamportClock, PgNodeStore, PgPayloadStore>;
@@ -75,7 +75,11 @@ fn begin_local_core_op(
     })
 }
 
-fn finish_local_core_op(session: &mut LocalOpSession, op: &Operation, plan: LocalFinalizePlan) {
+fn finish_local_core_op(
+    session: &mut LocalOpSession,
+    op: &Operation,
+    plan: LocalFinalizePlan,
+) -> Result<()> {
     let mut post_materialization_ok = true;
     let mut seq = 0u64;
 
@@ -110,7 +114,7 @@ fn finish_local_core_op(session: &mut LocalOpSession, op: &Operation, plan: Loca
     }
 
     if !post_materialization_ok {
-        let _ = set_tree_meta_replay_frontier(
+        set_tree_meta_replay_frontier(
             &session.ctx.client,
             &session.ctx.doc_id,
             &treecrdt_core::MaterializationFrontier {
@@ -118,9 +122,10 @@ fn finish_local_core_op(session: &mut LocalOpSession, op: &Operation, plan: Loca
                 replica: Vec::new(),
                 counter: 0,
             },
-        )
-        .or_else(|_| set_tree_meta_dirty(&session.ctx.client, &session.ctx.doc_id, true));
+        )?;
     }
+
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -138,7 +143,7 @@ pub fn local_insert(
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let placement = LocalPlacement::from_parts(placement, after)?;
         let (op, plan) = session.crdt.local_insert_with_plan(parent, node, placement, payload)?;
-        finish_local_core_op(&mut session, &op, plan);
+        finish_local_core_op(&mut session, &op, plan)?;
         Ok(op)
     })
 }
@@ -156,7 +161,7 @@ pub fn local_move(
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let placement = LocalPlacement::from_parts(placement, after)?;
         let (op, plan) = session.crdt.local_move_with_plan(node, new_parent, placement)?;
-        finish_local_core_op(&mut session, &op, plan);
+        finish_local_core_op(&mut session, &op, plan)?;
         Ok(op)
     })
 }
@@ -170,7 +175,7 @@ pub fn local_delete(
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let (op, plan) = session.crdt.local_delete_with_plan(node)?;
-        finish_local_core_op(&mut session, &op, plan);
+        finish_local_core_op(&mut session, &op, plan)?;
         Ok(op)
     })
 }
@@ -185,7 +190,7 @@ pub fn local_payload(
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let (op, plan) = session.crdt.local_payload_with_plan(node, payload)?;
-        finish_local_core_op(&mut session, &op, plan);
+        finish_local_core_op(&mut session, &op, plan)?;
         Ok(op)
     })
 }

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -10,8 +10,8 @@ use treecrdt_core::{
 
 use crate::store::{
     ensure_materialized_in_tx, load_tree_meta_for_update, set_tree_meta_dirty,
-    update_tree_meta_head, PgCtx, PgNodeStore, PgOpStorage, PgParentOpIndex, PgPayloadStore,
-    TreeMeta,
+    set_tree_meta_replay_frontier, update_tree_meta_head, PgCtx, PgNodeStore, PgOpStorage,
+    PgParentOpIndex, PgPayloadStore, TreeMeta,
 };
 
 type LocalCrdt = TreeCrdt<PgOpStorage, LamportClock, PgNodeStore, PgPayloadStore>;
@@ -110,7 +110,16 @@ fn finish_local_core_op(session: &mut LocalOpSession, op: &Operation, plan: Loca
     }
 
     if !post_materialization_ok {
-        let _ = set_tree_meta_dirty(&session.ctx.client, &session.ctx.doc_id, true);
+        let _ = set_tree_meta_replay_frontier(
+            &session.ctx.client,
+            &session.ctx.doc_id,
+            &treecrdt_core::MaterializationFrontier {
+                lamport: 0,
+                replica: Vec::new(),
+                counter: 0,
+            },
+        )
+        .or_else(|_| set_tree_meta_dirty(&session.ctx.client, &session.ctx.doc_id, true));
     }
 }
 

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -86,10 +86,12 @@ fn finish_local_core_op(
     let mut op_index = PgParentOpIndex::new(session.ctx.clone());
     // commit_local() already persisted the op and updated node/payload state. The finalize step
     // refreshes adapter-owned derived state that lives outside TreeCrdt itself.
-    match session
-        .crdt
-        .finalize_local_with_plan(op, &mut op_index, session.meta.head_seq(), &plan)
-    {
+    match session.crdt.finalize_local_with_plan(
+        op,
+        &mut op_index,
+        session.meta.state().head_seq(),
+        &plan,
+    ) {
         Ok(v) => {
             seq = v;
             if session.nodes.flush_last_change().is_err() || op_index.flush().is_err() {

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -101,16 +101,16 @@ fn finish_local_core_op(
         Err(_) => post_materialization_ok = false,
     }
 
+    let head = treecrdt_core::MaterializationHead {
+        at: treecrdt_core::MaterializationKey {
+            lamport: op.meta.lamport,
+            replica: op.meta.id.replica.as_bytes(),
+            counter: op.meta.id.counter,
+        },
+        seq,
+    };
     if post_materialization_ok
-        && update_tree_meta_head(
-            &session.ctx.client,
-            &session.ctx.doc_id,
-            op.meta.lamport,
-            op.meta.id.replica.as_bytes(),
-            op.meta.id.counter,
-            seq,
-        )
-        .is_err()
+        && update_tree_meta_head(&session.ctx.client, &session.ctx.doc_id, Some(&head)).is_err()
     {
         post_materialization_ok = false;
     }

--- a/packages/treecrdt-postgres-rs/src/profile.rs
+++ b/packages/treecrdt-postgres-rs/src/profile.rs
@@ -15,14 +15,14 @@ pub(crate) fn append_profile_enabled() -> bool {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PgAppendProfile {
     pub(crate) batch_ops: usize,
-    pub(crate) doc_dirty_before: bool,
+    pub(crate) replay_pending_before: bool,
     pub(crate) head_seq_before: u64,
     pub(crate) bulk_insert_ms: f64,
     pub(crate) bulk_inserted_ops: usize,
     pub(crate) dedupe_filter_ms: f64,
     pub(crate) materialize_ms: f64,
     pub(crate) update_head_ms: f64,
-    pub(crate) fallback_mark_dirty: bool,
+    pub(crate) replay_deferred: bool,
     pub(crate) node_load_count: u64,
     pub(crate) node_load_ms: f64,
     pub(crate) node_ensure_count: u64,
@@ -46,10 +46,10 @@ pub(crate) struct PgAppendProfile {
 }
 
 impl PgAppendProfile {
-    pub(crate) fn new(batch_ops: usize, doc_dirty_before: bool, head_seq_before: u64) -> Self {
+    pub(crate) fn new(batch_ops: usize, replay_pending_before: bool, head_seq_before: u64) -> Self {
         Self {
             batch_ops,
-            doc_dirty_before,
+            replay_pending_before,
             head_seq_before,
             ..Self::default()
         }
@@ -63,14 +63,14 @@ impl PgAppendProfile {
                 "docId": doc_id,
                 "batchOps": self.batch_ops,
                 "insertedOps": inserted,
-                "docDirtyBefore": self.doc_dirty_before,
+                "replayPendingBefore": self.replay_pending_before,
                 "headSeqBefore": self.head_seq_before,
                 "bulkInsertMs": self.bulk_insert_ms,
                 "bulkInsertedOps": self.bulk_inserted_ops,
                 "dedupeFilterMs": self.dedupe_filter_ms,
                 "materializeMs": self.materialize_ms,
                 "updateHeadMs": self.update_head_ms,
-                "fallbackMarkDirty": self.fallback_mark_dirty,
+                "replayDeferred": self.replay_deferred,
                 "nodeLoadCount": self.node_load_count,
                 "nodeLoadMs": self.node_load_ms,
                 "nodeEnsureCount": self.node_ensure_count,

--- a/packages/treecrdt-postgres-rs/src/profile.rs
+++ b/packages/treecrdt-postgres-rs/src/profile.rs
@@ -15,14 +15,14 @@ pub(crate) fn append_profile_enabled() -> bool {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PgAppendProfile {
     pub(crate) batch_ops: usize,
-    pub(crate) replay_pending_before: bool,
+    pub(crate) frontier_pending_before: bool,
     pub(crate) head_seq_before: u64,
     pub(crate) bulk_insert_ms: f64,
     pub(crate) bulk_inserted_ops: usize,
     pub(crate) dedupe_filter_ms: f64,
     pub(crate) materialize_ms: f64,
     pub(crate) update_head_ms: f64,
-    pub(crate) replay_deferred: bool,
+    pub(crate) frontier_recorded: bool,
     pub(crate) node_load_count: u64,
     pub(crate) node_load_ms: f64,
     pub(crate) node_ensure_count: u64,
@@ -46,10 +46,14 @@ pub(crate) struct PgAppendProfile {
 }
 
 impl PgAppendProfile {
-    pub(crate) fn new(batch_ops: usize, replay_pending_before: bool, head_seq_before: u64) -> Self {
+    pub(crate) fn new(
+        batch_ops: usize,
+        frontier_pending_before: bool,
+        head_seq_before: u64,
+    ) -> Self {
         Self {
             batch_ops,
-            replay_pending_before,
+            frontier_pending_before,
             head_seq_before,
             ..Self::default()
         }
@@ -63,14 +67,14 @@ impl PgAppendProfile {
                 "docId": doc_id,
                 "batchOps": self.batch_ops,
                 "insertedOps": inserted,
-                "replayPendingBefore": self.replay_pending_before,
+                "frontierPendingBefore": self.frontier_pending_before,
                 "headSeqBefore": self.head_seq_before,
                 "bulkInsertMs": self.bulk_insert_ms,
                 "bulkInsertedOps": self.bulk_inserted_ops,
                 "dedupeFilterMs": self.dedupe_filter_ms,
                 "materializeMs": self.materialize_ms,
                 "updateHeadMs": self.update_head_ms,
-                "replayDeferred": self.replay_deferred,
+                "frontierRecorded": self.frontier_recorded,
                 "nodeLoadCount": self.node_load_count,
                 "nodeLoadMs": self.node_load_ms,
                 "nodeEnsureCount": self.node_ensure_count,

--- a/packages/treecrdt-postgres-rs/src/schema.rs
+++ b/packages/treecrdt-postgres-rs/src/schema.rs
@@ -30,8 +30,15 @@ CREATE TABLE IF NOT EXISTS treecrdt_meta (
   head_lamport BIGINT NOT NULL DEFAULT 0,
   head_replica BYTEA NOT NULL DEFAULT ''::bytea,
   head_counter BIGINT NOT NULL DEFAULT 0,
-  head_seq BIGINT NOT NULL DEFAULT 0
+  head_seq BIGINT NOT NULL DEFAULT 0,
+  replay_lamport BIGINT,
+  replay_replica BYTEA,
+  replay_counter BIGINT
 );
+
+ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_lamport BIGINT;
+ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_replica BYTEA;
+ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_counter BIGINT;
 
 CREATE TABLE IF NOT EXISTS treecrdt_nodes (
   doc_id TEXT NOT NULL,

--- a/packages/treecrdt-postgres-rs/src/schema.rs
+++ b/packages/treecrdt-postgres-rs/src/schema.rs
@@ -26,7 +26,6 @@ CREATE INDEX IF NOT EXISTS idx_treecrdt_ops_doc_order
 
 CREATE TABLE IF NOT EXISTS treecrdt_meta (
   doc_id TEXT PRIMARY KEY,
-  dirty BOOLEAN NOT NULL DEFAULT FALSE,
   head_lamport BIGINT NOT NULL DEFAULT 0,
   head_replica BYTEA NOT NULL DEFAULT ''::bytea,
   head_counter BIGINT NOT NULL DEFAULT 0,
@@ -39,6 +38,7 @@ CREATE TABLE IF NOT EXISTS treecrdt_meta (
 ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_lamport BIGINT;
 ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_replica BYTEA;
 ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_counter BIGINT;
+ALTER TABLE treecrdt_meta DROP COLUMN IF EXISTS dirty;
 
 CREATE TABLE IF NOT EXISTS treecrdt_nodes (
   doc_id TEXT NOT NULL,

--- a/packages/treecrdt-postgres-rs/src/schema.rs
+++ b/packages/treecrdt-postgres-rs/src/schema.rs
@@ -35,11 +35,6 @@ CREATE TABLE IF NOT EXISTS treecrdt_meta (
   replay_counter BIGINT
 );
 
-ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_lamport BIGINT;
-ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_replica BYTEA;
-ALTER TABLE treecrdt_meta ADD COLUMN IF NOT EXISTS replay_counter BIGINT;
-ALTER TABLE treecrdt_meta DROP COLUMN IF EXISTS dirty;
-
 CREATE TABLE IF NOT EXISTS treecrdt_nodes (
   doc_id TEXT NOT NULL,
   node BYTEA NOT NULL,

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -51,7 +51,6 @@ pub(crate) fn vv_from_bytes(bytes: &[u8]) -> Result<VersionVector> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct TreeMeta {
-    dirty: bool,
     head_lamport: Lamport,
     head_replica: Vec<u8>,
     head_counter: u64,
@@ -62,10 +61,6 @@ pub(crate) struct TreeMeta {
 }
 
 impl MaterializationCursor for TreeMeta {
-    fn dirty(&self) -> bool {
-        self.dirty
-    }
-
     fn head_lamport(&self) -> Lamport {
         self.head_lamport
     }
@@ -98,8 +93,7 @@ impl MaterializationCursor for TreeMeta {
 pub(crate) fn ensure_doc_meta(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
     let mut c = client.borrow_mut();
     c.execute(
-        // Default new docs to "clean" so we can incrementally maintain materialized state.
-        "INSERT INTO treecrdt_meta(doc_id, dirty) VALUES ($1, FALSE) ON CONFLICT (doc_id) DO NOTHING",
+        "INSERT INTO treecrdt_meta(doc_id) VALUES ($1) ON CONFLICT (doc_id) DO NOTHING",
         &[&doc_id],
     )
     .map_err(storage_debug)?;
@@ -116,14 +110,14 @@ fn load_tree_meta_row(
     let stmt = if for_update {
         ctx.stmt(
             &mut c,
-            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+            "SELECT head_lamport, head_replica, head_counter, head_seq, \
                     replay_lamport, replay_replica, replay_counter \
              FROM treecrdt_meta WHERE doc_id = $1 FOR UPDATE",
         )?
     } else {
         ctx.stmt(
             &mut c,
-            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+            "SELECT head_lamport, head_replica, head_counter, head_seq, \
                     replay_lamport, replay_replica, replay_counter \
              FROM treecrdt_meta WHERE doc_id = $1 LIMIT 1",
         )?
@@ -133,14 +127,13 @@ fn load_tree_meta_row(
     let row = rows.first().ok_or_else(|| Error::Storage("missing treecrdt_meta row".into()))?;
 
     Ok(TreeMeta {
-        dirty: row.get::<_, bool>(0),
-        head_lamport: row.get::<_, i64>(1).max(0) as Lamport,
-        head_replica: row.get::<_, Vec<u8>>(2),
-        head_counter: row.get::<_, i64>(3).max(0) as u64,
-        head_seq: row.get::<_, i64>(4).max(0) as u64,
-        replay_lamport: row.get::<_, Option<i64>>(5).map(|v| v.max(0) as Lamport),
-        replay_replica: row.get::<_, Option<Vec<u8>>>(6),
-        replay_counter: row.get::<_, Option<i64>>(7).map(|v| v.max(0) as u64),
+        head_lamport: row.get::<_, i64>(0).max(0) as Lamport,
+        head_replica: row.get::<_, Vec<u8>>(1),
+        head_counter: row.get::<_, i64>(2).max(0) as u64,
+        head_seq: row.get::<_, i64>(3).max(0) as u64,
+        replay_lamport: row.get::<_, Option<i64>>(4).map(|v| v.max(0) as Lamport),
+        replay_replica: row.get::<_, Option<Vec<u8>>>(5),
+        replay_counter: row.get::<_, Option<i64>>(6).map(|v| v.max(0) as u64),
     })
 }
 
@@ -155,23 +148,6 @@ pub(crate) fn load_tree_meta_for_update(
     load_tree_meta_row(client, doc_id, true)
 }
 
-pub(crate) fn set_tree_meta_dirty(
-    client: &Rc<RefCell<Client>>,
-    doc_id: &str,
-    dirty: bool,
-) -> Result<()> {
-    ensure_doc_meta(client, doc_id)?;
-    let mut c = client.borrow_mut();
-    c.execute(
-        "UPDATE treecrdt_meta \
-         SET dirty = $2, replay_lamport = NULL, replay_replica = NULL, replay_counter = NULL \
-         WHERE doc_id = $1",
-        &[&doc_id, &dirty],
-    )
-    .map_err(|e| Error::Storage(e.to_string()))?;
-    Ok(())
-}
-
 pub(crate) fn set_tree_meta_replay_frontier(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
@@ -181,7 +157,7 @@ pub(crate) fn set_tree_meta_replay_frontier(
     let mut c = client.borrow_mut();
     c.execute(
         "UPDATE treecrdt_meta \
-         SET dirty = FALSE, replay_lamport = $2, replay_replica = $3, replay_counter = $4 \
+         SET replay_lamport = $2, replay_replica = $3, replay_counter = $4 \
          WHERE doc_id = $1",
         &[
             &doc_id,
@@ -206,8 +182,7 @@ pub(crate) fn update_tree_meta_head(
     let mut c = client.borrow_mut();
     c.execute(
         "UPDATE treecrdt_meta \
-         SET dirty = FALSE, \
-             head_lamport = $2, \
+         SET head_lamport = $2, \
              head_replica = $3, \
              head_counter = $4, \
              head_seq = $5, \
@@ -1634,7 +1609,7 @@ fn append_ops_in_tx(
     let append_profile = append_profile_enabled().then(|| {
         Rc::new(RefCell::new(PgAppendProfile::new(
             ops.len(),
-            meta.dirty,
+            meta.replay_lamport.is_some(),
             meta.head_seq(),
         )))
     });
@@ -1680,8 +1655,7 @@ fn append_ops_in_tx(
             result
         },
         |frontier| set_tree_meta_replay_frontier(client, doc_id, frontier),
-        || set_tree_meta_dirty(client, doc_id, true),
-    );
+    )?;
     if let Some(profile) = &append_profile {
         profile.borrow_mut().materialize_ms +=
             materialize_started_at.elapsed().as_secs_f64() * 1000.0;
@@ -1689,8 +1663,8 @@ fn append_ops_in_tx(
 
     if let Some(profile) = &append_profile {
         profile.borrow_mut().update_head_ms += update_head_ms;
-        if apply_result.dirty_fallback {
-            profile.borrow_mut().fallback_mark_dirty = true;
+        if apply_result.replay_deferred {
+            profile.borrow_mut().replay_deferred = true;
         }
         profile.borrow().log(doc_id, apply_result.inserted_count as usize);
     }
@@ -1725,13 +1699,13 @@ pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result
 
 pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
     let meta = load_tree_meta(client, doc_id)?;
-    if !meta.dirty && meta.replay_lamport.is_none() {
+    if meta.replay_lamport.is_none() {
         return Ok(());
     }
 
     // Take a per-doc lock so rebuild can't race with concurrent append/materialization.
     let meta = load_tree_meta_for_update(client, doc_id)?;
-    if !meta.dirty && meta.replay_lamport.is_none() {
+    if meta.replay_lamport.is_none() {
         return Ok(());
     }
 

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -51,48 +51,11 @@ pub(crate) fn vv_from_bytes(bytes: &[u8]) -> Result<VersionVector> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct TreeMeta {
-    head_lamport: Lamport,
-    head_replica: Vec<u8>,
-    head_counter: u64,
-    head_seq: u64,
-    replay_lamport: Option<Lamport>,
-    replay_replica: Option<Vec<u8>>,
-    replay_counter: Option<u64>,
-}
+pub(crate) struct TreeMeta(MaterializationState);
 
 impl MaterializationCursor for TreeMeta {
     fn state(&self) -> MaterializationState<&[u8]> {
-        let head = if self.head_seq == 0
-            && self.head_lamport == 0
-            && self.head_replica.is_empty()
-            && self.head_counter == 0
-        {
-            None
-        } else {
-            Some(MaterializationHead {
-                at: MaterializationKey {
-                    lamport: self.head_lamport,
-                    replica: self.head_replica.as_slice(),
-                    counter: self.head_counter,
-                },
-                seq: self.head_seq,
-            })
-        };
-        let replay_from = match (
-            self.replay_lamport,
-            self.replay_replica.as_deref(),
-            self.replay_counter,
-        ) {
-            (Some(lamport), Some(replica), Some(counter)) => Some(MaterializationKey {
-                lamport,
-                replica,
-                counter,
-            }),
-            _ => None,
-        };
-
-        MaterializationState { head, replay_from }
+        self.0.as_borrowed()
     }
 }
 
@@ -132,15 +95,37 @@ fn load_tree_meta_row(
 
     let row = rows.first().ok_or_else(|| Error::Storage("missing treecrdt_meta row".into()))?;
 
-    Ok(TreeMeta {
-        head_lamport: row.get::<_, i64>(0).max(0) as Lamport,
-        head_replica: row.get::<_, Vec<u8>>(1),
-        head_counter: row.get::<_, i64>(2).max(0) as u64,
-        head_seq: row.get::<_, i64>(3).max(0) as u64,
-        replay_lamport: row.get::<_, Option<i64>>(4).map(|v| v.max(0) as Lamport),
-        replay_replica: row.get::<_, Option<Vec<u8>>>(5),
-        replay_counter: row.get::<_, Option<i64>>(6).map(|v| v.max(0) as u64),
-    })
+    let head_lamport = row.get::<_, i64>(0).max(0) as Lamport;
+    let head_replica = row.get::<_, Vec<u8>>(1);
+    let head_counter = row.get::<_, i64>(2).max(0) as u64;
+    let head_seq = row.get::<_, i64>(3).max(0) as u64;
+    let replay_lamport = row.get::<_, Option<i64>>(4).map(|v| v.max(0) as Lamport);
+    let replay_replica = row.get::<_, Option<Vec<u8>>>(5);
+    let replay_counter = row.get::<_, Option<i64>>(6).map(|v| v.max(0) as u64);
+
+    let head = if head_seq == 0 && head_lamport == 0 && head_replica.is_empty() && head_counter == 0
+    {
+        None
+    } else {
+        Some(MaterializationHead {
+            at: MaterializationKey {
+                lamport: head_lamport,
+                replica: head_replica,
+                counter: head_counter,
+            },
+            seq: head_seq,
+        })
+    };
+    let replay_from = match (replay_lamport, replay_replica, replay_counter) {
+        (Some(lamport), Some(replica), Some(counter)) => Some(MaterializationKey {
+            lamport,
+            replica,
+            counter,
+        }),
+        _ => None,
+    };
+
+    Ok(TreeMeta(MaterializationState { head, replay_from }))
 }
 
 fn load_tree_meta(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<TreeMeta> {
@@ -176,15 +161,21 @@ pub(crate) fn set_tree_meta_replay_frontier(
     Ok(())
 }
 
-pub(crate) fn update_tree_meta_head(
+pub(crate) fn update_tree_meta_head<R: AsRef<[u8]>>(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
-    lamport: Lamport,
-    replica: &[u8],
-    counter: u64,
-    seq: u64,
+    head: Option<&MaterializationHead<R>>,
 ) -> Result<()> {
     ensure_doc_meta(client, doc_id)?;
+    let (lamport, replica, counter, seq): (Lamport, &[u8], u64, u64) = match head {
+        Some(head) => (
+            head.at.lamport,
+            head.at.replica.as_ref(),
+            head.at.counter,
+            head.seq,
+        ),
+        None => (0, &[], 0, 0),
+    };
     let mut c = client.borrow_mut();
     c.execute(
         "UPDATE treecrdt_meta \
@@ -1649,14 +1640,7 @@ fn append_ops_in_tx(
         |inserted| materialize_inserted_ops(ctx.clone(), &meta, inserted),
         |head| {
             let started_at = Instant::now();
-            let result = update_tree_meta_head(
-                &ctx.client,
-                &ctx.doc_id,
-                head.at.lamport,
-                &head.at.replica,
-                head.at.counter,
-                head.seq,
-            );
+            let result = update_tree_meta_head(&ctx.client, &ctx.doc_id, Some(head));
             update_head_ms += started_at.elapsed().as_secs_f64() * 1000.0;
             result
         },
@@ -1731,18 +1715,7 @@ pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &s
         |index| index.flush(),
     )?;
 
-    if let Some(last) = head {
-        update_tree_meta_head(
-            client,
-            doc_id,
-            last.at.lamport,
-            &last.at.replica,
-            last.at.counter,
-            last.seq,
-        )?;
-    } else {
-        update_tree_meta_head(client, doc_id, 0, &[], 0, 0)?;
-    }
+    update_tree_meta_head(client, doc_id, head.as_ref())?;
 
     Ok(())
 }

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -1653,8 +1653,8 @@ fn append_ops_in_tx(
 
     if let Some(profile) = &append_profile {
         profile.borrow_mut().update_head_ms += update_head_ms;
-        if apply_result.replay_deferred {
-            profile.borrow_mut().replay_deferred = true;
+        if apply_result.frontier_recorded {
+            profile.borrow_mut().frontier_recorded = true;
         }
         profile.borrow().log(doc_id, apply_result.inserted_count as usize);
     }
@@ -1693,7 +1693,7 @@ pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &s
         return Ok(());
     }
 
-    // Take a per-doc lock so rebuild can't race with concurrent append/materialization.
+    // Take a per-doc lock so catch-up can't race with concurrent append/materialization.
     let meta = load_tree_meta_for_update(client, doc_id)?;
     if meta.state().replay_from.is_none() {
         return Ok(());

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -6,10 +6,10 @@ use std::time::Instant;
 use postgres::{Client, Row, Statement};
 
 use treecrdt_core::{
-    apply_persisted_remote_ops_with_delta, materialize_persisted_remote_ops_with_delta, Error,
-    Lamport, LamportClock, MaterializationCursor, NodeId, NodeStore, Operation, OperationId,
-    OperationKind, ParentOpIndex, PayloadStore, PersistedRemoteStores, ReplicaId, Result, Storage,
-    TreeCrdt, VersionVector,
+    apply_persisted_remote_ops_with_delta, catch_up_materialized_state,
+    materialize_persisted_remote_ops_with_delta, Error, Lamport, LamportClock,
+    MaterializationCursor, MaterializationFrontier, NodeId, Operation, OperationId, OperationKind,
+    PersistedRemoteStores, ReplicaId, Result, Storage, VersionVector,
 };
 
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
@@ -56,6 +56,9 @@ pub(crate) struct TreeMeta {
     head_replica: Vec<u8>,
     head_counter: u64,
     head_seq: u64,
+    replay_lamport: Option<Lamport>,
+    replay_replica: Option<Vec<u8>>,
+    replay_counter: Option<u64>,
 }
 
 impl MaterializationCursor for TreeMeta {
@@ -77,6 +80,18 @@ impl MaterializationCursor for TreeMeta {
 
     fn head_seq(&self) -> u64 {
         self.head_seq
+    }
+
+    fn replay_lamport(&self) -> Option<Lamport> {
+        self.replay_lamport
+    }
+
+    fn replay_replica(&self) -> Option<&[u8]> {
+        self.replay_replica.as_deref()
+    }
+
+    fn replay_counter(&self) -> Option<u64> {
+        self.replay_counter
     }
 }
 
@@ -101,13 +116,15 @@ fn load_tree_meta_row(
     let stmt = if for_update {
         ctx.stmt(
             &mut c,
-            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq \
+            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+                    replay_lamport, replay_replica, replay_counter \
              FROM treecrdt_meta WHERE doc_id = $1 FOR UPDATE",
         )?
     } else {
         ctx.stmt(
             &mut c,
-            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq \
+            "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+                    replay_lamport, replay_replica, replay_counter \
              FROM treecrdt_meta WHERE doc_id = $1 LIMIT 1",
         )?
     };
@@ -121,6 +138,9 @@ fn load_tree_meta_row(
         head_replica: row.get::<_, Vec<u8>>(2),
         head_counter: row.get::<_, i64>(3).max(0) as u64,
         head_seq: row.get::<_, i64>(4).max(0) as u64,
+        replay_lamport: row.get::<_, Option<i64>>(5).map(|v| v.max(0) as Lamport),
+        replay_replica: row.get::<_, Option<Vec<u8>>>(6),
+        replay_counter: row.get::<_, Option<i64>>(7).map(|v| v.max(0) as u64),
     })
 }
 
@@ -143,8 +163,32 @@ pub(crate) fn set_tree_meta_dirty(
     ensure_doc_meta(client, doc_id)?;
     let mut c = client.borrow_mut();
     c.execute(
-        "UPDATE treecrdt_meta SET dirty = $2 WHERE doc_id = $1",
+        "UPDATE treecrdt_meta \
+         SET dirty = $2, replay_lamport = NULL, replay_replica = NULL, replay_counter = NULL \
+         WHERE doc_id = $1",
         &[&doc_id, &dirty],
+    )
+    .map_err(|e| Error::Storage(e.to_string()))?;
+    Ok(())
+}
+
+pub(crate) fn set_tree_meta_replay_frontier(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    frontier: &MaterializationFrontier,
+) -> Result<()> {
+    ensure_doc_meta(client, doc_id)?;
+    let mut c = client.borrow_mut();
+    c.execute(
+        "UPDATE treecrdt_meta \
+         SET dirty = FALSE, replay_lamport = $2, replay_replica = $3, replay_counter = $4 \
+         WHERE doc_id = $1",
+        &[
+            &doc_id,
+            &(frontier.lamport as i64),
+            &frontier.replica,
+            &(frontier.counter as i64),
+        ],
     )
     .map_err(|e| Error::Storage(e.to_string()))?;
     Ok(())
@@ -161,8 +205,23 @@ pub(crate) fn update_tree_meta_head(
     ensure_doc_meta(client, doc_id)?;
     let mut c = client.borrow_mut();
     c.execute(
-        "UPDATE treecrdt_meta SET dirty = FALSE, head_lamport = $2, head_replica = $3, head_counter = $4, head_seq = $5 WHERE doc_id = $1",
-        &[&doc_id, &(lamport as i64), &replica, &(counter as i64), &(seq as i64)],
+        "UPDATE treecrdt_meta \
+         SET dirty = FALSE, \
+             head_lamport = $2, \
+             head_replica = $3, \
+             head_counter = $4, \
+             head_seq = $5, \
+             replay_lamport = NULL, \
+             replay_replica = NULL, \
+             replay_counter = NULL \
+         WHERE doc_id = $1",
+        &[
+            &doc_id,
+            &(lamport as i64),
+            &replica,
+            &(counter as i64),
+            &(seq as i64),
+        ],
     )
     .map_err(|e| Error::Storage(e.to_string()))?;
     Ok(())
@@ -1620,6 +1679,7 @@ fn append_ops_in_tx(
             update_head_ms += started_at.elapsed().as_secs_f64() * 1000.0;
             result
         },
+        |frontier| set_tree_meta_replay_frontier(client, doc_id, frontier),
         || set_tree_meta_dirty(client, doc_id, true),
     );
     if let Some(profile) = &append_profile {
@@ -1639,20 +1699,6 @@ fn append_ops_in_tx(
         inserted_count: apply_result.inserted_count,
         affected_nodes: apply_result.affected_nodes,
     })
-}
-
-fn clear_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
-    let mut c = client.borrow_mut();
-    c.execute(
-        "DELETE FROM treecrdt_oprefs_children WHERE doc_id = $1",
-        &[&doc_id],
-    )
-    .map_err(|e| Error::Storage(e.to_string()))?;
-    c.execute("DELETE FROM treecrdt_payload WHERE doc_id = $1", &[&doc_id])
-        .map_err(|e| Error::Storage(e.to_string()))?;
-    c.execute("DELETE FROM treecrdt_nodes WHERE doc_id = $1", &[&doc_id])
-        .map_err(|e| Error::Storage(e.to_string()))?;
-    Ok(())
 }
 
 pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
@@ -1679,51 +1725,40 @@ pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result
 
 pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
     let meta = load_tree_meta(client, doc_id)?;
-    if !meta.dirty {
+    if !meta.dirty && meta.replay_lamport.is_none() {
         return Ok(());
     }
 
     // Take a per-doc lock so rebuild can't race with concurrent append/materialization.
     let meta = load_tree_meta_for_update(client, doc_id)?;
-    if !meta.dirty {
+    if !meta.dirty && meta.replay_lamport.is_none() {
         return Ok(());
     }
 
-    clear_materialized(client, doc_id)?;
-
     let ctx = PgCtx::new(client.clone(), doc_id)?;
     let storage = PgOpStorage::new(ctx.clone());
-    let mut nodes = PgNodeStore::new(ctx.clone());
-    let node_flush = nodes.clone();
-    let mut payloads = PgPayloadStore::new(ctx.clone());
-    let mut index = PgParentOpIndex::new(ctx.clone());
-
-    nodes.reset()?;
-    payloads.reset()?;
-    index.reset()?;
-
-    let mut crdt = TreeCrdt::with_stores(
-        ReplicaId::new(b"postgres"),
+    let head = catch_up_materialized_state(
         storage,
-        LamportClock::default(),
-        nodes,
-        payloads,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"postgres"),
+            clock: LamportClock::default(),
+            nodes: PgNodeStore::new(ctx.clone()),
+            payloads: PgPayloadStore::new(ctx.clone()),
+            index: PgParentOpIndex::new(ctx.clone()),
+        },
+        &meta,
+        |nodes| nodes.flush_last_change(),
+        |index| index.flush(),
     )?;
-    // Full rebuild path: replay the persisted op log through treecrdt-core to reconstruct
-    // nodes, payloads, subtree opRef index rows, and cached tombstone state from scratch.
-    crdt.replay_from_storage_with_materialization(&mut index)?;
-    node_flush.flush_last_change()?;
-    index.flush()?;
 
-    let seq = crdt.log_len().min(u64::MAX as usize) as u64;
-    if let Some(last) = crdt.head_op() {
+    if let Some(last) = head {
         update_tree_meta_head(
             client,
             doc_id,
-            last.meta.lamport,
-            last.meta.id.replica.as_bytes(),
-            last.meta.id.counter,
-            seq,
+            last.lamport,
+            &last.replica,
+            last.counter,
+            last.seq,
         )?;
     } else {
         update_tree_meta_head(client, doc_id, 0, &[], 0, 0)?;

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -8,8 +8,9 @@ use postgres::{Client, Row, Statement};
 use treecrdt_core::{
     apply_persisted_remote_ops_with_delta, catch_up_materialized_state,
     materialize_persisted_remote_ops_with_delta, Error, Lamport, LamportClock,
-    MaterializationCursor, MaterializationFrontier, NodeId, Operation, OperationId, OperationKind,
-    PersistedRemoteStores, ReplicaId, Result, Storage, VersionVector,
+    MaterializationCursor, MaterializationFrontier, MaterializationHead, MaterializationKey,
+    MaterializationState, NodeId, Operation, OperationId, OperationKind, PersistedRemoteStores,
+    ReplicaId, Result, Storage, VersionVector,
 };
 
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
@@ -61,32 +62,37 @@ pub(crate) struct TreeMeta {
 }
 
 impl MaterializationCursor for TreeMeta {
-    fn head_lamport(&self) -> Lamport {
-        self.head_lamport
-    }
+    fn state(&self) -> MaterializationState<&[u8]> {
+        let head = if self.head_seq == 0
+            && self.head_lamport == 0
+            && self.head_replica.is_empty()
+            && self.head_counter == 0
+        {
+            None
+        } else {
+            Some(MaterializationHead {
+                at: MaterializationKey {
+                    lamport: self.head_lamport,
+                    replica: self.head_replica.as_slice(),
+                    counter: self.head_counter,
+                },
+                seq: self.head_seq,
+            })
+        };
+        let replay_from = match (
+            self.replay_lamport,
+            self.replay_replica.as_deref(),
+            self.replay_counter,
+        ) {
+            (Some(lamport), Some(replica), Some(counter)) => Some(MaterializationKey {
+                lamport,
+                replica,
+                counter,
+            }),
+            _ => None,
+        };
 
-    fn head_replica(&self) -> &[u8] {
-        &self.head_replica
-    }
-
-    fn head_counter(&self) -> u64 {
-        self.head_counter
-    }
-
-    fn head_seq(&self) -> u64 {
-        self.head_seq
-    }
-
-    fn replay_lamport(&self) -> Option<Lamport> {
-        self.replay_lamport
-    }
-
-    fn replay_replica(&self) -> Option<&[u8]> {
-        self.replay_replica.as_deref()
-    }
-
-    fn replay_counter(&self) -> Option<u64> {
-        self.replay_counter
+        MaterializationState { head, replay_from }
     }
 }
 
@@ -1609,8 +1615,8 @@ fn append_ops_in_tx(
     let append_profile = append_profile_enabled().then(|| {
         Rc::new(RefCell::new(PgAppendProfile::new(
             ops.len(),
-            meta.replay_lamport.is_some(),
-            meta.head_seq(),
+            meta.state().replay_from.is_some(),
+            meta.state().head_seq(),
         )))
     });
     let ctx = PgCtx::new_with_profile(client.clone(), doc_id, append_profile.clone())?;
@@ -1646,9 +1652,9 @@ fn append_ops_in_tx(
             let result = update_tree_meta_head(
                 &ctx.client,
                 &ctx.doc_id,
-                head.lamport,
-                &head.replica,
-                head.counter,
+                head.at.lamport,
+                &head.at.replica,
+                head.at.counter,
                 head.seq,
             );
             update_head_ms += started_at.elapsed().as_secs_f64() * 1000.0;
@@ -1699,13 +1705,13 @@ pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result
 
 pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
     let meta = load_tree_meta(client, doc_id)?;
-    if meta.replay_lamport.is_none() {
+    if meta.state().replay_from.is_none() {
         return Ok(());
     }
 
     // Take a per-doc lock so rebuild can't race with concurrent append/materialization.
     let meta = load_tree_meta_for_update(client, doc_id)?;
-    if meta.replay_lamport.is_none() {
+    if meta.state().replay_from.is_none() {
         return Ok(());
     }
 
@@ -1729,9 +1735,9 @@ pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &s
         update_tree_meta_head(
             client,
             doc_id,
-            last.lamport,
-            &last.replica,
-            last.counter,
+            last.at.lamport,
+            &last.at.replica,
+            last.at.counter,
             last.seq,
         )?;
     } else {

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -335,7 +335,7 @@ fn postgres_backend_replay_from_start_frontier_recovers_materialized_state() {
 }
 
 #[test]
-fn postgres_backend_large_append_rebuilds_materialized_views_on_demand() {
+fn postgres_backend_large_append_catches_up_materialized_views_on_demand() {
     let Some(client) = connect() else {
         return;
     };

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -199,24 +199,22 @@ fn postgres_backend_out_of_order_append_uses_replay_frontier() {
     let affected = append_ops_with_affected_nodes(&client, &doc_id, &[first.clone()]).unwrap();
     assert!(affected.is_empty());
 
-    let (dirty_before_read, replay_lamport, replay_replica, replay_counter, head_seq_before) = {
+    let (replay_lamport, replay_replica, replay_counter, head_seq_before) = {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty, replay_lamport, replay_replica, replay_counter, head_seq \
+                "SELECT replay_lamport, replay_replica, replay_counter, head_seq \
                  FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
         (
-            row.get::<_, bool>(0),
-            row.get::<_, Option<i64>>(1).map(|v| v.max(0) as u64),
-            row.get::<_, Option<Vec<u8>>>(2),
-            row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
-            row.get::<_, i64>(4).max(0) as u64,
+            row.get::<_, Option<i64>>(0).map(|v| v.max(0) as u64),
+            row.get::<_, Option<Vec<u8>>>(1),
+            row.get::<_, Option<i64>>(2).map(|v| v.max(0) as u64),
+            row.get::<_, i64>(3).max(0) as u64,
         )
     };
-    assert!(!dirty_before_read);
     assert_eq!(replay_lamport, Some(first.meta.lamport));
     assert_eq!(
         replay_replica,
@@ -230,18 +228,17 @@ fn postgres_backend_out_of_order_append_uses_replay_frontier() {
         vec![node(1), node(2)]
     );
 
-    let (dirty_after_read, replay_after_read) = {
+    let replay_after_read = {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty, replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
+                "SELECT replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
-        assert_eq!(row.get::<_, i64>(2).max(0) as u64, 2);
-        (row.get::<_, bool>(0), row.get::<_, Option<i64>>(1))
+        assert_eq!(row.get::<_, i64>(1).max(0) as u64, 2);
+        row.get::<_, Option<i64>>(0)
     };
-    assert!(!dirty_after_read);
     assert_eq!(replay_after_read, None);
 
     let refs = list_op_refs_children(&client, &doc_id, NodeId::ROOT).unwrap();
@@ -253,7 +250,7 @@ fn postgres_backend_out_of_order_append_uses_replay_frontier() {
 }
 
 #[test]
-fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
+fn postgres_backend_replay_from_start_frontier_recovers_materialized_state() {
     let Some(client) = connect() else {
         return;
     };
@@ -265,7 +262,7 @@ fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
         reset_doc_for_tests(&mut c, &doc_id).unwrap();
     }
 
-    let replica = ReplicaId::new(b"dirty");
+    let replica = ReplicaId::new(b"restart");
     let first = Operation::insert(
         &replica,
         1,
@@ -287,7 +284,9 @@ fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
     {
         let mut c = client.borrow_mut();
         c.execute(
-            "UPDATE treecrdt_meta SET dirty = TRUE WHERE doc_id = $1",
+            "UPDATE treecrdt_meta \
+             SET replay_lamport = 0, replay_replica = ''::bytea, replay_counter = 0 \
+             WHERE doc_id = $1",
             &[&doc_id],
         )
         .unwrap();
@@ -296,23 +295,21 @@ fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
     let affected = append_ops_with_affected_nodes(&client, &doc_id, &[second]).unwrap();
     assert!(affected.is_empty());
 
-    let (dirty_before_read, replay_lamport, replay_replica, replay_counter) = {
+    let (replay_lamport, replay_replica, replay_counter) = {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty, replay_lamport, replay_replica, replay_counter \
+                "SELECT replay_lamport, replay_replica, replay_counter \
                  FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
         (
-            row.get::<_, bool>(0),
-            row.get::<_, Option<i64>>(1).map(|v| v.max(0) as u64),
-            row.get::<_, Option<Vec<u8>>>(2),
-            row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
+            row.get::<_, Option<i64>>(0).map(|v| v.max(0) as u64),
+            row.get::<_, Option<Vec<u8>>>(1),
+            row.get::<_, Option<i64>>(2).map(|v| v.max(0) as u64),
         )
     };
-    assert!(!dirty_before_read);
     assert_eq!(replay_lamport, Some(0));
     assert_eq!(replay_replica, Some(Vec::new()));
     assert_eq!(replay_counter, Some(0));
@@ -322,19 +319,18 @@ fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
         vec![node(1), node(2)]
     );
 
-    let dirty_after_read = {
+    let replay_after_read = {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty, replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
+                "SELECT replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
-        assert_eq!(row.get::<_, i64>(2).max(0) as u64, 2);
-        assert!(row.get::<_, Option<i64>>(1).is_none());
-        row.get::<_, bool>(0)
+        assert_eq!(row.get::<_, i64>(1).max(0) as u64, 2);
+        row.get::<_, Option<i64>>(0)
     };
-    assert!(!dirty_after_read);
+    assert_eq!(replay_after_read, None);
 }
 
 #[test]

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -196,7 +196,8 @@ fn postgres_backend_out_of_order_append_uses_replay_frontier() {
     );
 
     append_ops(&client, &doc_id, &[second]).unwrap();
-    let affected = append_ops_with_affected_nodes(&client, &doc_id, &[first.clone()]).unwrap();
+    let affected =
+        append_ops_with_affected_nodes(&client, &doc_id, std::slice::from_ref(&first)).unwrap();
     assert!(affected.is_empty());
 
     let (replay_lamport, replay_replica, replay_counter, head_seq_before) = {

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -165,7 +165,95 @@ fn postgres_backend_append_with_affected_nodes_matches_representative_remote_bat
 }
 
 #[test]
-fn postgres_backend_dirty_append_falls_back_to_rebuild_on_read() {
+fn postgres_backend_out_of_order_append_uses_replay_frontier() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    {
+        let mut c = client.borrow_mut();
+        reset_doc_for_tests(&mut c, &doc_id).unwrap();
+    }
+
+    let replica = ReplicaId::new(b"ooo");
+    let second = Operation::insert(
+        &replica,
+        2,
+        2,
+        NodeId::ROOT,
+        node(2),
+        order_key_from_position(1),
+    );
+    let first = Operation::insert(
+        &replica,
+        1,
+        1,
+        NodeId::ROOT,
+        node(1),
+        order_key_from_position(0),
+    );
+
+    append_ops(&client, &doc_id, &[second]).unwrap();
+    let affected = append_ops_with_affected_nodes(&client, &doc_id, &[first.clone()]).unwrap();
+    assert!(affected.is_empty());
+
+    let (dirty_before_read, replay_lamport, replay_replica, replay_counter, head_seq_before) = {
+        let mut c = client.borrow_mut();
+        let row = c
+            .query_one(
+                "SELECT dirty, replay_lamport, replay_replica, replay_counter, head_seq \
+                 FROM treecrdt_meta WHERE doc_id = $1",
+                &[&doc_id],
+            )
+            .unwrap();
+        (
+            row.get::<_, bool>(0),
+            row.get::<_, Option<i64>>(1).map(|v| v.max(0) as u64),
+            row.get::<_, Option<Vec<u8>>>(2),
+            row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
+            row.get::<_, i64>(4).max(0) as u64,
+        )
+    };
+    assert!(!dirty_before_read);
+    assert_eq!(replay_lamport, Some(first.meta.lamport));
+    assert_eq!(
+        replay_replica,
+        Some(first.meta.id.replica.as_bytes().to_vec())
+    );
+    assert_eq!(replay_counter, Some(first.meta.id.counter));
+    assert_eq!(head_seq_before, 1);
+
+    assert_eq!(
+        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
+        vec![node(1), node(2)]
+    );
+
+    let (dirty_after_read, replay_after_read) = {
+        let mut c = client.borrow_mut();
+        let row = c
+            .query_one(
+                "SELECT dirty, replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
+                &[&doc_id],
+            )
+            .unwrap();
+        assert_eq!(row.get::<_, i64>(2).max(0) as u64, 2);
+        (row.get::<_, bool>(0), row.get::<_, Option<i64>>(1))
+    };
+    assert!(!dirty_after_read);
+    assert_eq!(replay_after_read, None);
+
+    let refs = list_op_refs_children(&client, &doc_id, NodeId::ROOT).unwrap();
+    let ops = get_ops_by_op_refs(&client, &doc_id, &refs).unwrap();
+    assert_eq!(
+        ops.iter().map(|op| op.meta.id.counter).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn postgres_backend_legacy_dirty_recovery_is_converted_to_replay_from_start() {
     let Some(client) = connect() else {
         return;
     };
@@ -208,17 +296,26 @@ fn postgres_backend_dirty_append_falls_back_to_rebuild_on_read() {
     let affected = append_ops_with_affected_nodes(&client, &doc_id, &[second]).unwrap();
     assert!(affected.is_empty());
 
-    let dirty_before_read = {
+    let (dirty_before_read, replay_lamport, replay_replica, replay_counter) = {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty FROM treecrdt_meta WHERE doc_id = $1",
+                "SELECT dirty, replay_lamport, replay_replica, replay_counter \
+                 FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
-        row.get::<_, bool>(0)
+        (
+            row.get::<_, bool>(0),
+            row.get::<_, Option<i64>>(1).map(|v| v.max(0) as u64),
+            row.get::<_, Option<Vec<u8>>>(2),
+            row.get::<_, Option<i64>>(3).map(|v| v.max(0) as u64),
+        )
     };
-    assert!(dirty_before_read);
+    assert!(!dirty_before_read);
+    assert_eq!(replay_lamport, Some(0));
+    assert_eq!(replay_replica, Some(Vec::new()));
+    assert_eq!(replay_counter, Some(0));
 
     assert_eq!(
         tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
@@ -229,11 +326,12 @@ fn postgres_backend_dirty_append_falls_back_to_rebuild_on_read() {
         let mut c = client.borrow_mut();
         let row = c
             .query_one(
-                "SELECT dirty, head_seq FROM treecrdt_meta WHERE doc_id = $1",
+                "SELECT dirty, replay_lamport, head_seq FROM treecrdt_meta WHERE doc_id = $1",
                 &[&doc_id],
             )
             .unwrap();
-        assert_eq!(row.get::<_, i64>(1).max(0) as u64, 2);
+        assert_eq!(row.get::<_, i64>(2).max(0) as u64, 2);
+        assert!(row.get::<_, Option<i64>>(1).is_none());
         row.get::<_, bool>(0)
     };
     assert!(!dirty_after_read);

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/doc_id.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/doc_id.rs
@@ -77,8 +77,7 @@ pub(super) unsafe extern "C" fn treecrdt_set_doc_id(
         return;
     }
 
-    // No backfill/migration: callers must set `doc_id` before appending ops so `op_ref`
-    // is always computed at write time.
+    // Callers must set `doc_id` before appending ops so `op_ref` is always computed at write time.
     sqlite_result_int(ctx, 1);
 }
 

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/doc_id.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/doc_id.rs
@@ -71,7 +71,7 @@ pub(super) unsafe extern "C" fn treecrdt_set_doc_id(
     };
 
     // Ensure the materialized tree state is available for direct SQL reads over `tree_nodes`.
-    // This is especially important on reopen, where `tree_meta.dirty = 1` requires a replay.
+    // This is especially important on reopen, where a pending replay frontier requires catch-up.
     if let Err(rc) = ensure_materialized(db) {
         sqlite_result_error_code(ctx, rc);
         return;

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -229,15 +229,14 @@ fn finish_local_core_op(
         post_materialization_ok = false;
     }
     if !post_materialization_ok {
-        let _ = set_tree_meta_replay_frontier(
+        set_tree_meta_replay_frontier(
             session.db,
             &treecrdt_core::MaterializationFrontier {
                 lamport: 0,
                 replica: Vec::new(),
                 counter: 0,
             },
-        )
-        .or_else(|_| set_tree_meta_dirty(session.db, true));
+        )?;
     }
 
     let out = match json_op_from_operation(op) {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -229,7 +229,15 @@ fn finish_local_core_op(
         post_materialization_ok = false;
     }
     if !post_materialization_ok {
-        let _ = set_tree_meta_dirty(session.db, true);
+        let _ = set_tree_meta_replay_frontier(
+            session.db,
+            &treecrdt_core::MaterializationFrontier {
+                lamport: 0,
+                replica: Vec::new(),
+                counter: 0,
+            },
+        )
+        .or_else(|_| set_tree_meta_dirty(session.db, true));
     }
 
     let out = match json_op_from_operation(op) {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -8,7 +8,8 @@ use super::util::{
 };
 use super::*;
 use treecrdt_core::{
-    LamportClock, LocalFinalizePlan, LocalPlacement, Operation, OperationKind, ReplicaId, TreeCrdt,
+    LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor, Operation,
+    OperationKind, ReplicaId, TreeCrdt,
 };
 
 #[derive(serde::Serialize)]
@@ -200,7 +201,7 @@ fn finish_local_core_op(
     let mut next_seq = 0u64;
     let mut head_seq = 0u64;
     match load_tree_meta(session.db) {
-        Ok(meta) => head_seq = meta.head_seq,
+        Ok(meta) => head_seq = meta.state().head_seq(),
         Err(_) => post_materialization_ok = false,
     }
     if post_materialization_ok {
@@ -216,16 +217,15 @@ fn finish_local_core_op(
             Err(_) => post_materialization_ok = false,
         }
     }
-    if post_materialization_ok
-        && update_tree_meta_head(
-            session.db,
-            op.meta.lamport,
-            op.meta.id.replica.as_bytes(),
-            op.meta.id.counter,
-            next_seq,
-        )
-        .is_err()
-    {
+    let head = treecrdt_core::MaterializationHead {
+        at: treecrdt_core::MaterializationKey {
+            lamport: op.meta.lamport,
+            replica: op.meta.id.replica.as_bytes(),
+            counter: op.meta.id.counter,
+        },
+        seq: next_seq,
+    };
+    if post_materialization_ok && update_tree_meta_head(session.db, Some(&head)).is_err() {
         post_materialization_ok = false;
     }
     if !post_materialization_ok {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -5,6 +5,7 @@ use super::payload_store::SqlitePayloadStore;
 use super::schema::set_tree_meta_replay_frontier;
 use super::util::sqlite_err_from_core;
 use super::*;
+use treecrdt_core::MaterializationCursor;
 use treecrdt_core::Storage;
 
 fn parse_node_id(bytes: &[u8]) -> Result<NodeId, c_int> {
@@ -82,32 +83,39 @@ fn json_append_op_to_operation(op: &JsonAppendOp) -> Result<treecrdt_core::Opera
 }
 
 impl treecrdt_core::MaterializationCursor for TreeMeta {
-    fn head_lamport(&self) -> Lamport {
-        self.head_lamport
-    }
+    fn state(&self) -> treecrdt_core::MaterializationState<&[u8]> {
+        let head = if self.head_seq == 0
+            && self.head_lamport == 0
+            && self.head_replica.is_empty()
+            && self.head_counter == 0
+        {
+            None
+        } else {
+            Some(treecrdt_core::MaterializationHead {
+                at: treecrdt_core::MaterializationKey {
+                    lamport: self.head_lamport,
+                    replica: self.head_replica.as_slice(),
+                    counter: self.head_counter,
+                },
+                seq: self.head_seq,
+            })
+        };
+        let replay_from = match (
+            self.replay_lamport,
+            self.replay_replica.as_deref(),
+            self.replay_counter,
+        ) {
+            (Some(lamport), Some(replica), Some(counter)) => {
+                Some(treecrdt_core::MaterializationKey {
+                    lamport,
+                    replica,
+                    counter,
+                })
+            }
+            _ => None,
+        };
 
-    fn head_replica(&self) -> &[u8] {
-        &self.head_replica
-    }
-
-    fn head_counter(&self) -> u64 {
-        self.head_counter
-    }
-
-    fn head_seq(&self) -> u64 {
-        self.head_seq
-    }
-
-    fn replay_lamport(&self) -> Option<Lamport> {
-        self.replay_lamport
-    }
-
-    fn replay_replica(&self) -> Option<&[u8]> {
-        self.replay_replica.as_deref()
-    }
-
-    fn replay_counter(&self) -> Option<u64> {
-        self.replay_counter
+        treecrdt_core::MaterializationState { head, replay_from }
     }
 }
 
@@ -142,7 +150,7 @@ fn materialize_inserted_ops(
 
 pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     let meta = load_tree_meta(db)?;
-    if meta.replay_lamport.is_none() {
+    if meta.state().replay_from.is_none() {
         return Ok(());
     }
     rebuild_materialized(db)
@@ -232,8 +240,13 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     };
 
     if let Some(last) = head {
-        let head_rc =
-            update_tree_meta_head(db, last.lamport, &last.replica, last.counter, last.seq);
+        let head_rc = update_tree_meta_head(
+            db,
+            last.at.lamport,
+            &last.at.replica,
+            last.at.counter,
+            last.seq,
+        );
         if head_rc.is_err() {
             sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
             return head_rc;
@@ -305,7 +318,15 @@ pub(super) fn append_ops_impl(
         &meta,
         inserted_ops,
         |inserted| materialize_inserted_ops(db, doc_id, &meta, &inserted),
-        |head| update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq),
+        |head| {
+            update_tree_meta_head(
+                db,
+                head.at.lamport,
+                &head.at.replica,
+                head.at.counter,
+                head.seq,
+            )
+        },
         |frontier| set_tree_meta_replay_frontier(db, frontier),
     )?;
 

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -82,10 +82,6 @@ fn json_append_op_to_operation(op: &JsonAppendOp) -> Result<treecrdt_core::Opera
 }
 
 impl treecrdt_core::MaterializationCursor for TreeMeta {
-    fn dirty(&self) -> bool {
-        self.dirty
-    }
-
     fn head_lamport(&self) -> Lamport {
         self.head_lamport
     }
@@ -146,7 +142,7 @@ fn materialize_inserted_ops(
 
 pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     let meta = load_tree_meta(db)?;
-    if !meta.dirty && meta.replay_lamport.is_none() {
+    if meta.replay_lamport.is_none() {
         return Ok(());
     }
     rebuild_materialized(db)
@@ -311,8 +307,7 @@ pub(super) fn append_ops_impl(
         |inserted| materialize_inserted_ops(db, doc_id, &meta, &inserted),
         |head| update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq),
         |frontier| set_tree_meta_replay_frontier(db, frontier),
-        || set_tree_meta_dirty(db, true),
-    );
+    )?;
 
     let commit_rc = sqlite_exec(db, commit.as_ptr(), None, null_mut(), null_mut());
     if commit_rc != SQLITE_OK as c_int {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -82,43 +82,6 @@ fn json_append_op_to_operation(op: &JsonAppendOp) -> Result<treecrdt_core::Opera
     })
 }
 
-impl treecrdt_core::MaterializationCursor for TreeMeta {
-    fn state(&self) -> treecrdt_core::MaterializationState<&[u8]> {
-        let head = if self.head_seq == 0
-            && self.head_lamport == 0
-            && self.head_replica.is_empty()
-            && self.head_counter == 0
-        {
-            None
-        } else {
-            Some(treecrdt_core::MaterializationHead {
-                at: treecrdt_core::MaterializationKey {
-                    lamport: self.head_lamport,
-                    replica: self.head_replica.as_slice(),
-                    counter: self.head_counter,
-                },
-                seq: self.head_seq,
-            })
-        };
-        let replay_from = match (
-            self.replay_lamport,
-            self.replay_replica.as_deref(),
-            self.replay_counter,
-        ) {
-            (Some(lamport), Some(replica), Some(counter)) => {
-                Some(treecrdt_core::MaterializationKey {
-                    lamport,
-                    replica,
-                    counter,
-                })
-            }
-            _ => None,
-        };
-
-        treecrdt_core::MaterializationState { head, replay_from }
-    }
-}
-
 fn materialize_inserted_ops(
     db: *mut sqlite3,
     doc_id: &[u8],
@@ -239,24 +202,10 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
         }
     };
 
-    if let Some(last) = head {
-        let head_rc = update_tree_meta_head(
-            db,
-            last.at.lamport,
-            &last.at.replica,
-            last.at.counter,
-            last.seq,
-        );
-        if head_rc.is_err() {
-            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-            return head_rc;
-        }
-    } else {
-        let head_rc = update_tree_meta_head(db, 0, &[], 0, 0);
-        if head_rc.is_err() {
-            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-            return head_rc;
-        }
+    let head_rc = update_tree_meta_head(db, head.as_ref());
+    if head_rc.is_err() {
+        sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
+        return head_rc;
     }
 
     let commit_rc = sqlite_exec(db, commit.as_ptr(), None, null_mut(), null_mut());
@@ -318,15 +267,7 @@ pub(super) fn append_ops_impl(
         &meta,
         inserted_ops,
         |inserted| materialize_inserted_ops(db, doc_id, &meta, &inserted),
-        |head| {
-            update_tree_meta_head(
-                db,
-                head.at.lamport,
-                &head.at.replica,
-                head.at.counter,
-                head.seq,
-            )
-        },
+        |head| update_tree_meta_head(db, Some(head)),
         |frontier| set_tree_meta_replay_frontier(db, frontier),
     )?;
 

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -116,7 +116,7 @@ pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     if meta.state().replay_from.is_none() {
         return Ok(());
     }
-    rebuild_materialized(db)
+    catch_up_materialized_from_frontier(db)
 }
 
 pub(super) unsafe extern "C" fn treecrdt_ensure_materialized(
@@ -139,7 +139,7 @@ pub(super) unsafe extern "C" fn treecrdt_ensure_materialized(
     }
 }
 
-fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
+fn catch_up_materialized_from_frontier(db: *mut sqlite3) -> Result<(), c_int> {
     let begin = CString::new("SAVEPOINT treecrdt_materialize").expect("static");
     let commit = CString::new("RELEASE treecrdt_materialize").expect("static");
     let rollback = CString::new("ROLLBACK TO treecrdt_materialize; RELEASE treecrdt_materialize")
@@ -151,7 +151,8 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
 
     let doc_id = load_doc_id(db).unwrap_or(None).unwrap_or_default();
 
-    // Rebuild materialized state by replaying the op-log through core semantics.
+    // Catch materialized state up from the pending frontier by replaying the op-log through core
+    // semantics.
     use treecrdt_core::{catch_up_materialized_state, LamportClock, ReplicaId};
     let storage = super::op_storage::SqliteOpStorage::with_doc_id(db, doc_id.clone());
     let meta = match load_tree_meta(db) {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -2,6 +2,7 @@ use super::append::JsonAppendOp;
 use super::node_store::SqliteNodeStore;
 use super::op_index::SqliteParentOpIndex;
 use super::payload_store::SqlitePayloadStore;
+use super::schema::set_tree_meta_replay_frontier;
 use super::util::sqlite_err_from_core;
 use super::*;
 use treecrdt_core::Storage;
@@ -100,6 +101,18 @@ impl treecrdt_core::MaterializationCursor for TreeMeta {
     fn head_seq(&self) -> u64 {
         self.head_seq
     }
+
+    fn replay_lamport(&self) -> Option<Lamport> {
+        self.replay_lamport
+    }
+
+    fn replay_replica(&self) -> Option<&[u8]> {
+        self.replay_replica.as_deref()
+    }
+
+    fn replay_counter(&self) -> Option<u64> {
+        self.replay_counter
+    }
 }
 
 fn materialize_inserted_ops(
@@ -133,7 +146,7 @@ fn materialize_inserted_ops(
 
 pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     let meta = load_tree_meta(db)?;
-    if !meta.dirty {
+    if !meta.dirty && meta.replay_lamport.is_none() {
         return Ok(());
     }
     rebuild_materialized(db)
@@ -172,52 +185,59 @@ fn rebuild_materialized(db: *mut sqlite3) -> Result<(), c_int> {
     let doc_id = load_doc_id(db).unwrap_or(None).unwrap_or_default();
 
     // Rebuild materialized state by replaying the op-log through core semantics.
-    use treecrdt_core::{LamportClock, ReplicaId, TreeCrdt};
-    let node_store = match SqliteNodeStore::prepare(db) {
-        Ok(store) => store,
-        Err(_) => {
-            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-            return Err(SQLITE_ERROR as c_int);
-        }
-    };
-    let payload_store = match SqlitePayloadStore::prepare(db) {
-        Ok(store) => store,
-        Err(_) => {
-            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-            return Err(SQLITE_ERROR as c_int);
-        }
-    };
+    use treecrdt_core::{catch_up_materialized_state, LamportClock, ReplicaId};
     let storage = super::op_storage::SqliteOpStorage::with_doc_id(db, doc_id.clone());
-    let mut op_index = match SqliteParentOpIndex::prepare(db, doc_id.clone()) {
+    let meta = match load_tree_meta(db) {
+        Ok(meta) => meta,
+        Err(rc) => {
+            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
+            return Err(rc);
+        }
+    };
+    let nodes = match SqliteNodeStore::prepare(db) {
+        Ok(store) => store,
+        Err(_) => {
+            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
+            return Err(SQLITE_ERROR as c_int);
+        }
+    };
+    let payloads = match SqlitePayloadStore::prepare(db) {
+        Ok(store) => store,
+        Err(_) => {
+            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
+            return Err(SQLITE_ERROR as c_int);
+        }
+    };
+    let index = match SqliteParentOpIndex::prepare(db, doc_id.clone()) {
+        Ok(index) => index,
+        Err(_) => {
+            sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
+            return Err(SQLITE_ERROR as c_int);
+        }
+    };
+    let head = match catch_up_materialized_state(
+        storage,
+        treecrdt_core::PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"sqlite-ext"),
+            clock: LamportClock::default(),
+            nodes,
+            payloads,
+            index,
+        },
+        &meta,
+        |_| Ok(()),
+        |_| Ok(()),
+    ) {
         Ok(v) => v,
         Err(_) => {
             sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
             return Err(SQLITE_ERROR as c_int);
         }
     };
-    let mut crdt = TreeCrdt::with_stores(
-        ReplicaId::new(b"sqlite-ext"),
-        storage,
-        LamportClock::default(),
-        node_store,
-        payload_store,
-    )
-    .map_err(|_| SQLITE_ERROR as c_int)?;
-    if crdt.replay_from_storage_with_materialization(&mut op_index).is_err() {
-        sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-        return Err(SQLITE_ERROR as c_int);
-    }
 
-    // Update meta head + seq.
-    let seq = crdt.log_len() as u64;
-    if let Some(last) = crdt.head_op() {
-        let head_rc = update_tree_meta_head(
-            db,
-            last.meta.lamport,
-            last.meta.id.replica.as_bytes(),
-            last.meta.id.counter,
-            seq,
-        );
+    if let Some(last) = head {
+        let head_rc =
+            update_tree_meta_head(db, last.lamport, &last.replica, last.counter, last.seq);
         if head_rc.is_err() {
             sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
             return head_rc;
@@ -290,6 +310,7 @@ pub(super) fn append_ops_impl(
         inserted_ops,
         |inserted| materialize_inserted_ops(db, doc_id, &meta, &inserted),
         |head| update_tree_meta_head(db, head.lamport, &head.replica, head.counter, head.seq),
+        |frontier| set_tree_meta_replay_frontier(db, frontier),
         || set_tree_meta_dirty(db, true),
     );
 

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
@@ -26,10 +26,6 @@ pub(super) struct SqliteOpStorage {
 }
 
 impl SqliteOpStorage {
-    pub(super) fn new(db: *mut sqlite3) -> Self {
-        Self { db, doc_id: None }
-    }
-
     pub(super) fn with_doc_id(db: *mut sqlite3, doc_id: Vec<u8>) -> Self {
         Self {
             db,

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -368,7 +368,7 @@ CREATE INDEX IF NOT EXISTS idx_oprefs_children_parent_seq ON oprefs_children(par
     }
 
     // If this is a fresh database with no ops yet, seed the materialized root so appends can
-    // maintain state incrementally without a full rebuild.
+    // maintain state incrementally without a full catch-up pass.
     let mut ops_count: i64 = 0;
     {
         let sql = CString::new("SELECT COUNT(*) FROM ops").expect("count ops sql");
@@ -383,7 +383,7 @@ CREATE INDEX IF NOT EXISTS idx_oprefs_children_parent_seq ON oprefs_children(par
         }
     }
     if ops_count == 0 {
-        // Ensure ROOT exists even before first rebuild.
+        // Ensure ROOT exists even before first catch-up.
         let _ = {
             let sql = CString::new(
                 "INSERT OR IGNORE INTO tree_nodes(node,parent,order_key,tombstone) VALUES (?1,NULL,X'',0)",

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -220,115 +220,6 @@ pub(super) fn update_tree_meta_head(
     Ok(())
 }
 
-fn tree_meta_has_column(db: *mut sqlite3, column: &str) -> Result<bool, c_int> {
-    let sql = CString::new("PRAGMA table_info(tree_meta)").expect("tree_meta pragma sql");
-    let mut stmt: *mut sqlite3_stmt = null_mut();
-    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
-    if rc != SQLITE_OK as c_int {
-        return Err(rc);
-    }
-
-    let mut found = false;
-    loop {
-        let step_rc = unsafe { sqlite_step(stmt) };
-        if step_rc == SQLITE_ROW as c_int {
-            let ptr = unsafe { sqlite_column_text(stmt, 1) } as *const u8;
-            let len = unsafe { sqlite_column_bytes(stmt, 1) } as usize;
-            if ptr.is_null() {
-                continue;
-            }
-            let name =
-                std::str::from_utf8(unsafe { slice::from_raw_parts(ptr, len) }).unwrap_or("");
-            if name == column {
-                found = true;
-                break;
-            }
-        } else if step_rc == SQLITE_DONE as c_int {
-            break;
-        } else {
-            unsafe { sqlite_finalize(stmt) };
-            return Err(step_rc);
-        }
-    }
-
-    let finalize_rc = unsafe { sqlite_finalize(stmt) };
-    if finalize_rc != SQLITE_OK as c_int {
-        return Err(finalize_rc);
-    }
-    Ok(found)
-}
-
-fn ensure_tree_meta_replay_columns(db: *mut sqlite3) -> Result<(), c_int> {
-    for (column, sql_type) in [
-        ("replay_lamport", "INTEGER"),
-        ("replay_replica", "BLOB"),
-        ("replay_counter", "INTEGER"),
-    ] {
-        if tree_meta_has_column(db, column)? {
-            continue;
-        }
-        let sql = CString::new(format!(
-            "ALTER TABLE tree_meta ADD COLUMN {column} {sql_type}"
-        ))
-        .expect("tree_meta alter sql");
-        let rc = sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut());
-        if rc != SQLITE_OK as c_int {
-            return Err(rc);
-        }
-    }
-    Ok(())
-}
-
-fn drop_tree_meta_dirty_column(db: *mut sqlite3) -> Result<(), c_int> {
-    if !tree_meta_has_column(db, "dirty")? {
-        return Ok(());
-    }
-
-    let sql = CString::new(
-        r#"
-CREATE TABLE tree_meta_new (
-  id INTEGER PRIMARY KEY CHECK (id = 1),
-  head_lamport INTEGER NOT NULL DEFAULT 0,
-  head_replica BLOB NOT NULL DEFAULT X'',
-  head_counter INTEGER NOT NULL DEFAULT 0,
-  head_seq INTEGER NOT NULL DEFAULT 0,
-  replay_lamport INTEGER,
-  replay_replica BLOB,
-  replay_counter INTEGER
-);
-INSERT INTO tree_meta_new(
-  id,
-  head_lamport,
-  head_replica,
-  head_counter,
-  head_seq,
-  replay_lamport,
-  replay_replica,
-  replay_counter
-)
-SELECT
-  id,
-  head_lamport,
-  head_replica,
-  head_counter,
-  head_seq,
-  replay_lamport,
-  replay_replica,
-  replay_counter
-FROM tree_meta;
-DROP TABLE tree_meta;
-ALTER TABLE tree_meta_new RENAME TO tree_meta;
-INSERT OR IGNORE INTO tree_meta(id) VALUES (1);
-"#,
-    )
-    .expect("tree_meta drop dirty sql");
-    let rc = sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut());
-    if rc != SQLITE_OK as c_int {
-        return Err(rc);
-    }
-    Ok(())
-}
-
 pub(super) fn ensure_schema(db: *mut sqlite3) -> Result<(), c_int> {
     ensure_api_initialized()?;
 
@@ -355,7 +246,7 @@ CREATE TABLE IF NOT EXISTS ops (
   PRIMARY KEY (replica, counter)
 );
 "#;
-    // Materialized tree state + indexes (v1).
+    // Materialized tree state + indexes.
     const TREE_META: &str = r#"
 CREATE TABLE IF NOT EXISTS tree_meta (
   id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -418,8 +309,6 @@ CREATE TABLE IF NOT EXISTS tree_payload (
     if rc_tree_meta != SQLITE_OK as c_int {
         return Err(rc_tree_meta);
     }
-    ensure_tree_meta_replay_columns(db)?;
-    drop_tree_meta_dirty_column(db)?;
     let rc_nodes = {
         let sql = CString::new(TREE_NODES).expect("tree_nodes schema");
         sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -5,19 +5,19 @@ use std::os::raw::{c_int, c_void};
 use std::ptr::null_mut;
 use std::slice;
 
-use treecrdt_core::Lamport;
+use treecrdt_core::{
+    Lamport, MaterializationCursor, MaterializationHead, MaterializationKey, MaterializationState,
+};
 
 pub(super) const ROOT_NODE_ID: [u8; 16] = [0u8; 16];
 
 #[derive(Clone, Debug)]
-pub(super) struct TreeMeta {
-    pub(super) head_lamport: Lamport,
-    pub(super) head_replica: Vec<u8>,
-    pub(super) head_counter: u64,
-    pub(super) head_seq: u64,
-    pub(super) replay_lamport: Option<Lamport>,
-    pub(super) replay_replica: Option<Vec<u8>>,
-    pub(super) replay_counter: Option<u64>,
+pub(super) struct TreeMeta(MaterializationState);
+
+impl MaterializationCursor for TreeMeta {
+    fn state(&self) -> MaterializationState<&[u8]> {
+        self.0.as_borrowed()
+    }
 }
 
 pub(super) fn load_doc_id(db: *mut sqlite3) -> Result<Option<Vec<u8>>, c_int> {
@@ -111,15 +111,29 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
         return Err(finalize_rc);
     }
 
-    Ok(TreeMeta {
-        head_lamport,
-        head_replica,
-        head_counter,
-        head_seq,
-        replay_lamport,
-        replay_replica,
-        replay_counter,
-    })
+    let head = if head_seq == 0 && head_lamport == 0 && head_replica.is_empty() && head_counter == 0
+    {
+        None
+    } else {
+        Some(MaterializationHead {
+            at: MaterializationKey {
+                lamport: head_lamport,
+                replica: head_replica,
+                counter: head_counter,
+            },
+            seq: head_seq,
+        })
+    };
+    let replay_from = match (replay_lamport, replay_replica, replay_counter) {
+        (Some(lamport), Some(replica), Some(counter)) => Some(MaterializationKey {
+            lamport,
+            replica,
+            counter,
+        }),
+        _ => None,
+    };
+
+    Ok(TreeMeta(MaterializationState { head, replay_from }))
 }
 
 pub(super) fn set_tree_meta_replay_frontier(
@@ -166,13 +180,19 @@ pub(super) fn set_tree_meta_replay_frontier(
     Ok(())
 }
 
-pub(super) fn update_tree_meta_head(
+pub(super) fn update_tree_meta_head<R: AsRef<[u8]>>(
     db: *mut sqlite3,
-    lamport: Lamport,
-    replica: &[u8],
-    counter: u64,
-    seq: u64,
+    head: Option<&MaterializationHead<R>>,
 ) -> Result<(), c_int> {
+    let (lamport, replica, counter, seq): (Lamport, &[u8], u64, u64) = match head {
+        Some(head) => (
+            head.at.lamport,
+            head.at.replica.as_ref(),
+            head.at.counter,
+            head.seq,
+        ),
+        None => (0, &[], 0, 0),
+    };
     let sql = CString::new(
         "UPDATE tree_meta \
          SET head_lamport = ?1, \

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -11,7 +11,6 @@ pub(super) const ROOT_NODE_ID: [u8; 16] = [0u8; 16];
 
 #[derive(Clone, Debug)]
 pub(super) struct TreeMeta {
-    pub(super) dirty: bool,
     pub(super) head_lamport: Lamport,
     pub(super) head_replica: Vec<u8>,
     pub(super) head_counter: u64,
@@ -58,7 +57,7 @@ pub(super) fn load_doc_id(db: *mut sqlite3) -> Result<Option<Vec<u8>>, c_int> {
 
 pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
     let sql = CString::new(
-        "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+        "SELECT head_lamport, head_replica, head_counter, head_seq, \
                 replay_lamport, replay_replica, replay_counter \
          FROM tree_meta WHERE id = 1 LIMIT 1",
     )
@@ -75,37 +74,36 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
         return Err(SQLITE_ERROR as c_int);
     }
 
-    let dirty = unsafe { sqlite_column_int64(stmt, 0) } != 0;
-    let head_lamport = unsafe { sqlite_column_int64(stmt, 1) } as Lamport;
-    let rep_ptr = unsafe { sqlite_column_blob(stmt, 2) } as *const u8;
-    let rep_len = unsafe { sqlite_column_bytes(stmt, 2) } as usize;
+    let head_lamport = unsafe { sqlite_column_int64(stmt, 0) } as Lamport;
+    let rep_ptr = unsafe { sqlite_column_blob(stmt, 1) } as *const u8;
+    let rep_len = unsafe { sqlite_column_bytes(stmt, 1) } as usize;
     let head_replica = if rep_ptr.is_null() || rep_len == 0 {
         Vec::new()
     } else {
         unsafe { slice::from_raw_parts(rep_ptr, rep_len) }.to_vec()
     };
-    let head_counter = unsafe { sqlite_column_int64(stmt, 3) } as u64;
-    let head_seq = unsafe { sqlite_column_int64(stmt, 4) } as u64;
-    let replay_lamport = if unsafe { sqlite_column_type(stmt, 5) } == SQLITE_NULL as c_int {
+    let head_counter = unsafe { sqlite_column_int64(stmt, 2) } as u64;
+    let head_seq = unsafe { sqlite_column_int64(stmt, 3) } as u64;
+    let replay_lamport = if unsafe { sqlite_column_type(stmt, 4) } == SQLITE_NULL as c_int {
         None
     } else {
-        Some(unsafe { sqlite_column_int64(stmt, 5).max(0) as Lamport })
+        Some(unsafe { sqlite_column_int64(stmt, 4).max(0) as Lamport })
     };
-    let replay_replica = if unsafe { sqlite_column_type(stmt, 6) } == SQLITE_NULL as c_int {
+    let replay_replica = if unsafe { sqlite_column_type(stmt, 5) } == SQLITE_NULL as c_int {
         None
     } else {
-        let ptr = unsafe { sqlite_column_blob(stmt, 6) } as *const u8;
-        let len = unsafe { sqlite_column_bytes(stmt, 6) } as usize;
+        let ptr = unsafe { sqlite_column_blob(stmt, 5) } as *const u8;
+        let len = unsafe { sqlite_column_bytes(stmt, 5) } as usize;
         Some(if ptr.is_null() || len == 0 {
             Vec::new()
         } else {
             unsafe { slice::from_raw_parts(ptr, len) }.to_vec()
         })
     };
-    let replay_counter = if unsafe { sqlite_column_type(stmt, 7) } == SQLITE_NULL as c_int {
+    let replay_counter = if unsafe { sqlite_column_type(stmt, 6) } == SQLITE_NULL as c_int {
         None
     } else {
-        Some(unsafe { sqlite_column_int64(stmt, 7).max(0) as u64 })
+        Some(unsafe { sqlite_column_int64(stmt, 6).max(0) as u64 })
     };
 
     let finalize_rc = unsafe { sqlite_finalize(stmt) };
@@ -114,7 +112,6 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
     }
 
     Ok(TreeMeta {
-        dirty,
         head_lamport,
         head_replica,
         head_counter,
@@ -125,43 +122,13 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
     })
 }
 
-pub(super) fn set_tree_meta_dirty(db: *mut sqlite3, dirty: bool) -> Result<(), c_int> {
-    let sql = CString::new(
-        "UPDATE tree_meta \
-         SET dirty = ?1, replay_lamport = NULL, replay_replica = NULL, replay_counter = NULL \
-         WHERE id = 1",
-    )
-    .expect("tree meta dirty sql");
-    let mut stmt: *mut sqlite3_stmt = null_mut();
-    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
-    if rc != SQLITE_OK as c_int {
-        return Err(rc);
-    }
-
-    let bind_rc = unsafe { sqlite_bind_int64(stmt, 1, if dirty { 1 } else { 0 }) };
-    if bind_rc != SQLITE_OK as c_int {
-        unsafe { sqlite_finalize(stmt) };
-        return Err(bind_rc);
-    }
-
-    let step_rc = unsafe { sqlite_step(stmt) };
-    let finalize_rc = unsafe { sqlite_finalize(stmt) };
-    if step_rc != SQLITE_DONE as c_int {
-        return Err(step_rc);
-    }
-    if finalize_rc != SQLITE_OK as c_int {
-        return Err(finalize_rc);
-    }
-    Ok(())
-}
-
 pub(super) fn set_tree_meta_replay_frontier(
     db: *mut sqlite3,
     frontier: &treecrdt_core::MaterializationFrontier,
 ) -> Result<(), c_int> {
     let sql = CString::new(
         "UPDATE tree_meta \
-         SET dirty = 0, replay_lamport = ?1, replay_replica = ?2, replay_counter = ?3 \
+         SET replay_lamport = ?1, replay_replica = ?2, replay_counter = ?3 \
          WHERE id = 1",
     )
     .expect("tree meta replay sql");
@@ -208,8 +175,7 @@ pub(super) fn update_tree_meta_head(
 ) -> Result<(), c_int> {
     let sql = CString::new(
         "UPDATE tree_meta \
-         SET dirty = 0, \
-             head_lamport = ?1, \
+         SET head_lamport = ?1, \
              head_replica = ?2, \
              head_counter = ?3, \
              head_seq = ?4, \
@@ -313,6 +279,56 @@ fn ensure_tree_meta_replay_columns(db: *mut sqlite3) -> Result<(), c_int> {
     Ok(())
 }
 
+fn drop_tree_meta_dirty_column(db: *mut sqlite3) -> Result<(), c_int> {
+    if !tree_meta_has_column(db, "dirty")? {
+        return Ok(());
+    }
+
+    let sql = CString::new(
+        r#"
+CREATE TABLE tree_meta_new (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  head_lamport INTEGER NOT NULL DEFAULT 0,
+  head_replica BLOB NOT NULL DEFAULT X'',
+  head_counter INTEGER NOT NULL DEFAULT 0,
+  head_seq INTEGER NOT NULL DEFAULT 0,
+  replay_lamport INTEGER,
+  replay_replica BLOB,
+  replay_counter INTEGER
+);
+INSERT INTO tree_meta_new(
+  id,
+  head_lamport,
+  head_replica,
+  head_counter,
+  head_seq,
+  replay_lamport,
+  replay_replica,
+  replay_counter
+)
+SELECT
+  id,
+  head_lamport,
+  head_replica,
+  head_counter,
+  head_seq,
+  replay_lamport,
+  replay_replica,
+  replay_counter
+FROM tree_meta;
+DROP TABLE tree_meta;
+ALTER TABLE tree_meta_new RENAME TO tree_meta;
+INSERT OR IGNORE INTO tree_meta(id) VALUES (1);
+"#,
+    )
+    .expect("tree_meta drop dirty sql");
+    let rc = sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(rc);
+    }
+    Ok(())
+}
+
 pub(super) fn ensure_schema(db: *mut sqlite3) -> Result<(), c_int> {
     ensure_api_initialized()?;
 
@@ -343,7 +359,6 @@ CREATE TABLE IF NOT EXISTS ops (
     const TREE_META: &str = r#"
 CREATE TABLE IF NOT EXISTS tree_meta (
   id INTEGER PRIMARY KEY CHECK (id = 1),
-  dirty INTEGER NOT NULL DEFAULT 1,
   head_lamport INTEGER NOT NULL DEFAULT 0,
   head_replica BLOB NOT NULL DEFAULT X'',
   head_counter INTEGER NOT NULL DEFAULT 0,
@@ -404,6 +419,7 @@ CREATE TABLE IF NOT EXISTS tree_payload (
         return Err(rc_tree_meta);
     }
     ensure_tree_meta_replay_columns(db)?;
+    drop_tree_meta_dirty_column(db)?;
     let rc_nodes = {
         let sql = CString::new(TREE_NODES).expect("tree_nodes schema");
         sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut())
@@ -442,7 +458,7 @@ CREATE INDEX IF NOT EXISTS idx_oprefs_children_parent_seq ON oprefs_children(par
         return Err(rc_idx);
     }
 
-    // If this is a fresh database with no ops yet, mark materialization clean so appends can
+    // If this is a fresh database with no ops yet, seed the materialized root so appends can
     // maintain state incrementally without a full rebuild.
     let mut ops_count: i64 = 0;
     {
@@ -458,7 +474,6 @@ CREATE INDEX IF NOT EXISTS idx_oprefs_children_parent_seq ON oprefs_children(par
         }
     }
     if ops_count == 0 {
-        let _ = set_tree_meta_dirty(db, false);
         // Ensure ROOT exists even before first rebuild.
         let _ = {
             let sql = CString::new(

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -16,6 +16,9 @@ pub(super) struct TreeMeta {
     pub(super) head_replica: Vec<u8>,
     pub(super) head_counter: u64,
     pub(super) head_seq: u64,
+    pub(super) replay_lamport: Option<Lamport>,
+    pub(super) replay_replica: Option<Vec<u8>>,
+    pub(super) replay_counter: Option<u64>,
 }
 
 pub(super) fn load_doc_id(db: *mut sqlite3) -> Result<Option<Vec<u8>>, c_int> {
@@ -55,7 +58,8 @@ pub(super) fn load_doc_id(db: *mut sqlite3) -> Result<Option<Vec<u8>>, c_int> {
 
 pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
     let sql = CString::new(
-        "SELECT dirty, head_lamport, head_replica, head_counter, head_seq \
+        "SELECT dirty, head_lamport, head_replica, head_counter, head_seq, \
+                replay_lamport, replay_replica, replay_counter \
          FROM tree_meta WHERE id = 1 LIMIT 1",
     )
     .expect("tree meta sql");
@@ -82,6 +86,27 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
     };
     let head_counter = unsafe { sqlite_column_int64(stmt, 3) } as u64;
     let head_seq = unsafe { sqlite_column_int64(stmt, 4) } as u64;
+    let replay_lamport = if unsafe { sqlite_column_type(stmt, 5) } == SQLITE_NULL as c_int {
+        None
+    } else {
+        Some(unsafe { sqlite_column_int64(stmt, 5).max(0) as Lamport })
+    };
+    let replay_replica = if unsafe { sqlite_column_type(stmt, 6) } == SQLITE_NULL as c_int {
+        None
+    } else {
+        let ptr = unsafe { sqlite_column_blob(stmt, 6) } as *const u8;
+        let len = unsafe { sqlite_column_bytes(stmt, 6) } as usize;
+        Some(if ptr.is_null() || len == 0 {
+            Vec::new()
+        } else {
+            unsafe { slice::from_raw_parts(ptr, len) }.to_vec()
+        })
+    };
+    let replay_counter = if unsafe { sqlite_column_type(stmt, 7) } == SQLITE_NULL as c_int {
+        None
+    } else {
+        Some(unsafe { sqlite_column_int64(stmt, 7).max(0) as u64 })
+    };
 
     let finalize_rc = unsafe { sqlite_finalize(stmt) };
     if finalize_rc != SQLITE_OK as c_int {
@@ -94,12 +119,19 @@ pub(super) fn load_tree_meta(db: *mut sqlite3) -> Result<TreeMeta, c_int> {
         head_replica,
         head_counter,
         head_seq,
+        replay_lamport,
+        replay_replica,
+        replay_counter,
     })
 }
 
 pub(super) fn set_tree_meta_dirty(db: *mut sqlite3, dirty: bool) -> Result<(), c_int> {
-    let sql =
-        CString::new("UPDATE tree_meta SET dirty = ?1 WHERE id = 1").expect("tree meta dirty sql");
+    let sql = CString::new(
+        "UPDATE tree_meta \
+         SET dirty = ?1, replay_lamport = NULL, replay_replica = NULL, replay_counter = NULL \
+         WHERE id = 1",
+    )
+    .expect("tree meta dirty sql");
     let mut stmt: *mut sqlite3_stmt = null_mut();
     let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
     if rc != SQLITE_OK as c_int {
@@ -123,6 +155,50 @@ pub(super) fn set_tree_meta_dirty(db: *mut sqlite3, dirty: bool) -> Result<(), c
     Ok(())
 }
 
+pub(super) fn set_tree_meta_replay_frontier(
+    db: *mut sqlite3,
+    frontier: &treecrdt_core::MaterializationFrontier,
+) -> Result<(), c_int> {
+    let sql = CString::new(
+        "UPDATE tree_meta \
+         SET dirty = 0, replay_lamport = ?1, replay_replica = ?2, replay_counter = ?3 \
+         WHERE id = 1",
+    )
+    .expect("tree meta replay sql");
+    let mut stmt: *mut sqlite3_stmt = null_mut();
+    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(rc);
+    }
+
+    let mut bind_err = false;
+    unsafe {
+        bind_err |= sqlite_bind_int64(stmt, 1, frontier.lamport as i64) != SQLITE_OK as c_int;
+        bind_err |= sqlite_bind_blob(
+            stmt,
+            2,
+            frontier.replica.as_ptr() as *const c_void,
+            frontier.replica.len() as c_int,
+            None,
+        ) != SQLITE_OK as c_int;
+        bind_err |= sqlite_bind_int64(stmt, 3, frontier.counter as i64) != SQLITE_OK as c_int;
+    }
+    if bind_err {
+        unsafe { sqlite_finalize(stmt) };
+        return Err(SQLITE_ERROR as c_int);
+    }
+
+    let step_rc = unsafe { sqlite_step(stmt) };
+    let finalize_rc = unsafe { sqlite_finalize(stmt) };
+    if step_rc != SQLITE_DONE as c_int {
+        return Err(step_rc);
+    }
+    if finalize_rc != SQLITE_OK as c_int {
+        return Err(finalize_rc);
+    }
+    Ok(())
+}
+
 pub(super) fn update_tree_meta_head(
     db: *mut sqlite3,
     lamport: Lamport,
@@ -132,7 +208,14 @@ pub(super) fn update_tree_meta_head(
 ) -> Result<(), c_int> {
     let sql = CString::new(
         "UPDATE tree_meta \
-         SET dirty = 0, head_lamport = ?1, head_replica = ?2, head_counter = ?3, head_seq = ?4 \
+         SET dirty = 0, \
+             head_lamport = ?1, \
+             head_replica = ?2, \
+             head_counter = ?3, \
+             head_seq = ?4, \
+             replay_lamport = NULL, \
+             replay_replica = NULL, \
+             replay_counter = NULL \
          WHERE id = 1",
     )
     .expect("tree meta head sql");
@@ -171,6 +254,65 @@ pub(super) fn update_tree_meta_head(
     Ok(())
 }
 
+fn tree_meta_has_column(db: *mut sqlite3, column: &str) -> Result<bool, c_int> {
+    let sql = CString::new("PRAGMA table_info(tree_meta)").expect("tree_meta pragma sql");
+    let mut stmt: *mut sqlite3_stmt = null_mut();
+    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(rc);
+    }
+
+    let mut found = false;
+    loop {
+        let step_rc = unsafe { sqlite_step(stmt) };
+        if step_rc == SQLITE_ROW as c_int {
+            let ptr = unsafe { sqlite_column_text(stmt, 1) } as *const u8;
+            let len = unsafe { sqlite_column_bytes(stmt, 1) } as usize;
+            if ptr.is_null() {
+                continue;
+            }
+            let name =
+                std::str::from_utf8(unsafe { slice::from_raw_parts(ptr, len) }).unwrap_or("");
+            if name == column {
+                found = true;
+                break;
+            }
+        } else if step_rc == SQLITE_DONE as c_int {
+            break;
+        } else {
+            unsafe { sqlite_finalize(stmt) };
+            return Err(step_rc);
+        }
+    }
+
+    let finalize_rc = unsafe { sqlite_finalize(stmt) };
+    if finalize_rc != SQLITE_OK as c_int {
+        return Err(finalize_rc);
+    }
+    Ok(found)
+}
+
+fn ensure_tree_meta_replay_columns(db: *mut sqlite3) -> Result<(), c_int> {
+    for (column, sql_type) in [
+        ("replay_lamport", "INTEGER"),
+        ("replay_replica", "BLOB"),
+        ("replay_counter", "INTEGER"),
+    ] {
+        if tree_meta_has_column(db, column)? {
+            continue;
+        }
+        let sql = CString::new(format!(
+            "ALTER TABLE tree_meta ADD COLUMN {column} {sql_type}"
+        ))
+        .expect("tree_meta alter sql");
+        let rc = sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut());
+        if rc != SQLITE_OK as c_int {
+            return Err(rc);
+        }
+    }
+    Ok(())
+}
+
 pub(super) fn ensure_schema(db: *mut sqlite3) -> Result<(), c_int> {
     ensure_api_initialized()?;
 
@@ -205,7 +347,10 @@ CREATE TABLE IF NOT EXISTS tree_meta (
   head_lamport INTEGER NOT NULL DEFAULT 0,
   head_replica BLOB NOT NULL DEFAULT X'',
   head_counter INTEGER NOT NULL DEFAULT 0,
-  head_seq INTEGER NOT NULL DEFAULT 0
+  head_seq INTEGER NOT NULL DEFAULT 0,
+  replay_lamport INTEGER,
+  replay_replica BLOB,
+  replay_counter INTEGER
 );
 INSERT OR IGNORE INTO tree_meta(id) VALUES (1);
 "#;
@@ -258,6 +403,7 @@ CREATE TABLE IF NOT EXISTS tree_payload (
     if rc_tree_meta != SQLITE_OK as c_int {
         return Err(rc_tree_meta);
     }
+    ensure_tree_meta_replay_columns(db)?;
     let rc_nodes = {
         let sql = CString::new(TREE_NODES).expect("tree_nodes schema");
         sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut())

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -29,6 +29,15 @@ fn read_tree_meta(conn: &Connection) -> (i64, i64, Vec<u8>, i64, i64) {
     .unwrap()
 }
 
+fn read_replay_frontier(conn: &Connection) -> (Option<i64>, Option<Vec<u8>>, Option<i64>) {
+    conn.query_row(
+        "SELECT replay_lamport, replay_replica, replay_counter FROM tree_meta WHERE id = 1",
+        [],
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    )
+    .unwrap()
+}
+
 fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (Vec<Vec<u8>>, i64) {
     let json = serde_json::to_string(ops).unwrap();
     let affected_json: String = conn
@@ -366,7 +375,71 @@ fn remote_append_representative_batch_matches_postgres_shape() {
 }
 
 #[test]
-fn remote_append_dirty_fallback_rebuilds_on_ensure_materialized() {
+fn remote_append_out_of_order_uses_replay_frontier() {
+    let conn = setup_conn();
+
+    let root = node_bytes(0);
+    let second = JsonOp {
+        replica: b"ooo".to_vec(),
+        counter: 2,
+        lamport: 2,
+        kind: "insert".into(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node_bytes(2).as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some((2u16).to_be_bytes().to_vec()),
+        known_state: None,
+        payload: None,
+    };
+    let first = JsonOp {
+        replica: b"ooo".to_vec(),
+        counter: 1,
+        lamport: 1,
+        kind: "insert".into(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node_bytes(1).as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some((1u16).to_be_bytes().to_vec()),
+        known_state: None,
+        payload: None,
+    };
+
+    append_ops_json(&conn, &[second]);
+    let (affected, _) = append_ops_json(&conn, &[first.clone()]);
+    assert!(affected.is_empty());
+
+    let (dirty, _, _, _, head_seq_before) = read_tree_meta(&conn);
+    let (replay_lamport, replay_replica, replay_counter) = read_replay_frontier(&conn);
+    assert_eq!(dirty, 0);
+    assert_eq!(head_seq_before, 1);
+    assert_eq!(replay_lamport, Some(first.lamport as i64));
+    assert_eq!(replay_replica, Some(first.replica.clone()));
+    assert_eq!(replay_counter, Some(first.counter as i64));
+
+    let _: i64 = conn
+        .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
+            row.get(0)
+        })
+        .unwrap();
+
+    assert_eq!(
+        visible_children(&conn, &root),
+        vec![node_bytes(1), node_bytes(2)]
+    );
+    let (dirty_after, _, _, _, head_seq_after) = read_tree_meta(&conn);
+    assert_eq!(dirty_after, 0);
+    assert_eq!(head_seq_after, 2);
+    assert_eq!(read_replay_frontier(&conn), (None, None, None));
+
+    let ops = ops_by_oprefs(&conn, &oprefs_children(&conn, &root));
+    assert_eq!(
+        ops.iter().map(|op| op.counter).collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+}
+
+#[test]
+fn remote_append_legacy_dirty_recovery_converts_to_replay_from_start() {
     let conn = setup_conn();
 
     let root = node_bytes(0);
@@ -400,7 +473,11 @@ fn remote_append_dirty_fallback_rebuilds_on_ensure_materialized() {
 
     let (affected, _) = append_ops_json(&conn, &[second]);
     assert!(affected.is_empty());
-    assert_eq!(read_tree_meta(&conn).0, 1);
+    assert_eq!(read_tree_meta(&conn).0, 0);
+    assert_eq!(
+        read_replay_frontier(&conn),
+        (Some(0), Some(Vec::new()), Some(0))
+    );
 
     let _: i64 = conn
         .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
@@ -415,6 +492,7 @@ fn remote_append_dirty_fallback_rebuilds_on_ensure_materialized() {
     let (dirty, _, _, _, head_seq) = read_tree_meta(&conn);
     assert_eq!(dirty, 0);
     assert_eq!(head_seq, 2);
+    assert_eq!(read_replay_frontier(&conn), (None, None, None));
 }
 
 #[test]

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -20,11 +20,11 @@ struct JsonOp {
     payload: Option<Vec<u8>>,
 }
 
-fn read_tree_meta(conn: &Connection) -> (i64, i64, Vec<u8>, i64, i64) {
+fn read_tree_meta(conn: &Connection) -> (i64, Vec<u8>, i64, i64) {
     conn.query_row(
-        "SELECT dirty, head_lamport, head_replica, head_counter, head_seq FROM tree_meta WHERE id = 1",
+        "SELECT head_lamport, head_replica, head_counter, head_seq FROM tree_meta WHERE id = 1",
         [],
-        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
     )
     .unwrap()
 }
@@ -304,8 +304,7 @@ fn local_insert_returns_appended_insert_op() {
     let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0)).unwrap();
     assert_eq!(count, 1);
 
-    let (dirty, head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
-    assert_eq!(dirty, 0);
+    let (head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_lamport, 1);
     assert_eq!(head_replica, b"r1".to_vec());
     assert_eq!(head_counter, 1);
@@ -349,7 +348,7 @@ fn remote_append_materializes_only_inserted_ops() {
     assert_eq!(op_count, 2);
     assert_eq!(visible_children(&conn, &root), vec![node]);
 
-    let (_, _, _, _, head_seq) = read_tree_meta(&conn);
+    let (_, _, _, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_seq, 2);
 }
 
@@ -408,9 +407,8 @@ fn remote_append_out_of_order_uses_replay_frontier() {
     let (affected, _) = append_ops_json(&conn, &[first.clone()]);
     assert!(affected.is_empty());
 
-    let (dirty, _, _, _, head_seq_before) = read_tree_meta(&conn);
+    let (_, _, _, head_seq_before) = read_tree_meta(&conn);
     let (replay_lamport, replay_replica, replay_counter) = read_replay_frontier(&conn);
-    assert_eq!(dirty, 0);
     assert_eq!(head_seq_before, 1);
     assert_eq!(replay_lamport, Some(first.lamport as i64));
     assert_eq!(replay_replica, Some(first.replica.clone()));
@@ -426,8 +424,7 @@ fn remote_append_out_of_order_uses_replay_frontier() {
         visible_children(&conn, &root),
         vec![node_bytes(1), node_bytes(2)]
     );
-    let (dirty_after, _, _, _, head_seq_after) = read_tree_meta(&conn);
-    assert_eq!(dirty_after, 0);
+    let (_, _, _, head_seq_after) = read_tree_meta(&conn);
     assert_eq!(head_seq_after, 2);
     assert_eq!(read_replay_frontier(&conn), (None, None, None));
 
@@ -439,12 +436,12 @@ fn remote_append_out_of_order_uses_replay_frontier() {
 }
 
 #[test]
-fn remote_append_legacy_dirty_recovery_converts_to_replay_from_start() {
+fn remote_append_replay_from_start_frontier_recovers_materialized_state() {
     let conn = setup_conn();
 
     let root = node_bytes(0);
     let first = JsonOp {
-        replica: b"dirty".to_vec(),
+        replica: b"restart".to_vec(),
         counter: 1,
         lamport: 1,
         kind: "insert".into(),
@@ -456,7 +453,7 @@ fn remote_append_legacy_dirty_recovery_converts_to_replay_from_start() {
         payload: None,
     };
     let second = JsonOp {
-        replica: b"dirty".to_vec(),
+        replica: b"restart".to_vec(),
         counter: 2,
         lamport: 2,
         kind: "insert".into(),
@@ -469,11 +466,16 @@ fn remote_append_legacy_dirty_recovery_converts_to_replay_from_start() {
     };
 
     append_ops_json(&conn, &[first]);
-    conn.execute("UPDATE tree_meta SET dirty = 1 WHERE id = 1", []).unwrap();
+    conn.execute(
+        "UPDATE tree_meta \
+         SET replay_lamport = 0, replay_replica = X'', replay_counter = 0 \
+         WHERE id = 1",
+        [],
+    )
+    .unwrap();
 
     let (affected, _) = append_ops_json(&conn, &[second]);
     assert!(affected.is_empty());
-    assert_eq!(read_tree_meta(&conn).0, 0);
     assert_eq!(
         read_replay_frontier(&conn),
         (Some(0), Some(Vec::new()), Some(0))
@@ -489,8 +491,7 @@ fn remote_append_legacy_dirty_recovery_converts_to_replay_from_start() {
         visible_children(&conn, &root),
         vec![node_bytes(1), node_bytes(2)]
     );
-    let (dirty, _, _, _, head_seq) = read_tree_meta(&conn);
-    assert_eq!(dirty, 0);
+    let (_, _, _, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_seq, 2);
     assert_eq!(read_replay_frontier(&conn), (None, None, None));
 }
@@ -670,8 +671,7 @@ fn local_move_allocates_key_excluding_self() {
     let expected = allocate_between(Some(&key_a), Some(&key_c), &seed).expect("allocate_between");
     assert_eq!(op.order_key.as_ref().unwrap(), &expected);
 
-    let (dirty, head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
-    assert_eq!(dirty, 0);
+    let (head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_lamport, 4);
     assert_eq!(head_replica, replica);
     assert_eq!(head_counter, 4);
@@ -742,8 +742,7 @@ fn local_delete_includes_known_state_bytes() {
     let vv: VersionVector = serde_json::from_slice(bytes).unwrap();
     assert!(vv.get(&ReplicaId::new(replica)) >= 1);
 
-    let (dirty, head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
-    assert_eq!(dirty, 0);
+    let (head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_lamport, 2);
     assert_eq!(head_replica, b"r1".to_vec());
     assert_eq!(head_counter, 2);
@@ -850,8 +849,7 @@ fn local_payload_set_and_clear_updates_meta() {
     assert_eq!(clear_ops[0].counter, 3);
     assert_eq!(clear_ops[0].lamport, 3);
 
-    let (dirty, head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
-    assert_eq!(dirty, 0);
+    let (head_lamport, head_replica, head_counter, head_seq) = read_tree_meta(&conn);
     assert_eq!(head_lamport, 3);
     assert_eq!(head_replica, replica);
     assert_eq!(head_counter, 3);


### PR DESCRIPTION
## Summary
- replace the coarse materialization `dirty` model with an explicit replay frontier in core, Postgres, and sqlite
- remove `dirty` from runtime behavior, adapter state, tests, and schemas; replay-from-start is now represented explicitly as frontier `(0, "", 0)`
- collapse the materialization cursor API into a shared `MaterializationState` / `MaterializationKey` shape instead of flattened `head_*` and `replay_*` getters
- make out-of-order persisted remote ops record the earliest invalidated replay frontier instead of treating the document as generically dirty

## New Frontier Model
- the op log remains canonical
- materialization metadata now tracks:
  - the materialized head
  - an optional replay frontier
- core represents both positions with the same ordered op-key shape: `(lamport, replica, counter)`
- when persisted remote ops arrive before the current materialized head, adapters record the earliest replay frontier instead of dirtying the whole document
- reads / catch-up now use that explicit frontier to decide whether materialization is current or replay is pending

## Why The Frontier Is `(lamport, replica, counter)` Instead Of A Version Vector
- this frontier is not modeling causal awareness; it is modeling the earliest point in the persisted op-log order from which materialization must be replayed
- core materialization already orders ops by the same key used in `cmp_op_key(...)`: `(lamport, replica, counter)`
- replay invalidation needs a single lower bound in that total order so catch-up can answer: “from which op onward do I have to trust replay again?”
- a version vector answers a different question: “which per-replica counters am I aware of?” That is useful for delete/awareness semantics, but it does not directly identify one earliest invalidated position in the globally sorted materialization stream
- with a version vector, we would still need to derive a concrete earliest replay point from the op log before catch-up could resume, which would add more state and more translation without improving the replay model
- the frontier is therefore intentionally narrow: one explicit op-key boundary in the same order the materializer already uses

## Why The Cursor API Changed
- the previous cursor trait flattened one materialization state into separate getters like `head_lamport`, `head_replica`, `replay_counter`, etc.
- that duplicated the shared op-key shape across the API and leaked the “zeroed head means none” sentinel into core helpers
- the new API returns one `MaterializationState` object instead
- `head` and `replay_from` now share the same `MaterializationKey` representation, while `head` alone also carries `seq`
- adapter implementations now hide empty/sentinel metadata locally, so core operates on explicit `Option<head>` / `Option<replay_from>` state instead of reconstructing that from scattered getters

## What This PR Changes Operationally
- normal persisted remote out-of-order append no longer uses `dirty` as the steady-state invalidation path
- Postgres and sqlite both record an explicit replay frontier for those cases
- replay-from-start recovery is now just an explicit frontier at the beginning of the log, not a separate boolean state
- local post-materialization recovery also schedules replay with the same frontier model instead of reintroducing `dirty`

## What This PR Does Not Yet Do
- catch-up still rebuilds materialized state from the op log when a replay frontier is pending
- this PR improves the state model and invalidation semantics, but not the catch-up cost model yet
- checkpoint-backed or suffix-only catch-up is intentionally left to a follow-up PR

## Postgres
- `treecrdt_meta` now stores only head + optional replay frontier metadata; `dirty` is gone
- remote append schedules `set_tree_meta_replay_frontier(...)` for out-of-order inserts instead of falling back to whole-doc dirty state
- `ensure_materialized_in_tx` now catches up from the recorded replay frontier instead of branching on `dirty`
- schema init now reflects the frontier model directly and no longer carries old-column upgrade logic

## SQLite
- `tree_meta` now stores only head + optional replay frontier metadata; `dirty` is gone from runtime model and schema
- remote append stores replay frontier metadata for out-of-order batches
- `treecrdt_ensure_materialized()` now catches up based on the replay frontier instead of a dirty bit
- schema init now reflects the frontier model directly and no longer carries old-column upgrade logic

## Why This PR Still Has Value Without Checkpoints
- it removes a coarse, misleading state model from core and both backends
- it makes the normal out-of-order persisted-remote path explicit and deterministic instead of “mark dirty and hope a later rebuild fixes it”
- it gives us one narrow, testable abstraction for invalidation (`replay_from`) that later optimizations can build on
- it keeps external correctness stable while making the materialization architecture easier to reason about

## Recovery / Fallback That Still Remains
- if incremental materialization cannot safely advance head metadata, the transaction records an explicit replay frontier and defers catch-up
- if neither the head update nor replay-frontier metadata can be written, the transaction fails; there is no separate dirty escape hatch anymore
- replay-from-start still exists, but only as an explicit frontier at the beginning of the log

## Tests
- `cargo test -p treecrdt-core`
- `cargo test -p treecrdt-postgres --test postgres_test`
- `cargo test -p treecrdt-sqlite-ext --features ext-sqlite --test extension_roundtrip`
- `pnpm run clippy`
