### PR TITLE
Add unified materialization events

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { type Operation, type OperationKind } from "@treecrdt/interface";
+import { type Operation } from "@treecrdt/interface";
 import type { MaterializationEvent } from "@treecrdt/interface/engine";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import { createTreecrdtClient, type TreecrdtClient } from "@treecrdt/wa-sqlite/client";
@@ -274,6 +274,7 @@ export default function App() {
     treeStateRef.current = treeState;
   }, [treeState]);
 
+  const payloadWriteQueueRef = useRef<Promise<void>>(Promise.resolve());
   const childrenLoadInFlightRef = useRef<Set<string>>(new Set());
 
   const ensureChildrenLoaded = React.useCallback(
@@ -702,30 +703,6 @@ export default function App() {
     await initClient(target, nextKey, opts.docId);
   };
 
-  const appendOperation = async (kind: OperationKind) => {
-    if (!client || !replica) return;
-    setBusy(true);
-    try {
-      let op: Operation;
-      if (kind.type === "payload") {
-        const encryptedPayload = await encryptPayloadBytes(kind.payload);
-        op = await client.local.payload(replica, kind.node, encryptedPayload);
-      } else if (kind.type === "delete") {
-        op = await client.local.delete(replica, kind.node);
-      } else {
-        throw new Error(`unsupported operation kind: ${kind.type}`);
-      }
-      await verifyLocalOps([op]);
-
-      recordLocalOps([op]);
-    } catch (err) {
-      console.error("Failed to append op", err);
-      setError("Failed to append operation (see console)");
-    } finally {
-      setBusy(false);
-    }
-  };
-
   const appendMoveAfter = async (nodeId: string, newParent: string, after: string | null) => {
     if (!client || !replica) return;
     if (authEnabled && (!canWriteStructure || (isScopedAccess && newParent === ROOT_ID))) return;
@@ -861,15 +838,39 @@ export default function App() {
     }
   };
 
-  const handleSetValue = async (nodeId: string, value: string) => {
-    if (nodeId === ROOT_ID) return;
-    const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
-    await appendOperation({ type: "payload", node: nodeId, payload });
+  const handleSetValue = (nodeId: string, value: string): Promise<void> => {
+    const run = payloadWriteQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        if (nodeId === ROOT_ID || !client || !replica) return;
+        try {
+          const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
+          const encryptedPayload = await encryptPayloadBytes(payload);
+          const op = await client.local.payload(replica, nodeId, encryptedPayload);
+          await verifyLocalOps([op]);
+          recordLocalOps([op]);
+        } catch (err) {
+          console.error("Failed to write payload", err);
+          setError("Failed to write payload (see console)");
+        }
+      });
+    payloadWriteQueueRef.current = run.catch(() => undefined);
+    return run;
   };
 
   const handleDelete = async (nodeId: string) => {
-    if (nodeId === ROOT_ID) return;
-    await appendOperation({ type: "delete", node: nodeId });
+    if (nodeId === ROOT_ID || !client || !replica) return;
+    setBusy(true);
+    try {
+      const op = await client.local.delete(replica, nodeId);
+      await verifyLocalOps([op]);
+      recordLocalOps([op]);
+    } catch (err) {
+      console.error("Failed to delete node", err);
+      setError("Failed to delete node (see console)");
+    } finally {
+      setBusy(false);
+    }
   };
 
   const handleMove = async (nodeId: string, direction: "up" | "down") => {

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -34,11 +34,7 @@ import {
   persistStorage,
 } from "./playground/persist";
 import { getPlaygroundProfileId, prefixPlaygroundStorageKey } from "./playground/storage";
-import {
-  applyChildrenLoaded,
-  flattenForSelectState,
-  nodesAffectedByPayloadOps,
-} from "./playground/treeState";
+import { applyChildrenLoaded, flattenForSelectState } from "./playground/treeState";
 import type {
   CollapseState,
   DisplayNode,
@@ -548,8 +544,7 @@ export default function App() {
 
   const applyMaterializationEvent = React.useCallback(
     (event: MaterializationEvent) => {
-      const active = clientRef.current ?? client;
-      if (!active || event.changes.length === 0) return;
+      if (event.changes.length === 0) return;
 
       const payloadNodes = new Set<string>();
       const parentsToRefresh = new Set<string>();
@@ -590,17 +585,15 @@ export default function App() {
       scheduleRefreshParents(parentsToRefresh);
       scheduleRefreshNodeCount();
     },
-    [client, scheduleRefreshNodeCount, scheduleRefreshParents, scheduleRefreshPayloads]
+    [scheduleRefreshNodeCount, scheduleRefreshParents, scheduleRefreshPayloads]
   );
 
   useEffect(() => {
     if (!client) return;
-    return client.onMaterialized((event) => {
-      applyMaterializationEvent(event);
-    });
+    return client.onMaterialized(applyMaterializationEvent);
   }, [client, applyMaterializationEvent]);
 
-  const onRemoteOpsApplied = React.useCallback(
+  const onRemoteOpsImported = React.useCallback(
     async (appliedOps: Operation[]) => {
       ingestOps(appliedOps);
       if (appliedOps.length > 0) {
@@ -673,12 +666,10 @@ export default function App() {
     revocationCutoverCounter,
     treeStateRef,
     refreshMeta,
-    refreshParents,
-    refreshNodeCount,
     getLocalIdentityChain,
     onPeerIdentityChain,
     onAuthGrantMessage,
-    onRemoteOpsApplied,
+    onRemoteOpsImported,
   });
 
   const grantSubtreeToReplicaPubkey = React.useCallback(
@@ -901,7 +892,14 @@ export default function App() {
       fetched.sort(compareOps);
       setOps(fetched);
       knownOpsRef.current = new Set(fetched.map(opKey));
-      await refreshPayloadsForNodes(active, nodesAffectedByPayloadOps(fetched));
+      const payloadNodeIds = new Set<string>();
+      for (const op of fetched) {
+        const kind = op.kind;
+        if (kind.type === "insert" || kind.type === "payload" || kind.type === "delete") {
+          payloadNodeIds.add(kind.node);
+        }
+      }
+      await refreshPayloadsForNodes(active, payloadNodeIds);
       setParentChoice((prev) => (opts.preserveParent ? prev : ROOT_ID));
     } catch (err) {
       console.error("Failed to refresh ops", err);

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -35,6 +35,7 @@ import {
 import { getPlaygroundProfileId, prefixPlaygroundStorageKey } from "./playground/storage";
 import { applyChildrenLoaded, flattenForSelectState } from "./playground/treeState";
 import type {
+  BulkAddProgress,
   CollapseState,
   DisplayNode,
   Status,
@@ -75,13 +76,6 @@ function initialSyncTransportMode(): SyncTransportMode {
 
   return "local";
 }
-
-type BulkAddProgress = {
-  total: number;
-  completed: number;
-  phase: "creating" | "applying";
-  startedAtMs: number;
-};
 
 export default function App() {
   const [client, setClient] = useState<TreecrdtClient | null>(null);

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { type Operation, type OperationKind } from "@treecrdt/interface";
+import type { MaterializationEvent } from "@treecrdt/interface/engine";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import { createTreecrdtClient, type TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 import { detectOpfsSupport } from "@treecrdt/wa-sqlite/opfs";
@@ -37,7 +38,6 @@ import {
   applyChildrenLoaded,
   flattenForSelectState,
   nodesAffectedByPayloadOps,
-  parentsAffectedByOps,
 } from "./playground/treeState";
 import type {
   CollapseState,
@@ -504,12 +504,12 @@ export default function App() {
       if (queue.size === 0) return;
       if (refreshParentsScheduledRef.current) return;
       refreshParentsScheduledRef.current = true;
-      queueMicrotask(() => {
+      setTimeout(() => {
         refreshParentsScheduledRef.current = false;
         const ids = Array.from(refreshParentsQueueRef.current);
         refreshParentsQueueRef.current.clear();
         void refreshParents(ids);
-      });
+      }, 0);
     },
     [refreshParents]
   );
@@ -518,20 +518,90 @@ export default function App() {
   const scheduleRefreshNodeCount = React.useCallback(() => {
     if (refreshNodeCountQueuedRef.current) return;
     refreshNodeCountQueuedRef.current = true;
-    queueMicrotask(() => {
+    setTimeout(() => {
       refreshNodeCountQueuedRef.current = false;
       void refreshNodeCount();
-    });
+    }, 0);
   }, [refreshNodeCount]);
+
+  const refreshPayloadsQueueRef = useRef<Set<string>>(new Set());
+  const refreshPayloadsScheduledRef = useRef(false);
+  const scheduleRefreshPayloads = React.useCallback(
+    (nodeIds: Iterable<string>) => {
+      const queue = refreshPayloadsQueueRef.current;
+      for (const id of nodeIds) queue.add(id);
+      if (queue.size === 0 || refreshPayloadsScheduledRef.current) return;
+      refreshPayloadsScheduledRef.current = true;
+      setTimeout(() => {
+        refreshPayloadsScheduledRef.current = false;
+        const ids = new Set(refreshPayloadsQueueRef.current);
+        refreshPayloadsQueueRef.current.clear();
+        const active = clientRef.current ?? client;
+        if (!active || ids.size === 0) return;
+        void refreshPayloadsForNodes(active, ids);
+      }, 0);
+    },
+    [client, refreshPayloadsForNodes]
+  );
 
   const getMaxLamport = React.useCallback(() => BigInt(lamportRef.current), []);
 
-  const onRemoteOpsApplied = React.useCallback(
-    async (appliedOps: Operation[], affectedNodeIds: string[]) => {
+  const applyMaterializationEvent = React.useCallback(
+    (event: MaterializationEvent) => {
       const active = clientRef.current ?? client;
-      if (active && appliedOps.length > 0) {
-        await refreshPayloadsForNodes(active, nodesAffectedByPayloadOps(appliedOps));
+      if (!active || event.changes.length === 0) return;
+
+      const payloadNodes = new Set<string>();
+      const parentsToRefresh = new Set<string>();
+      const loadedChildren = treeStateRef.current.childrenByParent;
+
+      const addLoadedParent = (id: string | null | undefined) => {
+        if (id && Object.prototype.hasOwnProperty.call(loadedChildren, id)) {
+          parentsToRefresh.add(id);
+        }
+      };
+
+      for (const change of event.changes) {
+        if (change.kind === "payload") {
+          payloadNodes.add(change.node);
+          continue;
+        }
+
+        if (change.kind === "insert") {
+          payloadNodes.add(change.node);
+          addLoadedParent(change.parentAfter);
+        } else if (change.kind === "move") {
+          addLoadedParent(change.parentBefore);
+          addLoadedParent(change.parentAfter);
+        } else if (change.kind === "delete") {
+          addLoadedParent(change.parentBefore);
+        } else if (change.kind === "restore") {
+          addLoadedParent(change.parentAfter);
+        }
+
+        if (Object.prototype.hasOwnProperty.call(loadedChildren, change.node)) {
+          parentsToRefresh.add(change.node);
+        }
       }
+
+      if (payloadNodes.size > 0) {
+        scheduleRefreshPayloads(payloadNodes);
+      }
+      scheduleRefreshParents(parentsToRefresh);
+      scheduleRefreshNodeCount();
+    },
+    [client, scheduleRefreshNodeCount, scheduleRefreshParents, scheduleRefreshPayloads]
+  );
+
+  useEffect(() => {
+    if (!client) return;
+    return client.onMaterialized((event) => {
+      applyMaterializationEvent(event);
+    });
+  }, [client, applyMaterializationEvent]);
+
+  const onRemoteOpsApplied = React.useCallback(
+    async (appliedOps: Operation[]) => {
       ingestOps(appliedOps);
       if (appliedOps.length > 0) {
         let max = 0;
@@ -539,25 +609,8 @@ export default function App() {
         lamportRef.current = Math.max(lamportRef.current, max);
         setHeadLamport(lamportRef.current);
       }
-      const parentsToRefresh = new Set<string>();
-      const loadedChildren = treeStateRef.current.childrenByParent;
-      const index = treeStateRef.current.index;
-      for (const nodeId of affectedNodeIds) {
-        const parentId = index[nodeId]?.parentId;
-        if (parentId && Object.prototype.hasOwnProperty.call(loadedChildren, parentId)) {
-          parentsToRefresh.add(parentId);
-        }
-        if (Object.prototype.hasOwnProperty.call(loadedChildren, nodeId)) {
-          parentsToRefresh.add(nodeId);
-        }
-      }
-      for (const id of parentsAffectedByOps(treeStateRef.current, appliedOps)) {
-        parentsToRefresh.add(id);
-      }
-      scheduleRefreshParents(parentsToRefresh);
-      scheduleRefreshNodeCount();
     },
-    [client, ingestOps, refreshPayloadsForNodes, scheduleRefreshNodeCount, scheduleRefreshParents]
+    [ingestOps]
   );
 
   const openNewPeerTab = () => {
@@ -867,8 +920,6 @@ export default function App() {
     if (!client || !replica) return;
     setBusy(true);
     try {
-      const stateBefore = treeStateRef.current;
-
       let op: Operation;
       if (kind.type === "payload") {
         const encryptedPayload = await encryptPayloadBytes(kind.payload);
@@ -884,10 +935,7 @@ export default function App() {
       setHeadLamport(lamportRef.current);
 
       notifyLocalUpdate([op]);
-      await refreshPayloadsForNodes(client, nodesAffectedByPayloadOps([op]));
       ingestOps([op], { assumeSorted: true });
-      scheduleRefreshParents(parentsAffectedByOps(stateBefore, [op]));
-      scheduleRefreshNodeCount();
     } catch (err) {
       console.error("Failed to append op", err);
       setError("Failed to append operation (see console)");
@@ -901,13 +949,10 @@ export default function App() {
     if (authEnabled && (!canWriteStructure || (isScopedAccess && newParent === ROOT_ID))) return;
     setBusy(true);
     try {
-      const stateBefore = treeStateRef.current;
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
       const op = await client.local.move(replica, nodeId, newParent, placement);
       notifyLocalUpdate([op]);
       ingestOps([op], { assumeSorted: true });
-      scheduleRefreshParents(parentsAffectedByOps(stateBefore, [op]));
-      scheduleRefreshNodeCount();
       lamportRef.current = Math.max(lamportRef.current, op.meta.lamport);
       setHeadLamport(lamportRef.current);
     } catch (err) {
@@ -928,7 +973,6 @@ export default function App() {
     const progressStep = normalizedCount >= 1_000 ? 50 : normalizedCount >= 200 ? 20 : normalizedCount >= 50 ? 5 : 1;
     setBulkAddProgress({ total: normalizedCount, completed: 0, phase: "creating", startedAtMs });
     try {
-      const stateBefore = treeStateRef.current;
       const ops: Operation[] = [];
       const fanoutLimit = Math.max(0, Math.floor(opts.fanout ?? fanout));
       const valueBase = canWritePayload ? newNodeValue.trim() : "";
@@ -1010,10 +1054,7 @@ export default function App() {
       setHeadLamport(lamportRef.current);
 
       notifyLocalUpdate(ops);
-      await refreshPayloadsForNodes(client, nodesAffectedByPayloadOps(ops));
       ingestOps(ops, { assumeSorted: true });
-      scheduleRefreshParents(parentsAffectedByOps(stateBefore, ops));
-      scheduleRefreshNodeCount();
       setCollapse((prev) => {
         const overrides = new Set(prev.overrides);
         const setExpanded = (id: string) => {
@@ -1043,17 +1084,13 @@ export default function App() {
     if (authEnabled && !canWriteStructure) return;
     setBusy(true);
     try {
-      const stateBefore = treeStateRef.current;
       const valueBase = canWritePayload ? newNodeValue.trim() : "";
       const payload = valueBase.length > 0 ? textEncoder.encode(valueBase) : null;
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
       const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload);
       notifyLocalUpdate([op]);
-      await refreshPayloadsForNodes(client, [op.kind.node]);
       ingestOps([op], { assumeSorted: true });
-      scheduleRefreshParents(parentsAffectedByOps(stateBefore, [op]));
-      scheduleRefreshNodeCount();
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
       }

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1007,8 +1007,8 @@ export default function App() {
         error={error}
       />
 
-      <div className="grid gap-6 md:grid-cols-3">
-        <section className={`${showOpsPanel ? "md:col-span-2" : "md:col-span-3"} space-y-4`}>
+      <div className="grid min-w-0 gap-6 md:grid-cols-3">
+        <section className={`${showOpsPanel ? "md:col-span-2" : "md:col-span-3"} min-w-0 space-y-4`}>
           <ComposerPanel
             composerOpen={composerOpen}
             setComposerOpen={setComposerOpen}

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -419,10 +419,7 @@ export default function App() {
   const applyMaterializationEvent = React.useCallback(
     (event: MaterializationEvent) => {
       if (event.changes.length === 0) return;
-      const { payloadUpdates, parentsToRefresh } = materializationRefreshPlan(
-        event,
-        treeStateRef.current.childrenByParent
-      );
+      const { payloadUpdates, parentsToRefresh } = materializationRefreshPlan(event);
       schedulePayloadEventUpdates(payloadUpdates);
       scheduleRefreshParents(parentsToRefresh);
       scheduleRefreshNodeCount();

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -4,10 +4,7 @@ import type { MaterializationEvent } from "@treecrdt/interface/engine";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import { createTreecrdtClient, type TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 import { detectOpfsSupport } from "@treecrdt/wa-sqlite/opfs";
-import { base64urlDecode } from "@treecrdt/auth";
-import { encryptTreecrdtPayloadV1, maybeDecryptTreecrdtPayloadV1 } from "@treecrdt/crypto";
 
-import { loadOrCreateDocPayloadKeyB64 } from "./auth";
 import { hexToBytes16 } from "./sync-v0";
 import { useVirtualizer } from "./virtualizer";
 
@@ -19,8 +16,10 @@ import { ShareSubtreeDialog } from "./playground/components/ShareSubtreeDialog";
 import { PlaygroundToast } from "./playground/components/PlaygroundToast";
 import { TreePanel } from "./playground/components/TreePanel";
 import { usePlaygroundAuth } from "./playground/hooks/usePlaygroundAuth";
+import { usePlaygroundOpsLog } from "./playground/hooks/usePlaygroundOpsLog";
+import { usePlaygroundPayloads } from "./playground/hooks/usePlaygroundPayloads";
 import { usePlaygroundSync } from "./playground/hooks/usePlaygroundSync";
-import { compareOps, mergeSortedOps, opKey } from "./playground/ops";
+import { materializationRefreshPlan } from "./playground/materializationEvents";
 import {
   ensureOpfsKey,
   initialDocId,
@@ -38,7 +37,6 @@ import { applyChildrenLoaded, flattenForSelectState } from "./playground/treeSta
 import type {
   CollapseState,
   DisplayNode,
-  PayloadRecord,
   Status,
   StorageMode,
   SyncTransportMode,
@@ -88,9 +86,8 @@ type BulkAddProgress = {
 export default function App() {
   const [client, setClient] = useState<TreecrdtClient | null>(null);
   const clientRef = useRef<TreecrdtClient | null>(null);
-  const [ops, setOps] = useState<Operation[]>([]);
   const [treeState, setTreeState] = useState<TreeState>(() => ({
-    index: { [ROOT_ID]: { parentId: null, order: 0, childCount: 0, deleted: false } },
+    index: { [ROOT_ID]: { parentId: null, order: 0, childCount: 0 } },
     childrenByParent: { [ROOT_ID]: [] },
   }));
   const [status, setStatus] = useState<Status>("booting");
@@ -125,7 +122,6 @@ export default function App() {
     return false;
   });
   const [online, setOnline] = useState(true);
-  const [payloadVersion, setPayloadVersion] = useState(0);
 
   const joinMode =
     typeof window !== "undefined" && new URLSearchParams(window.location.search).get("join") === "1";
@@ -162,12 +158,14 @@ export default function App() {
   const initEpochRef = useRef(0);
   const disposedRef = useRef(false);
   const opfsSupport = useMemo(detectOpfsSupport, []);
-  const docPayloadKeyRef = useRef<Uint8Array | null>(null);
-  const refreshDocPayloadKey = React.useCallback(async () => {
-    const keyB64 = await loadOrCreateDocPayloadKeyB64(docId);
-    docPayloadKeyRef.current = base64urlDecode(keyB64);
-    return docPayloadKeyRef.current;
-  }, [docId]);
+  const {
+    encryptPayloadBytes,
+    payloadDisplayForNode,
+    refreshDocPayloadKey,
+    refreshPayloadsForNodes,
+    resetPayloadCache,
+    schedulePayloadEventUpdates,
+  } = usePlaygroundPayloads({ docId, setError });
   const identityByReplicaRef = useRef<Map<string, { identityPk: Uint8Array; devicePk: Uint8Array }>>(new Map());
   const [, bumpIdentityVersion] = useState(0);
   const onPeerIdentityChain = React.useCallback(
@@ -216,10 +214,8 @@ export default function App() {
     syncAuth,
     refreshAuthMaterial,
     localIdentityChainPromiseRef,
-    authToken,
     replica,
     selfPeerId,
-    authActionSet,
     viewRootId,
     authCanSyncAll,
     canWriteStructure,
@@ -235,19 +231,8 @@ export default function App() {
     authTokenScope,
     authTokenActions,
     authNeedsInvite,
-    revocationKnownTokenIds,
     hardRevokedTokenIds,
     toggleHardRevokedTokenId,
-    clearHardRevokedTokenIds,
-    revocationTokenInput,
-    setRevocationTokenInput,
-    addHardRevokedTokenId,
-    revocationCutoverEnabled,
-    setRevocationCutoverEnabled,
-    revocationCutoverTokenId,
-    setRevocationCutoverTokenId,
-    revocationCutoverCounter,
-    setRevocationCutoverCounter,
     pendingOps,
     refreshPendingOps,
     privateRoots,
@@ -279,123 +264,21 @@ export default function App() {
     refreshDocPayloadKey,
   });
 
-  const showOpsPanelRef = useRef(false);
   const textEncoder = useMemo(() => new TextEncoder(), []);
-  const textDecoder = useMemo(() => new TextDecoder(), []);
-
-  useEffect(() => {
-    docPayloadKeyRef.current = null;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const keyB64 = await loadOrCreateDocPayloadKeyB64(docId);
-        if (cancelled) return;
-        docPayloadKeyRef.current = base64urlDecode(keyB64);
-      } catch (err) {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [docId]);
-
-  const payloadByNodeRef = useRef<Map<string, PayloadRecord>>(new Map());
-
-  const requireDocPayloadKey = React.useCallback(async (): Promise<Uint8Array> => {
-    if (docPayloadKeyRef.current) return docPayloadKeyRef.current;
-    const next = await refreshDocPayloadKey();
-    if (!next) throw new Error("doc payload key is missing");
-    return next;
-  }, [refreshDocPayloadKey]);
-
-  const refreshPayloadsForNodes = React.useCallback(
-    async (active: TreecrdtClient, nodeIds: Iterable<string>) => {
-      const payloads = payloadByNodeRef.current;
-      const unique = [...new Set(nodeIds)].filter((id) => id !== ROOT_ID);
-      if (unique.length === 0) return;
-      let changed = false;
-      for (const nodeId of unique) {
-        const raw = await active.tree.getPayload(nodeId);
-        if (raw === null) {
-          payloads.set(nodeId, { payload: null, encrypted: false });
-          changed = true;
-          continue;
-        }
-        try {
-          const key = await requireDocPayloadKey();
-          const res = await maybeDecryptTreecrdtPayloadV1({
-            docId,
-            payloadKey: key,
-            bytes: raw,
-          });
-          payloads.set(nodeId, { payload: res.plaintext, encrypted: res.encrypted });
-        } catch {
-          payloads.set(nodeId, { payload: null, encrypted: true });
-        }
-        changed = true;
-      }
-      if (changed) setPayloadVersion((v) => v + 1);
-    },
-    [docId, requireDocPayloadKey]
-  );
-
-  const encryptPayloadBytes = React.useCallback(
-    async (payload: Uint8Array | null): Promise<Uint8Array | null> => {
-      if (payload === null) return null;
-      const key = await requireDocPayloadKey();
-      return await encryptTreecrdtPayloadV1({ docId, payloadKey: key, plaintext: payload });
-    },
-    [docId, requireDocPayloadKey]
-  );
-  const knownOpsRef = useRef<Set<string>>(new Set());
+  const { ops, recordOps, resetOps } = usePlaygroundOpsLog({
+    client,
+    status,
+    showOpsPanel,
+    lamportRef,
+    setHeadLamport,
+    setError,
+    refreshPayloadsForNodes,
+  });
 
   const treeStateRef = useRef<TreeState>(treeState);
   useEffect(() => {
     treeStateRef.current = treeState;
   }, [treeState]);
-
-  useEffect(() => {
-    showOpsPanelRef.current = showOpsPanel;
-    if (!showOpsPanel) {
-      setOps([]);
-      knownOpsRef.current = new Set();
-    }
-  }, [showOpsPanel]);
-
-  const ingestOps = React.useCallback(
-    (incoming: Operation[], opts: { assumeSorted?: boolean } = {}) => {
-      if (!showOpsPanelRef.current) return;
-      if (incoming.length === 0) return;
-      const fresh: Operation[] = [];
-      const known = knownOpsRef.current;
-      for (const op of incoming) {
-        const key = opKey(op);
-        if (known.has(key)) continue;
-        known.add(key);
-        fresh.push(op);
-      }
-      if (fresh.length === 0) return;
-      if (!opts.assumeSorted) fresh.sort(compareOps);
-      setOps((prev) => mergeSortedOps(prev, fresh));
-    },
-    []
-  );
-
-  const recordOps = React.useCallback(
-    (incoming: Operation[], opts: { assumeSorted?: boolean } = {}) => {
-      if (incoming.length === 0) return;
-      let nextLamport = lamportRef.current;
-      for (const op of incoming) nextLamport = Math.max(nextLamport, op.meta.lamport);
-      if (nextLamport !== lamportRef.current) {
-        lamportRef.current = nextLamport;
-        setHeadLamport(nextLamport);
-      }
-      ingestOps(incoming, opts);
-    },
-    [ingestOps]
-  );
 
   const childrenLoadInFlightRef = useRef<Set<string>>(new Set());
 
@@ -533,26 +416,6 @@ export default function App() {
     }, 0);
   }, [refreshNodeCount]);
 
-  const refreshPayloadsQueueRef = useRef<Set<string>>(new Set());
-  const refreshPayloadsScheduledRef = useRef(false);
-  const scheduleRefreshPayloads = React.useCallback(
-    (nodeIds: Iterable<string>) => {
-      const queue = refreshPayloadsQueueRef.current;
-      for (const id of nodeIds) queue.add(id);
-      if (queue.size === 0 || refreshPayloadsScheduledRef.current) return;
-      refreshPayloadsScheduledRef.current = true;
-      setTimeout(() => {
-        refreshPayloadsScheduledRef.current = false;
-        const ids = new Set(refreshPayloadsQueueRef.current);
-        refreshPayloadsQueueRef.current.clear();
-        const active = clientRef.current ?? client;
-        if (!active || ids.size === 0) return;
-        void refreshPayloadsForNodes(active, ids);
-      }, 0);
-    },
-    [client, refreshPayloadsForNodes]
-  );
-
   const getMaxLamport = React.useCallback(() => BigInt(lamportRef.current), []);
   const getLoadedParentIds = React.useCallback(
     () => Object.keys(treeStateRef.current.childrenByParent),
@@ -562,47 +425,15 @@ export default function App() {
   const applyMaterializationEvent = React.useCallback(
     (event: MaterializationEvent) => {
       if (event.changes.length === 0) return;
-
-      const payloadNodes = new Set<string>();
-      const parentsToRefresh = new Set<string>();
-      const loadedChildren = treeStateRef.current.childrenByParent;
-
-      const addLoadedParent = (id: string | null | undefined) => {
-        if (id && Object.prototype.hasOwnProperty.call(loadedChildren, id)) {
-          parentsToRefresh.add(id);
-        }
-      };
-
-      for (const change of event.changes) {
-        if (change.kind === "payload") {
-          payloadNodes.add(change.node);
-          continue;
-        }
-
-        if (change.kind === "insert") {
-          payloadNodes.add(change.node);
-          addLoadedParent(change.parentAfter);
-        } else if (change.kind === "move") {
-          addLoadedParent(change.parentBefore);
-          addLoadedParent(change.parentAfter);
-        } else if (change.kind === "delete") {
-          addLoadedParent(change.parentBefore);
-        } else if (change.kind === "restore") {
-          addLoadedParent(change.parentAfter);
-        }
-
-        if (Object.prototype.hasOwnProperty.call(loadedChildren, change.node)) {
-          parentsToRefresh.add(change.node);
-        }
-      }
-
-      if (payloadNodes.size > 0) {
-        scheduleRefreshPayloads(payloadNodes);
-      }
+      const { payloadUpdates, parentsToRefresh } = materializationRefreshPlan(
+        event,
+        treeStateRef.current.childrenByParent
+      );
+      schedulePayloadEventUpdates(payloadUpdates);
       scheduleRefreshParents(parentsToRefresh);
       scheduleRefreshNodeCount();
     },
-    [scheduleRefreshNodeCount, scheduleRefreshParents, scheduleRefreshPayloads]
+    [schedulePayloadEventUpdates, scheduleRefreshNodeCount, scheduleRefreshParents]
   );
 
   useEffect(() => {
@@ -704,31 +535,14 @@ export default function App() {
   }, [ensureChildrenLoaded, viewRootId]);
 
   const nodeLabelForId = React.useCallback(
-    (id: string) => {
-      if (id === ROOT_ID) return "Root";
-      const record = payloadByNodeRef.current.get(id);
-      const payload = record?.payload ?? null;
-      if (payload === null) return record?.encrypted ? "(encrypted)" : id;
-      const decoded = textDecoder.decode(payload);
-      return decoded.length === 0 ? "(empty)" : decoded;
-    },
-    [payloadVersion, textDecoder]
+    (id: string) => payloadDisplayForNode(id).label,
+    [payloadDisplayForNode]
   );
 
   const nodeList = useMemo(
     () => flattenForSelectState(childrenByParent, nodeLabelForId, { rootId: viewRootId }),
     [childrenByParent, nodeLabelForId, viewRootId]
   );
-  const privateRootEntries = useMemo(() => {
-    const roots = Array.from(privateRoots).filter((id) => id !== ROOT_ID);
-    roots.sort((a, b) => {
-      const la = nodeLabelForId(a);
-      const lb = nodeLabelForId(b);
-      if (la === lb) return a.localeCompare(b);
-      return la.localeCompare(lb);
-    });
-    return roots.map((id) => ({ id, label: nodeLabelForId(id) }));
-  }, [privateRoots, nodeLabelForId]);
 
   const expandPathTo = React.useCallback(
     (nodeId: string) => {
@@ -759,20 +573,8 @@ export default function App() {
     while (stack.length > 0) {
       const entry = stack.pop();
       if (!entry) break;
-      const record = payloadByNodeRef.current.get(entry.id);
-      const payload = record?.payload ?? null;
-      const value = payload === null ? "" : textDecoder.decode(payload);
-      const label =
-        entry.id === ROOT_ID
-          ? "Root"
-          : payload === null
-            ? record?.encrypted
-              ? "(encrypted)"
-              : entry.id
-            : value.length === 0
-              ? "(empty)"
-              : value;
-      acc.push({ node: { id: entry.id, label, value, children: [] }, depth: entry.depth });
+      const { label, value } = payloadDisplayForNode(entry.id);
+      acc.push({ node: { id: entry.id, label, value }, depth: entry.depth });
       if (isCollapsed(entry.id)) continue;
       const kids = childrenByParent[entry.id] ?? [];
       for (let i = kids.length - 1; i >= 0; i--) {
@@ -780,7 +582,7 @@ export default function App() {
       }
     }
     return acc;
-  }, [childrenByParent, collapse, payloadVersion, textDecoder]);
+  }, [childrenByParent, collapse, payloadDisplayForNode]);
   const treeParentRef = useRef<HTMLDivElement | null>(null);
   const opsParentRef = useRef<HTMLDivElement | null>(null);
   const treeEstimateSize = React.useCallback(() => 72, []);
@@ -888,14 +690,12 @@ export default function App() {
           : ensureOpfsKey()
         : sessionKey;
     setSessionKey(nextKey);
-    setOps([]);
+    resetOps();
     setTreeState({
-      index: { [ROOT_ID]: { parentId: null, order: 0, childCount: 0, deleted: false } },
+      index: { [ROOT_ID]: { parentId: null, order: 0, childCount: 0 } },
       childrenByParent: { [ROOT_ID]: [] },
     });
-    payloadByNodeRef.current = new Map();
-    setPayloadVersion((v) => v + 1);
-    knownOpsRef.current = new Set();
+    resetPayloadCache();
     setCollapse({ defaultCollapsed: true, overrides: new Set([ROOT_ID]) });
     lamportRef.current = 0;
     setHeadLamport(0);
@@ -910,36 +710,6 @@ export default function App() {
     await closeClientSafely(closingClient);
     await initClient(target, nextKey, opts.docId);
   };
-
-  const refreshOps = async (nextClient?: TreecrdtClient, opts: { preserveParent?: boolean } = {}) => {
-    const active = nextClient ?? client;
-    if (!active) return;
-    try {
-      const fetched = await active.ops.all();
-      fetched.sort(compareOps);
-      setOps(fetched);
-      knownOpsRef.current = new Set(fetched.map(opKey));
-      const payloadNodeIds = new Set<string>();
-      for (const op of fetched) {
-        const kind = op.kind;
-        if (kind.type === "insert" || kind.type === "payload" || kind.type === "delete") {
-          payloadNodeIds.add(kind.node);
-        }
-      }
-      await refreshPayloadsForNodes(active, payloadNodeIds);
-      setParentChoice((prev) => (opts.preserveParent ? prev : ROOT_ID));
-    } catch (err) {
-      console.error("Failed to refresh ops", err);
-      setError("Failed to refresh operations (see console)");
-    }
-  };
-
-  useEffect(() => {
-    if (!showOpsPanel) return;
-    if (!client || status !== "ready") return;
-    void refreshOps(undefined, { preserveParent: true });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showOpsPanel, client, status]);
 
   const appendOperation = async (kind: OperationKind) => {
     if (!client || !replica) return;
@@ -1196,31 +966,6 @@ export default function App() {
       ? `${selfPeerId.slice(0, 8)}…${selfPeerId.slice(-6)}`
       : selfPeerId
     : null;
-  const authScopeSummary = (() => {
-    if (!authTokenScope) return "-";
-    const rootId = (authTokenScope.rootNodeId ?? ROOT_ID).toLowerCase();
-    if (rootId === ROOT_ID) return "doc-wide";
-    const label = nodeLabelForId(rootId);
-    if (label && label !== rootId) return `subtree ${label}`;
-    return `subtree ${rootId.slice(0, 8)}…`;
-  })();
-  const authScopeTitle = (() => {
-    if (!authTokenScope) return "";
-    const rootId = (authTokenScope.rootNodeId ?? ROOT_ID).toLowerCase();
-    const parts = [`root=${rootId}`];
-    if (authTokenScope.maxDepth !== undefined) parts.push(`maxDepth=${authTokenScope.maxDepth}`);
-    const excludeCount = authTokenScope.excludeNodeIds?.length ?? 0;
-    if (excludeCount > 0) parts.push(`exclude=${excludeCount}`);
-    return parts.join(" ");
-  })();
-  const authSummaryBadges = (() => {
-    if (!Array.isArray(authTokenActions)) return [];
-    const set = new Set(authTokenActions.map(String));
-    const out: string[] = [];
-    if (set.has("write_structure") || set.has("write_payload")) out.push("write");
-    if (set.has("delete")) out.push("delete");
-    return out;
-  })();
   const canManageCapabilities = authEnabled && (authCanIssue || authCanDelegate);
   const localReplicaHex = selfPeerId;
 
@@ -1348,9 +1093,7 @@ export default function App() {
               authTokenCount,
               authTokenScope,
               authTokenActions,
-              authScopeSummary,
-              authScopeTitle,
-              authSummaryBadges,
+              nodeLabelForId,
               selfPeerId,
               revealIdentity,
               setRevealIdentity,

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -216,7 +216,6 @@ export default function App() {
     syncAuth,
     refreshAuthMaterial,
     localIdentityChainPromiseRef,
-    getLocalIdentityChain,
     authToken,
     replica,
     selfPeerId,
@@ -384,6 +383,20 @@ export default function App() {
     []
   );
 
+  const recordOps = React.useCallback(
+    (incoming: Operation[], opts: { assumeSorted?: boolean } = {}) => {
+      if (incoming.length === 0) return;
+      let nextLamport = lamportRef.current;
+      for (const op of incoming) nextLamport = Math.max(nextLamport, op.meta.lamport);
+      if (nextLamport !== lamportRef.current) {
+        lamportRef.current = nextLamport;
+        setHeadLamport(nextLamport);
+      }
+      ingestOps(incoming, opts);
+    },
+    [ingestOps]
+  );
+
   const childrenLoadInFlightRef = useRef<Set<string>>(new Set());
 
   const ensureChildrenLoaded = React.useCallback(
@@ -541,6 +554,10 @@ export default function App() {
   );
 
   const getMaxLamport = React.useCallback(() => BigInt(lamportRef.current), []);
+  const getLoadedParentIds = React.useCallback(
+    () => Object.keys(treeStateRef.current.childrenByParent),
+    []
+  );
 
   const applyMaterializationEvent = React.useCallback(
     (event: MaterializationEvent) => {
@@ -592,19 +609,6 @@ export default function App() {
     if (!client) return;
     return client.onMaterialized(applyMaterializationEvent);
   }, [client, applyMaterializationEvent]);
-
-  const onRemoteOpsImported = React.useCallback(
-    async (appliedOps: Operation[]) => {
-      ingestOps(appliedOps);
-      if (appliedOps.length > 0) {
-        let max = 0;
-        for (const op of appliedOps) max = Math.max(max, op.meta.lamport);
-        lamportRef.current = Math.max(lamportRef.current, max);
-        setHeadLamport(lamportRef.current);
-      }
-    },
-    [ingestOps]
-  );
 
   const openNewPeerTab = () => {
     if (typeof window === "undefined") return;
@@ -660,17 +664,19 @@ export default function App() {
     joinMode,
     authCanSyncAll,
     viewRootId,
-    hardRevokedTokenIds,
-    revocationCutoverEnabled,
-    revocationCutoverTokenId,
-    revocationCutoverCounter,
-    treeStateRef,
+    getLoadedParentIds,
     refreshMeta,
-    getLocalIdentityChain,
-    onPeerIdentityChain,
     onAuthGrantMessage,
-    onRemoteOpsImported,
+    onRemoteOpsImported: recordOps,
   });
+
+  const recordLocalOps = React.useCallback(
+    (ops: Operation[]) => {
+      notifyLocalUpdate(ops);
+      recordOps(ops, { assumeSorted: true });
+    },
+    [notifyLocalUpdate, recordOps]
+  );
 
   const grantSubtreeToReplicaPubkey = React.useCallback(
     async (opts?: {
@@ -723,6 +729,27 @@ export default function App() {
     });
     return roots.map((id) => ({ id, label: nodeLabelForId(id) }));
   }, [privateRoots, nodeLabelForId]);
+
+  const expandPathTo = React.useCallback(
+    (nodeId: string) => {
+      setCollapse((prev) => {
+        const overrides = new Set(prev.overrides);
+        const setExpanded = (id: string) => {
+          if (prev.defaultCollapsed) overrides.add(id);
+          else overrides.delete(id);
+        };
+        setExpanded(nodeId);
+        let cur = index[nodeId]?.parentId ?? null;
+        while (cur) {
+          setExpanded(cur);
+          cur = index[cur]?.parentId ?? null;
+        }
+        return { ...prev, overrides };
+      });
+    },
+    [index]
+  );
+
   const visibleNodes = useMemo(() => {
     const acc: Array<{ node: DisplayNode; depth: number }> = [];
     const isCollapsed = (id: string) => {
@@ -929,11 +956,7 @@ export default function App() {
       }
       await verifyLocalOps([op]);
 
-      lamportRef.current = Math.max(lamportRef.current, op.meta.lamport);
-      setHeadLamport(lamportRef.current);
-
-      notifyLocalUpdate([op]);
-      ingestOps([op], { assumeSorted: true });
+      recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to append op", err);
       setError("Failed to append operation (see console)");
@@ -949,10 +972,7 @@ export default function App() {
     try {
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
       const op = await client.local.move(replica, nodeId, newParent, placement);
-      notifyLocalUpdate([op]);
-      ingestOps([op], { assumeSorted: true });
-      lamportRef.current = Math.max(lamportRef.current, op.meta.lamport);
-      setHeadLamport(lamportRef.current);
+      recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to append move op", err);
       setError("Failed to move node (see console)");
@@ -1046,28 +1066,8 @@ export default function App() {
         prev ? { ...prev, completed: normalizedCount, phase: "applying" } : prev
       );
 
-      for (const op of ops) {
-        lamportRef.current = Math.max(lamportRef.current, op.meta.lamport);
-      }
-      setHeadLamport(lamportRef.current);
-
-      notifyLocalUpdate(ops);
-      ingestOps(ops, { assumeSorted: true });
-      setCollapse((prev) => {
-        const overrides = new Set(prev.overrides);
-        const setExpanded = (id: string) => {
-          if (prev.defaultCollapsed) overrides.add(id);
-          else overrides.delete(id);
-        };
-        // Keep the chosen parent expanded so the user sees immediate children.
-        setExpanded(parentId);
-        let cur = index[parentId]?.parentId ?? null;
-        while (cur) {
-          setExpanded(cur);
-          cur = index[cur]?.parentId ?? null;
-        }
-        return { ...prev, overrides };
-      });
+      recordLocalOps(ops);
+      expandPathTo(parentId);
     } catch (err) {
       console.error("Failed to add nodes", err);
       setError("Failed to add nodes (see console)");
@@ -1087,27 +1087,11 @@ export default function App() {
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
       const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload);
-      notifyLocalUpdate([op]);
-      ingestOps([op], { assumeSorted: true });
+      recordLocalOps([op]);
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
       }
-      lamportRef.current = Math.max(lamportRef.current, op.meta.lamport);
-      setHeadLamport(lamportRef.current);
-      setCollapse((prev) => {
-        const overrides = new Set(prev.overrides);
-        const setExpanded = (id: string) => {
-          if (prev.defaultCollapsed) overrides.add(id);
-          else overrides.delete(id);
-        };
-        setExpanded(parentId);
-        let cur = index[parentId]?.parentId ?? null;
-        while (cur) {
-          setExpanded(cur);
-          cur = index[cur]?.parentId ?? null;
-        }
-        return { ...prev, overrides };
-      });
+      expandPathTo(parentId);
     } catch (err) {
       console.error("Failed to insert node", err);
       setError("Failed to insert node (see console)");

--- a/examples/playground/src/playground/components/ComposerPanel.tsx
+++ b/examples/playground/src/playground/components/ComposerPanel.tsx
@@ -80,7 +80,7 @@ export function ComposerPanel({
 
   return (
     <div
-      className={`rounded-2xl bg-slate-900/60 shadow-lg shadow-black/20 ring-1 ring-slate-800/60 ${containerPadding}`}
+      className={`min-w-0 rounded-2xl bg-slate-900/60 shadow-lg shadow-black/20 ring-1 ring-slate-800/60 ${containerPadding}`}
     >
       <div className={`${headerMargin} flex flex-wrap items-center justify-between gap-2`}>
         <div className="text-sm font-semibold uppercase tracking-wide text-slate-400">Composer</div>
@@ -98,21 +98,21 @@ export function ComposerPanel({
       {composerOpen ? (
         <>
           <form
-            className="flex flex-col gap-3 md:flex-row md:items-end"
+            className="flex min-w-0 flex-col gap-3 md:flex-row md:items-end"
             onSubmit={(e) => {
               e.preventDefault();
               void onAddNodes(parentChoice, nodeCount, { fanout });
             }}
           >
             <ParentPicker nodeList={nodeList} value={parentChoice} onChange={setParentChoice} disabled={!ready} />
-            <label className="w-full space-y-2 text-sm text-slate-200 md:w-52">
+            <label className="min-w-0 w-full space-y-2 text-sm text-slate-200 md:w-52">
               <span>Value (optional)</span>
               <input
                 type="text"
                 value={newNodeValue}
                 onChange={(e) => setNewNodeValue(e.target.value)}
                 placeholder="Stored as payload bytes"
-                className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
+                className="min-w-0 w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
                 disabled={!ready || busy || !canWritePayload}
               />
             </label>

--- a/examples/playground/src/playground/components/ComposerPanel.tsx
+++ b/examples/playground/src/playground/components/ComposerPanel.tsx
@@ -1,14 +1,9 @@
 import React from "react";
 import { MdExpandLess, MdExpandMore } from "react-icons/md";
 
-import { ParentPicker } from "./ParentPicker";
+import type { BulkAddProgress } from "../types";
 
-type BulkAddProgress = {
-  total: number;
-  completed: number;
-  phase: "creating" | "applying";
-  startedAtMs: number;
-};
+import { ParentPicker } from "./ParentPicker";
 
 export function ComposerPanel({
   composerOpen,

--- a/examples/playground/src/playground/components/OpsPanel.tsx
+++ b/examples/playground/src/playground/components/OpsPanel.tsx
@@ -26,7 +26,7 @@ export function OpsPanel({
   opsVirtualizer: Virtualizer<HTMLDivElement, Element>;
 }) {
   return (
-    <aside className="space-y-3 rounded-2xl bg-slate-900/60 p-5 shadow-lg shadow-black/20 ring-1 ring-slate-800/60">
+    <aside className="min-w-0 space-y-3 rounded-2xl bg-slate-900/60 p-5 shadow-lg shadow-black/20 ring-1 ring-slate-800/60">
       <div className="text-sm font-semibold uppercase tracking-wide text-slate-400">Operations</div>
       <div className="flex items-center justify-between text-xs text-slate-400">
         <span>Ops: {ops.length}</span>

--- a/examples/playground/src/playground/components/ParentPicker.tsx
+++ b/examples/playground/src/playground/components/ParentPicker.tsx
@@ -12,10 +12,10 @@ export const ParentPicker = React.memo(function ParentPicker({
   disabled: boolean;
 }) {
   return (
-    <label className="w-full md:w-52 space-y-2 text-sm text-slate-200">
+    <label className="min-w-0 w-full space-y-2 text-sm text-slate-200 md:w-52">
       <span>Parent</span>
       <select
-        className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
+        className="min-w-0 w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
@@ -30,4 +30,3 @@ export const ParentPicker = React.memo(function ParentPicker({
     </label>
   );
 });
-

--- a/examples/playground/src/playground/components/PlaygroundHeader.tsx
+++ b/examples/playground/src/playground/components/PlaygroundHeader.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MdContentCopy, MdGroup, MdLockOutline, MdOpenInNew, MdVpnKey } from "react-icons/md";
 
 import type { Status, StorageMode } from "../types";

--- a/examples/playground/src/playground/components/PlaygroundToast.tsx
+++ b/examples/playground/src/playground/components/PlaygroundToast.tsx
@@ -1,7 +1,7 @@
 import type { Dispatch, SetStateAction } from "react";
 
-export type ToastKind = "success" | "info" | "error";
-export type ToastAction = "sync" | "details";
+type ToastKind = "success" | "info" | "error";
+type ToastAction = "sync" | "details";
 export type ToastState = {
   kind: ToastKind;
   title: string;
@@ -10,7 +10,7 @@ export type ToastState = {
   durationMs?: number;
 };
 
-export type PlaygroundToastProps = {
+type PlaygroundToastProps = {
   toast: ToastState | null;
   setToast: Dispatch<SetStateAction<ToastState | null>>;
   onSync: () => void;
@@ -83,4 +83,3 @@ export function PlaygroundToast(props: PlaygroundToastProps) {
     </div>
   );
 }
-

--- a/examples/playground/src/playground/components/ShareSubtreeDialog.tsx
+++ b/examples/playground/src/playground/components/ShareSubtreeDialog.tsx
@@ -6,7 +6,7 @@ import type { InviteActions } from "../invite";
 
 import { InvitePermissionsEditor } from "./InvitePermissionsEditor";
 
-export type ShareSubtreeDialogProps = {
+type ShareSubtreeDialogProps = {
   open: boolean;
   onClose: () => void;
   busy: boolean;

--- a/examples/playground/src/playground/components/SharingAuthPanel.tsx
+++ b/examples/playground/src/playground/components/SharingAuthPanel.tsx
@@ -12,15 +12,7 @@ import {
   setSealedIdentityKeyB64,
   setSealedIssuerKeyB64,
 } from "../../auth";
-
-type AuthTokenScope = {
-  docId: string;
-  rootNodeId?: string;
-  maxDepth?: number;
-  excludeNodeIds?: string[];
-};
-
-type PendingOpEntry = { id: string; kind: string; message?: string };
+import type { PlaygroundAuthApi } from "../hooks/usePlaygroundAuth";
 
 export type SharingAuthPanelProps = {
   docId: string;
@@ -37,11 +29,9 @@ export type SharingAuthPanelProps = {
   authLocalKeyIdHex: string | null;
   authLocalTokenIdHex: string | null;
   authTokenCount: number;
-  authTokenScope: AuthTokenScope | null;
-  authTokenActions: string[] | null;
-  authScopeSummary: string;
-  authScopeTitle: string;
-  authSummaryBadges: string[];
+  authTokenScope: PlaygroundAuthApi["authTokenScope"];
+  authTokenActions: PlaygroundAuthApi["authTokenActions"];
+  nodeLabelForId: (id: string) => string;
 
   selfPeerId: string | null;
   copyToClipboard: (text: string) => Promise<void>;
@@ -62,17 +52,103 @@ export type SharingAuthPanelProps = {
   deviceSigningKeyBlobImportText: string;
   setDeviceSigningKeyBlobImportText: React.Dispatch<React.SetStateAction<string>>;
 
-  localIdentityChainPromiseRef: React.MutableRefObject<unknown | null>;
+  localIdentityChainPromiseRef: PlaygroundAuthApi["localIdentityChainPromiseRef"];
 
   client: unknown | null;
-  pendingOps: PendingOpEntry[];
+  pendingOps: PlaygroundAuthApi["pendingOps"];
   refreshPendingOps: () => Promise<void>;
 
   revealIdentity: boolean;
   setRevealIdentity: React.Dispatch<React.SetStateAction<boolean>>;
 
-  refreshAuthMaterial: () => Promise<unknown>;
+  refreshAuthMaterial: PlaygroundAuthApi["refreshAuthMaterial"];
 };
+
+type KeyMaterialCardProps = {
+  label: string;
+  value: string | null;
+  emptyLabel?: string;
+  copyTitle: string;
+  importText: string;
+  setImportText: React.Dispatch<React.SetStateAction<string>>;
+  importPlaceholder: string;
+  importTitle: string;
+  help: string;
+  authBusy: boolean;
+  copyToClipboard: (text: string) => Promise<void>;
+  setAuthError: React.Dispatch<React.SetStateAction<string | null>>;
+  onImport: (value: string) => void;
+};
+
+function KeyMaterialCard(props: KeyMaterialCardProps) {
+  const {
+    label,
+    value,
+    emptyLabel = "-",
+    copyTitle,
+    importText,
+    setImportText,
+    importPlaceholder,
+    importTitle,
+    help,
+    authBusy,
+    copyToClipboard,
+    setAuthError,
+    onImport,
+  } = props;
+
+  return (
+    <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">{label}</div>
+        <button
+          className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
+          type="button"
+          onClick={() =>
+            void copyToClipboard(value ?? "").catch((err) =>
+              setAuthError(err instanceof Error ? err.message : String(err))
+            )
+          }
+          disabled={authBusy || !value}
+          title={copyTitle}
+        >
+          <MdContentCopy className="text-[16px]" />
+          Copy
+        </button>
+      </div>
+      <div className="mt-1 font-mono text-slate-200" title={value ?? ""}>
+        {value ? `${value.slice(0, 24)}…` : emptyLabel}
+      </div>
+      <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          type="text"
+          value={importText}
+          onChange={(e) => setImportText(e.target.value)}
+          placeholder={importPlaceholder}
+          className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
+          disabled={authBusy}
+        />
+        <button
+          className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent/90 disabled:opacity-50"
+          type="button"
+          onClick={() => {
+            try {
+              onImport(importText);
+              setImportText("");
+            } catch (err) {
+              setAuthError(err instanceof Error ? err.message : String(err));
+            }
+          }}
+          disabled={authBusy || importText.trim().length === 0}
+          title={importTitle}
+        >
+          Import
+        </button>
+      </div>
+      <div className="mt-1 text-[11px] text-slate-500">{help}</div>
+    </div>
+  );
+}
 
 export function SharingAuthPanel(props: SharingAuthPanelProps) {
   const {
@@ -93,9 +169,7 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
     authTokenCount,
     authTokenScope,
     authTokenActions,
-    authScopeSummary,
-    authScopeTitle,
-    authSummaryBadges,
+    nodeLabelForId,
     selfPeerId,
     openMintingPeerTab,
     revealIdentity,
@@ -123,6 +197,31 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
   const sealedIdentityKeyB64 = getSealedIdentityKeyB64();
   const sealedDeviceSigningKeyB64 = getSealedDeviceSigningKeyB64();
   const userFacingAuthTokenActions = authTokenActions?.filter((name) => name !== "tombstone") ?? null;
+  const authScopeSummary = (() => {
+    if (!authTokenScope) return "-";
+    const rootId = (authTokenScope.rootNodeId ?? ROOT_ID).toLowerCase();
+    if (rootId === ROOT_ID) return "doc-wide";
+    const label = nodeLabelForId(rootId);
+    if (label && label !== rootId) return `subtree ${label}`;
+    return `subtree ${rootId.slice(0, 8)}…`;
+  })();
+  const authScopeTitle = (() => {
+    if (!authTokenScope) return "";
+    const rootId = (authTokenScope.rootNodeId ?? ROOT_ID).toLowerCase();
+    const parts = [`root=${rootId}`];
+    if (authTokenScope.maxDepth !== undefined) parts.push(`maxDepth=${authTokenScope.maxDepth}`);
+    const excludeCount = authTokenScope.excludeNodeIds?.length ?? 0;
+    if (excludeCount > 0) parts.push(`exclude=${excludeCount}`);
+    return parts.join(" ");
+  })();
+  const authSummaryBadges = (() => {
+    if (!Array.isArray(authTokenActions)) return [];
+    const set = new Set(authTokenActions.map(String));
+    const out: string[] = [];
+    if (set.has("write_structure") || set.has("write_payload")) out.push("write");
+    if (set.has("delete")) out.push("delete");
+    return out;
+  })();
 
   return (
     <div id="playground-auth-panel" className="mb-3 rounded-xl border border-slate-800/80 bg-slate-950/40 p-3 text-xs text-slate-300">
@@ -311,217 +410,84 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
           </div>
 
           <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
-            <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Device wrap key</div>
-                <button
-                  className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
-                  type="button"
-                  onClick={() =>
-                    void copyToClipboard(deviceWrapKeyB64 ?? "").catch((err) =>
-                      setAuthError(err instanceof Error ? err.message : String(err))
-                    )
-                  }
-                  disabled={authBusy || !deviceWrapKeyB64}
-                  title="Copy device wrap key"
-                >
-                  <MdContentCopy className="text-[16px]" />
-                  Copy
-                </button>
-              </div>
-              <div className="mt-1 font-mono text-slate-200" title={deviceWrapKeyB64 ?? ""}>
-                {deviceWrapKeyB64 ? `${deviceWrapKeyB64.slice(0, 24)}…` : "(initializing)"}
-              </div>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  type="text"
-                  value={wrapKeyImportText}
-                  onChange={(e) => setWrapKeyImportText(e.target.value)}
-                  placeholder="Paste base64url wrap key"
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
-                  disabled={authBusy}
-                />
-                <button
-                  className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent/90 disabled:opacity-50"
-                  type="button"
-                  onClick={() => {
-                    try {
-                      importDeviceWrapKeyB64(wrapKeyImportText);
-                      setWrapKeyImportText("");
-                      void refreshAuthMaterial().catch((err) =>
-                        setAuthError(err instanceof Error ? err.message : String(err))
-                      );
-                    } catch (err) {
-                      setAuthError(err instanceof Error ? err.message : String(err));
-                    }
-                  }}
-                  disabled={authBusy || wrapKeyImportText.trim().length === 0}
-                  title="Import device wrap key"
-                >
-                  Import
-                </button>
-              </div>
-              <div className="mt-1 text-[11px] text-slate-500">
-                Back up this key (e.g. Supabase). Needed to decrypt doc key blobs.
-              </div>
-            </div>
+            <KeyMaterialCard
+              label="Device wrap key"
+              value={deviceWrapKeyB64}
+              emptyLabel="(initializing)"
+              copyTitle="Copy device wrap key"
+              importText={wrapKeyImportText}
+              setImportText={setWrapKeyImportText}
+              importPlaceholder="Paste base64url wrap key"
+              importTitle="Import device wrap key"
+              help="Back up this key (e.g. Supabase). Needed to decrypt doc key blobs."
+              authBusy={authBusy}
+              copyToClipboard={copyToClipboard}
+              setAuthError={setAuthError}
+              onImport={(value) => {
+                importDeviceWrapKeyB64(value);
+                void refreshAuthMaterial().catch((err) =>
+                  setAuthError(err instanceof Error ? err.message : String(err))
+                );
+              }}
+            />
 
-            <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Issuer key blob</div>
-                <button
-                  className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
-                  type="button"
-                  onClick={() =>
-                    void copyToClipboard(sealedIssuerKeyB64 ?? "").catch((err) =>
-                      setAuthError(err instanceof Error ? err.message : String(err))
-                    )
-                  }
-                  disabled={authBusy || !sealedIssuerKeyB64}
-                  title="Copy sealed issuer key blob (base64url)"
-                >
-                  <MdContentCopy className="text-[16px]" />
-                  Copy
-                </button>
-              </div>
-              <div className="mt-1 font-mono text-slate-200" title={sealedIssuerKeyB64 ?? ""}>
-                {sealedIssuerKeyB64 ? `${sealedIssuerKeyB64.slice(0, 24)}…` : "-"}
-              </div>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  type="text"
-                  value={issuerKeyBlobImportText}
-                  onChange={(e) => setIssuerKeyBlobImportText(e.target.value)}
-                  placeholder="Paste sealed issuer key blob (base64url)"
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
-                  disabled={authBusy}
-                />
-                <button
-                  className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent/90 disabled:opacity-50"
-                  type="button"
-                  onClick={() => {
-                    try {
-                      setSealedIssuerKeyB64(docId, issuerKeyBlobImportText);
-                      setIssuerKeyBlobImportText("");
-                      void refreshAuthMaterial().catch((err) =>
-                        setAuthError(err instanceof Error ? err.message : String(err))
-                      );
-                    } catch (err) {
-                      setAuthError(err instanceof Error ? err.message : String(err));
-                    }
-                  }}
-                  disabled={authBusy || issuerKeyBlobImportText.trim().length === 0}
-                  title="Import sealed issuer key blob"
-                >
-                  Import
-                </button>
-              </div>
-              <div className="mt-1 text-[11px] text-slate-500">Encrypted at rest. Bound to this `docId` via AAD.</div>
-            </div>
+            <KeyMaterialCard
+              label="Issuer key blob"
+              value={sealedIssuerKeyB64}
+              copyTitle="Copy sealed issuer key blob (base64url)"
+              importText={issuerKeyBlobImportText}
+              setImportText={setIssuerKeyBlobImportText}
+              importPlaceholder="Paste sealed issuer key blob (base64url)"
+              importTitle="Import sealed issuer key blob"
+              help="Encrypted at rest. Bound to this `docId` via AAD."
+              authBusy={authBusy}
+              copyToClipboard={copyToClipboard}
+              setAuthError={setAuthError}
+              onImport={(value) => {
+                setSealedIssuerKeyB64(docId, value);
+                void refreshAuthMaterial().catch((err) =>
+                  setAuthError(err instanceof Error ? err.message : String(err))
+                );
+              }}
+            />
           </div>
 
           <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-2">
-            <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Identity key blob</div>
-                <button
-                  className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
-                  type="button"
-                  onClick={() =>
-                    void copyToClipboard(sealedIdentityKeyB64 ?? "").catch((err) =>
-                      setAuthError(err instanceof Error ? err.message : String(err))
-                    )
-                  }
-                  disabled={authBusy || !sealedIdentityKeyB64}
-                  title="Copy sealed identity key blob (base64url)"
-                >
-                  <MdContentCopy className="text-[16px]" />
-                  Copy
-                </button>
-              </div>
-              <div className="mt-1 font-mono text-slate-200" title={sealedIdentityKeyB64 ?? ""}>
-                {sealedIdentityKeyB64 ? `${sealedIdentityKeyB64.slice(0, 24)}…` : "-"}
-              </div>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  type="text"
-                  value={identityKeyBlobImportText}
-                  onChange={(e) => setIdentityKeyBlobImportText(e.target.value)}
-                  placeholder="Paste sealed identity key blob (base64url)"
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
-                  disabled={authBusy}
-                />
-                <button
-                  className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent/90 disabled:opacity-50"
-                  type="button"
-                  onClick={() => {
-                    try {
-                      setSealedIdentityKeyB64(identityKeyBlobImportText);
-                      setIdentityKeyBlobImportText("");
-                      localIdentityChainPromiseRef.current = null;
-                    } catch (err) {
-                      setAuthError(err instanceof Error ? err.message : String(err));
-                    }
-                  }}
-                  disabled={authBusy || identityKeyBlobImportText.trim().length === 0}
-                  title="Import sealed identity key blob"
-                >
-                  Import
-                </button>
-              </div>
-              <div className="mt-1 text-[11px] text-slate-500">Encrypted at rest. Requires the device wrap key to open.</div>
-            </div>
+            <KeyMaterialCard
+              label="Identity key blob"
+              value={sealedIdentityKeyB64}
+              copyTitle="Copy sealed identity key blob (base64url)"
+              importText={identityKeyBlobImportText}
+              setImportText={setIdentityKeyBlobImportText}
+              importPlaceholder="Paste sealed identity key blob (base64url)"
+              importTitle="Import sealed identity key blob"
+              help="Encrypted at rest. Requires the device wrap key to open."
+              authBusy={authBusy}
+              copyToClipboard={copyToClipboard}
+              setAuthError={setAuthError}
+              onImport={(value) => {
+                setSealedIdentityKeyB64(value);
+                localIdentityChainPromiseRef.current = null;
+              }}
+            />
 
-            <div className="rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">
-              <div className="flex items-center justify-between gap-2">
-                <div className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Device signing key blob</div>
-                <button
-                  className="flex items-center gap-2 rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
-                  type="button"
-                  onClick={() =>
-                    void copyToClipboard(sealedDeviceSigningKeyB64 ?? "").catch((err) =>
-                      setAuthError(err instanceof Error ? err.message : String(err))
-                    )
-                  }
-                  disabled={authBusy || !sealedDeviceSigningKeyB64}
-                  title="Copy sealed device signing key blob (base64url)"
-                >
-                  <MdContentCopy className="text-[16px]" />
-                  Copy
-                </button>
-              </div>
-              <div className="mt-1 font-mono text-slate-200" title={sealedDeviceSigningKeyB64 ?? ""}>
-                {sealedDeviceSigningKeyB64 ? `${sealedDeviceSigningKeyB64.slice(0, 24)}…` : "-"}
-              </div>
-              <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-                <input
-                  type="text"
-                  value={deviceSigningKeyBlobImportText}
-                  onChange={(e) => setDeviceSigningKeyBlobImportText(e.target.value)}
-                  placeholder="Paste sealed device signing key blob (base64url)"
-                  className="w-full rounded-lg border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
-                  disabled={authBusy}
-                />
-                <button
-                  className="rounded-lg bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-accent/30 transition hover:bg-accent/90 disabled:opacity-50"
-                  type="button"
-                  onClick={() => {
-                    try {
-                      setSealedDeviceSigningKeyB64(deviceSigningKeyBlobImportText);
-                      setDeviceSigningKeyBlobImportText("");
-                      localIdentityChainPromiseRef.current = null;
-                    } catch (err) {
-                      setAuthError(err instanceof Error ? err.message : String(err));
-                    }
-                  }}
-                  disabled={authBusy || deviceSigningKeyBlobImportText.trim().length === 0}
-                  title="Import sealed device signing key blob"
-                >
-                  Import
-                </button>
-              </div>
-              <div className="mt-1 text-[11px] text-slate-500">Encrypted at rest. Requires the device wrap key to open.</div>
-            </div>
+            <KeyMaterialCard
+              label="Device signing key blob"
+              value={sealedDeviceSigningKeyB64}
+              copyTitle="Copy sealed device signing key blob (base64url)"
+              importText={deviceSigningKeyBlobImportText}
+              setImportText={setDeviceSigningKeyBlobImportText}
+              importPlaceholder="Paste sealed device signing key blob (base64url)"
+              importTitle="Import sealed device signing key blob"
+              help="Encrypted at rest. Requires the device wrap key to open."
+              authBusy={authBusy}
+              copyToClipboard={copyToClipboard}
+              setAuthError={setAuthError}
+              onImport={(value) => {
+                setSealedDeviceSigningKeyB64(value);
+                localIdentityChainPromiseRef.current = null;
+              }}
+            />
           </div>
 
           <div className="mt-3 rounded-lg border border-slate-800/80 bg-slate-950/30 p-3">

--- a/examples/playground/src/playground/components/SharingAuthPanel.tsx
+++ b/examples/playground/src/playground/components/SharingAuthPanel.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../auth";
 import type { PlaygroundAuthApi } from "../hooks/usePlaygroundAuth";
 
-export type SharingAuthPanelProps = {
+type SharingAuthPanelProps = {
   docId: string;
   authEnabled: boolean;
   authBusy: boolean;

--- a/examples/playground/src/playground/components/TreePanel.tsx
+++ b/examples/playground/src/playground/components/TreePanel.tsx
@@ -162,9 +162,9 @@ export function TreePanel({
   );
 
   return (
-    <div className="rounded-2xl bg-slate-900/60 p-5 shadow-lg shadow-black/20 ring-1 ring-slate-800/60">
+    <div className="min-w-0 rounded-2xl bg-slate-900/60 p-5 shadow-lg shadow-black/20 ring-1 ring-slate-800/60">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-3">
+        <div className="min-w-0 flex items-center gap-3">
           <div className="text-sm font-semibold uppercase tracking-wide text-slate-400">Tree</div>
           <div className="text-xs text-slate-500">
             {totalNodes === null ? "…" : totalNodes} nodes
@@ -177,7 +177,7 @@ export function TreePanel({
             )}
           </div>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
           <button
             className={`flex h-9 items-center gap-2 rounded-lg border px-3 text-xs font-semibold transition disabled:opacity-50 ${
               online

--- a/examples/playground/src/playground/components/TreePanel.tsx
+++ b/examples/playground/src/playground/components/TreePanel.tsx
@@ -15,6 +15,7 @@ import {
 } from "react-icons/md";
 
 import { ROOT_ID } from "../constants";
+import type { IssuedGrantRecord } from "../hooks/usePlaygroundAuth";
 import type { CollapseState, DisplayNode, NodeMeta, PeerInfo } from "../types";
 
 import { PeersPanel } from "./PeersPanel";
@@ -134,15 +135,7 @@ export function TreePanel({
   selfPeerId: string | null;
   canManageCapabilities: boolean;
   authBusy: boolean;
-  issuedGrantRecords: Array<{
-    recipientPkHex: string;
-    tokenIdHex: string;
-    rootNodeId: string;
-    actions: string[];
-    maxDepth?: number;
-    excludeCount: number;
-    ts: number;
-  }>;
+  issuedGrantRecords: IssuedGrantRecord[];
   hardRevokedTokenIds: string[];
   toggleHardRevokedTokenId: (tokenIdHex: string) => void;
   scopeRootId: string;

--- a/examples/playground/src/playground/components/TreeRow.tsx
+++ b/examples/playground/src/playground/components/TreeRow.tsx
@@ -337,12 +337,12 @@ export function TreeRow({
 
   return (
     <div
-      className="group rounded-lg bg-slate-950/40 px-2 py-2 ring-1 ring-slate-800/50 transition hover:bg-slate-950/55 hover:ring-slate-700/70"
+      className="group min-w-0 rounded-lg bg-slate-950/40 px-2 py-2 ring-1 ring-slate-800/50 transition hover:bg-slate-950/55 hover:ring-slate-700/70"
       style={{ paddingLeft: `${8 + depth * 16}px` }}
       data-testid="tree-row"
       data-node-id={node.id}
     >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 items-center gap-2">
           <button
             className="flex h-8 w-8 items-center justify-center rounded-md border border-slate-800/70 bg-slate-900/60 text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
@@ -428,7 +428,7 @@ export function TreeRow({
             )}
           </div>
         </div>
-        <div className="flex flex-wrap gap-1.5">
+        <div className="flex min-w-0 flex-wrap gap-1.5">
           <button
             className="flex h-9 w-9 items-center justify-center rounded-lg border border-slate-800/70 bg-slate-900/60 text-slate-200 transition hover:border-accent hover:text-white disabled:opacity-50"
             onClick={() => onShare(node.id)}

--- a/examples/playground/src/playground/components/TreeRow.tsx
+++ b/examples/playground/src/playground/components/TreeRow.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import {
   MdAdd,

--- a/examples/playground/src/playground/components/TreeRow.tsx
+++ b/examples/playground/src/playground/components/TreeRow.tsx
@@ -26,17 +26,8 @@ import {
   type CapabilityAction,
 } from "../capabilities";
 import { ROOT_ID } from "../constants";
+import type { IssuedGrantRecord } from "../hooks/usePlaygroundAuth";
 import type { CollapseState, DisplayNode, NodeMeta, PeerInfo } from "../types";
-
-type IssuedGrantRecordRow = {
-  recipientPkHex: string;
-  tokenIdHex: string;
-  rootNodeId: string;
-  actions: string[];
-  maxDepth?: number;
-  excludeCount: number;
-  ts: number;
-};
 
 type MembersMenuLayout = {
   top: number;
@@ -98,7 +89,7 @@ export function TreeRow({
   authEnabled: boolean;
   canManageCapabilities: boolean;
   authBusy: boolean;
-  issuedGrantRecords: IssuedGrantRecordRow[];
+  issuedGrantRecords: IssuedGrantRecord[];
   hardRevokedTokenIds: string[];
   onToggleHardRevokedTokenId: (tokenIdHex: string) => void;
   onGrantToReplicaPubkey: (opts: {
@@ -163,7 +154,7 @@ export function TreeRow({
     [peers, selfPeerId]
   );
   const latestScopedGrantByPeer = useMemo(() => {
-    const out = new Map<string, IssuedGrantRecordRow>();
+    const out = new Map<string, IssuedGrantRecord>();
     for (const row of issuedGrantRecords) {
       if (row.rootNodeId !== nodeIdLower) continue;
       if (out.has(row.recipientPkHex)) continue;

--- a/examples/playground/src/playground/components/TreeRow.tsx
+++ b/examples/playground/src/playground/components/TreeRow.tsx
@@ -269,6 +269,18 @@ export function TreeRow({
     if (!canEditValue && isEditing) setIsEditing(false);
   }, [canEditValue, isEditing]);
 
+  const pendingValueWriteRef = useRef<Promise<void>>(Promise.resolve());
+  const writeDraftValue = useCallback(
+    (nextValue: string) => {
+      setDraftValue(nextValue);
+      const run = Promise.resolve().then(() => onSetValue(node.id, nextValue));
+      pendingValueWriteRef.current = run.catch((err) => {
+        console.error("Failed to live-write node payload", err);
+      });
+    },
+    [node.id, onSetValue]
+  );
+
   useEffect(() => {
     if (showMembersButton) return;
     setShowMembersMenu(false);
@@ -350,14 +362,14 @@ export function TreeRow({
                   className="flex items-center gap-2"
                   onSubmit={async (e) => {
                     e.preventDefault();
+                    await pendingValueWriteRef.current;
                     setIsEditing(false);
-                    await onSetValue(node.id, draftValue);
                   }}
                 >
                   <input
                     type="text"
                     value={draftValue}
-                    onChange={(e) => setDraftValue(e.target.value)}
+                    onChange={(e) => writeDraftValue(e.target.value)}
                     className="w-56 max-w-full rounded-md border border-slate-700 bg-slate-900/60 px-2 py-1 text-sm text-white outline-none focus:border-accent focus:ring-2 focus:ring-accent/50"
                   />
                   <button

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -278,7 +278,7 @@ export type PlaygroundAuthApi = {
   onAuthGrantMessage: (grant: AuthGrantMessageV1) => void;
 };
 
-export type UsePlaygroundAuthOptions = {
+type UsePlaygroundAuthOptions = {
   docId: string;
   joinMode: boolean;
   client: TreecrdtClient | null;

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -203,7 +203,6 @@ export type PlaygroundAuthApi = {
   showAuthAdvanced: boolean;
   setShowAuthAdvanced: React.Dispatch<React.SetStateAction<boolean>>;
   authInfo: string | null;
-  setAuthInfo: React.Dispatch<React.SetStateAction<string | null>>;
   authError: string | null;
   setAuthError: React.Dispatch<React.SetStateAction<string | null>>;
   authBusy: boolean;
@@ -225,13 +224,10 @@ export type PlaygroundAuthApi = {
   localIdentityChainPromiseRef: React.MutableRefObject<
     Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
   >;
-  getLocalIdentityChain: () => Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null>;
-  authToken: TreecrdtCapabilityTokenV1 | null;
 
   replica: Uint8Array | null;
   selfPeerId: string | null;
 
-  authActionSet: Set<string>;
   viewRootId: string;
   authCanSyncAll: boolean;
   canWriteStructure: boolean;
@@ -248,45 +244,23 @@ export type PlaygroundAuthApi = {
   authTokenScope: TreecrdtCapabilityTokenV1["caps"][number]["res"] | null;
   authTokenActions: TreecrdtCapabilityTokenV1["caps"][number]["actions"] | null;
   authNeedsInvite: boolean;
-  revocationKnownTokenIds: string[];
   hardRevokedTokenIds: string[];
   toggleHardRevokedTokenId: (tokenIdHex: string) => void;
-  clearHardRevokedTokenIds: () => void;
-  revocationTokenInput: string;
-  setRevocationTokenInput: React.Dispatch<React.SetStateAction<string>>;
-  addHardRevokedTokenId: () => void;
-  revocationCutoverEnabled: boolean;
-  setRevocationCutoverEnabled: React.Dispatch<React.SetStateAction<boolean>>;
-  revocationCutoverTokenId: string;
-  setRevocationCutoverTokenId: React.Dispatch<React.SetStateAction<string>>;
-  revocationCutoverCounter: string;
-  setRevocationCutoverCounter: React.Dispatch<React.SetStateAction<string>>;
 
   pendingOps: Array<{ id: string; kind: string; message?: string }>;
   refreshPendingOps: () => Promise<void>;
 
   privateRoots: Set<string>;
   privateRootsCount: number;
-  showPrivateRootsPanel: boolean;
-  setShowPrivateRootsPanel: React.Dispatch<React.SetStateAction<boolean>>;
   togglePrivateRoot: (id: string) => void;
-  clearPrivateRoots: () => void;
 
   inviteRoot: string;
-  setInviteRoot: React.Dispatch<React.SetStateAction<string>>;
-  inviteMaxDepth: string;
-  setInviteMaxDepth: React.Dispatch<React.SetStateAction<string>>;
   inviteActions: InviteActions;
   setInviteActions: React.Dispatch<React.SetStateAction<InviteActions>>;
   inviteAllowGrant: boolean;
   setInviteAllowGrant: React.Dispatch<React.SetStateAction<boolean>>;
-  inviteExcludeNodeIds: string[];
   inviteLink: string;
   generateInviteLink: (opts?: { rootNodeId?: string; copyToClipboard?: boolean }) => Promise<void>;
-
-  inviteImportText: string;
-  setInviteImportText: React.Dispatch<React.SetStateAction<string>>;
-  importInviteLink: () => Promise<void>;
 
   issuedGrantRecords: IssuedGrantRecord[];
   grantSubtreeToReplicaPubkey: (
@@ -360,13 +334,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
   const [authToken, setAuthToken] = useState<TreecrdtCapabilityTokenV1 | null>(null);
   const [hardRevokedTokenIds, setHardRevokedTokenIds] = useState<string[]>([]);
-  const [revocationTokenInput, setRevocationTokenInput] = useState("");
-  const [revocationCutoverEnabled, setRevocationCutoverEnabled] = useState(false);
-  const [revocationCutoverTokenId, setRevocationCutoverTokenId] = useState("");
-  const [revocationCutoverCounter, setRevocationCutoverCounter] = useState("");
 
   const [inviteRoot, setInviteRoot] = useState(ROOT_ID);
-  const [inviteMaxDepth, setInviteMaxDepth] = useState<string>("");
   const [inviteActions, setInviteActions] = useState<InviteActions>({
     write_structure: true,
     write_payload: true,
@@ -375,19 +344,13 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
   const [inviteAllowGrant, setInviteAllowGrant] = useState(true);
   const [inviteLink, setInviteLink] = useState<string>("");
   const inviteLinkConfigKeyRef = useRef<string | null>(null);
-  const [inviteImportText, setInviteImportText] = useState<string>("");
   const [issuedGrantRecords, setIssuedGrantRecords] = useState<IssuedGrantRecord[]>(() => loadIssuedGrantRecords(docId));
   const [pendingOps, setPendingOps] = useState<Array<{ id: string; kind: string; message?: string }>>([]);
 
   const [privateRoots, setPrivateRoots] = useState<Set<string>>(() => loadPrivateRoots(docId));
-  const [showPrivateRootsPanel, setShowPrivateRootsPanel] = useState(false);
   const privateRootsCount = useMemo(
     () => Array.from(privateRoots).filter((id) => id !== ROOT_ID).length,
     [privateRoots]
-  );
-  const inviteExcludeNodeIds = useMemo(
-    () => computeInviteExcludeNodeIds(privateRoots, inviteRoot),
-    [privateRoots, inviteRoot]
   );
 
   useEffect(() => {
@@ -448,14 +411,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
-      persistPrivateRoots(docId, next);
-      return next;
-    });
-  };
-
-  const clearPrivateRoots = () => {
-    setPrivateRoots(() => {
-      const next = new Set<string>();
       persistPrivateRoots(docId, next);
       return next;
     });
@@ -598,7 +553,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         localCapabilityTokens: localTokens,
         capabilityStore,
         revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
-        isCapabilityTokenRevoked: runtimeCutoverRevocationChecker,
         requireProofRef: true,
         scopeEvaluator,
         opAuthStore,
@@ -664,9 +618,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     hardRevokedTokenIds.join(","),
     getLocalIdentityChain,
     onPeerIdentityChain,
-    revocationCutoverEnabled,
-    revocationCutoverTokenId,
-    revocationCutoverCounter,
   ]);
 
   const replica = useMemo(() => (authMaterial.localPkB64 ? base64urlDecode(authMaterial.localPkB64) : null), [
@@ -776,31 +727,9 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
   const authTokenActions = authToken?.caps?.[0]?.actions ?? null;
   const authNeedsInvite = Boolean(authEnabled && joinMode && authTokenCount === 0);
 
-  const revocationKnownTokenIds = useMemo(() => {
-    const seen = new Set<string>();
-    for (const tokenB64 of authMaterial.localTokensB64) {
-      try {
-        seen.add(bytesToHex(deriveTokenIdV1(base64urlDecode(tokenB64))));
-      } catch {
-        // ignore malformed local token bytes
-      }
-    }
-    return Array.from(seen.values());
-  }, [authMaterial.localTokensB64.join(",")]);
-
   useEffect(() => {
     setHardRevokedTokenIds([]);
-    setRevocationTokenInput("");
-    setRevocationCutoverEnabled(false);
-    setRevocationCutoverTokenId("");
-    setRevocationCutoverCounter("");
   }, [docId]);
-
-  useEffect(() => {
-    if (revocationCutoverTokenId) return;
-    if (revocationKnownTokenIds.length === 0) return;
-    setRevocationCutoverTokenId(revocationKnownTokenIds[0]!);
-  }, [revocationCutoverTokenId, revocationKnownTokenIds]);
 
   const toggleHardRevokedTokenId = React.useCallback((tokenIdHex: string) => {
     const normalized = normalizeTokenIdHex(tokenIdHex);
@@ -811,46 +740,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     });
   }, []);
 
-  const clearHardRevokedTokenIds = React.useCallback(() => {
-    setHardRevokedTokenIds([]);
-  }, []);
-
-  const addHardRevokedTokenId = React.useCallback(() => {
-    const normalized = normalizeTokenIdHex(revocationTokenInput);
-    if (!normalized) {
-      setAuthError("Token id must be exactly 32 hex chars (16 bytes).");
-      return;
-    }
-    setHardRevokedTokenIds((prev) => (prev.includes(normalized) ? prev : [...prev, normalized]));
-    setRevocationTokenInput("");
-    setAuthError(null);
-  }, [revocationTokenInput]);
-
   const hardRevokedTokenIdBytes = useMemo(() => hardRevokedTokenIds.map((hex) => hexToBytes16(hex)), [hardRevokedTokenIds]);
-  const revocationCutoverTokenIdNormalized = useMemo(
-    () => normalizeTokenIdHex(revocationCutoverTokenId),
-    [revocationCutoverTokenId]
-  );
-  const revocationCutoverCounterValue = useMemo(() => {
-    const text = revocationCutoverCounter.trim();
-    if (text.length === 0) return null;
-    const parsed = Number(text);
-    if (!Number.isInteger(parsed) || parsed < 0) return null;
-    return parsed;
-  }, [revocationCutoverCounter]);
-
-  const runtimeCutoverRevocationChecker = React.useCallback(
-    (ctx: { stage: "parse" | "runtime"; tokenIdHex: string; op?: Operation }) => {
-      if (ctx.stage !== "runtime") return false;
-      if (!revocationCutoverEnabled) return false;
-      if (!revocationCutoverTokenIdNormalized) return false;
-      if (revocationCutoverCounterValue === null) return false;
-      if (ctx.tokenIdHex !== revocationCutoverTokenIdNormalized) return false;
-      if (!ctx.op) return false;
-      return ctx.op.meta.id.counter >= revocationCutoverCounterValue;
-    },
-    [revocationCutoverCounterValue, revocationCutoverEnabled, revocationCutoverTokenIdNormalized]
-  );
 
   const importInvitePayload = React.useCallback(
     async (inviteB64: string, opts2: { clearHash?: boolean } = {}) => {
@@ -905,7 +795,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     void (async () => {
       try {
         const current = await loadAuthMaterial(docId);
-        let { issuerPkB64, issuerSkB64, localPkB64, localSkB64, localTokensB64 } = current;
+        let { issuerSkB64, localPkB64, localSkB64, localTokensB64 } = current;
 
         const ensureIssuerKeys = async (): Promise<Pick<StoredAuthMaterial, "issuerPkB64" | "issuerSkB64">> => {
           const run = async (): Promise<Pick<StoredAuthMaterial, "issuerPkB64" | "issuerSkB64">> => {
@@ -982,7 +872,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
         if (authEnabled) {
           const ensured = await ensureIssuerKeys();
-          issuerPkB64 = ensured.issuerPkB64;
           issuerSkB64 = ensured.issuerSkB64;
         }
 
@@ -1034,7 +923,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         const next = await loadAuthMaterial(docId);
         if (cancelled) return;
         setAuthMaterial(next);
-        setAuthError(authEnabled ? null : null);
+        setAuthError(null);
       } catch (err) {
         if (cancelled) return;
         localAuthRef.current = null;
@@ -1051,7 +940,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     clearAuthMaterial(docId);
     setInviteLink("");
     inviteLinkConfigKeyRef.current = null;
-    setInviteImportText("");
     setAuthEnabled(false);
     setAuthError(null);
     void refreshAuthMaterial().catch((err) => setAuthError(err instanceof Error ? err.message : String(err)));
@@ -1077,16 +965,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     actions = expandInternalCompatActions(actions);
     if (actions.length === 0) actions = ["read_structure", "read_payload"];
 
-    const maxDepthText = inviteMaxDepth.trim();
-    let maxDepth: number | undefined;
-    if (maxDepthText.length > 0) {
-      const parsed = Number(maxDepthText);
-      if (!Number.isFinite(parsed) || parsed < 0) throw new Error("max depth must be a non-negative number");
-      maxDepth = parsed;
-    }
-
     const excludeNodeIds = computeInviteExcludeNodeIds(privateRoots, rootNodeId);
-    return { actions, maxDepth, excludeNodeIds };
+    return { actions, maxDepth: undefined, excludeNodeIds };
   };
 
   const inviteConfigCacheKey = (rootNodeId: string): string => {
@@ -1281,34 +1161,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         await copyToClipboard(link);
         setAuthInfo("Invite link copied to clipboard.");
       }
-    } catch (err) {
-      setAuthError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setAuthBusy(false);
-    }
-  };
-
-  const importInviteLink = async () => {
-    if (typeof window === "undefined") return;
-    const raw = inviteImportText.trim();
-    if (!raw) return;
-    setAuthBusy(true);
-    setAuthError(null);
-    try {
-      let inviteB64: string | null = null;
-      try {
-        const url = new URL(raw, window.location.href);
-        inviteB64 = new URLSearchParams(url.hash.slice(1)).get("invite");
-      } catch {
-        // not a URL; fall back to raw text parsing
-      }
-
-      if (!inviteB64) {
-        inviteB64 = raw.startsWith("invite=") ? raw.slice("invite=".length) : raw;
-      }
-
-      await importInvitePayload(inviteB64);
-      setInviteImportText("");
     } catch (err) {
       setAuthError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -1601,7 +1453,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     showAuthAdvanced,
     setShowAuthAdvanced,
     authInfo,
-    setAuthInfo,
     authError,
     setAuthError,
     authBusy,
@@ -1619,11 +1470,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     syncAuth,
     refreshAuthMaterial,
     localIdentityChainPromiseRef,
-    getLocalIdentityChain,
-    authToken,
     replica,
     selfPeerId,
-    authActionSet,
     viewRootId,
     authCanSyncAll,
     canWriteStructure,
@@ -1639,41 +1487,20 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     authTokenScope,
     authTokenActions,
     authNeedsInvite,
-    revocationKnownTokenIds,
     hardRevokedTokenIds,
     toggleHardRevokedTokenId,
-    clearHardRevokedTokenIds,
-    revocationTokenInput,
-    setRevocationTokenInput,
-    addHardRevokedTokenId,
-    revocationCutoverEnabled,
-    setRevocationCutoverEnabled,
-    revocationCutoverTokenId,
-    setRevocationCutoverTokenId,
-    revocationCutoverCounter,
-    setRevocationCutoverCounter,
     pendingOps,
     refreshPendingOps,
     privateRoots,
     privateRootsCount,
-    showPrivateRootsPanel,
-    setShowPrivateRootsPanel,
     togglePrivateRoot,
-    clearPrivateRoots,
     inviteRoot,
-    setInviteRoot,
-    inviteMaxDepth,
-    setInviteMaxDepth,
     inviteActions,
     setInviteActions,
     inviteAllowGrant,
     setInviteAllowGrant,
-    inviteExcludeNodeIds,
     inviteLink,
     generateInviteLink,
-    inviteImportText,
-    setInviteImportText,
-    importInviteLink,
     issuedGrantRecords,
     grantSubtreeToReplicaPubkey,
     resetAuth,

--- a/examples/playground/src/playground/hooks/usePlaygroundOpsLog.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundOpsLog.ts
@@ -1,0 +1,105 @@
+import React, { useEffect, useRef, useState } from 'react';
+import type { Operation } from '@treecrdt/interface';
+import type { TreecrdtClient } from '@treecrdt/wa-sqlite/client';
+
+import { compareOps, mergeSortedOps, opKey } from '../ops';
+import type { Status } from '../types';
+
+export function usePlaygroundOpsLog(opts: {
+  client: TreecrdtClient | null;
+  status: Status;
+  showOpsPanel: boolean;
+  lamportRef: React.MutableRefObject<number>;
+  setHeadLamport: React.Dispatch<React.SetStateAction<number>>;
+  setError: (message: string) => void;
+  refreshPayloadsForNodes: (active: TreecrdtClient, nodeIds: Iterable<string>) => Promise<void>;
+}) {
+  const {
+    client,
+    status,
+    showOpsPanel,
+    lamportRef,
+    setHeadLamport,
+    setError,
+    refreshPayloadsForNodes,
+  } = opts;
+  const [ops, setOps] = useState<Operation[]>([]);
+  const knownOpsRef = useRef<Set<string>>(new Set());
+  const showOpsPanelRef = useRef(false);
+
+  const resetOps = React.useCallback(() => {
+    setOps([]);
+    knownOpsRef.current = new Set();
+  }, []);
+
+  useEffect(() => {
+    showOpsPanelRef.current = showOpsPanel;
+    if (!showOpsPanel) resetOps();
+  }, [resetOps, showOpsPanel]);
+
+  const ingestOps = React.useCallback(
+    (incoming: Operation[], opts: { assumeSorted?: boolean } = {}) => {
+      if (!showOpsPanelRef.current) return;
+      if (incoming.length === 0) return;
+      const fresh: Operation[] = [];
+      const known = knownOpsRef.current;
+      for (const op of incoming) {
+        const key = opKey(op);
+        if (known.has(key)) continue;
+        known.add(key);
+        fresh.push(op);
+      }
+      if (fresh.length === 0) return;
+      if (!opts.assumeSorted) fresh.sort(compareOps);
+      setOps((prev) => mergeSortedOps(prev, fresh));
+    },
+    [],
+  );
+
+  const recordOps = React.useCallback(
+    (incoming: Operation[], opts: { assumeSorted?: boolean } = {}) => {
+      if (incoming.length === 0) return;
+      let nextLamport = lamportRef.current;
+      for (const op of incoming) nextLamport = Math.max(nextLamport, op.meta.lamport);
+      if (nextLamport !== lamportRef.current) {
+        lamportRef.current = nextLamport;
+        setHeadLamport(lamportRef.current);
+      }
+      ingestOps(incoming, opts);
+    },
+    [ingestOps, lamportRef, setHeadLamport],
+  );
+
+  useEffect(() => {
+    if (!showOpsPanel) return;
+    if (!client || status !== 'ready') return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const fetched = await client.ops.all();
+        if (cancelled) return;
+        fetched.sort(compareOps);
+        setOps(fetched);
+        knownOpsRef.current = new Set(fetched.map(opKey));
+
+        const payloadNodeIds = new Set<string>();
+        for (const op of fetched) {
+          const kind = op.kind;
+          if (kind.type === 'insert' || kind.type === 'payload' || kind.type === 'delete') {
+            payloadNodeIds.add(kind.node);
+          }
+        }
+        await refreshPayloadsForNodes(client, payloadNodeIds);
+      } catch (err) {
+        if (cancelled) return;
+        console.error('Failed to refresh ops', err);
+        setError('Failed to refresh operations (see console)');
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [client, refreshPayloadsForNodes, setError, showOpsPanel, status]);
+
+  return { ops, recordOps, resetOps };
+}

--- a/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
@@ -5,9 +5,11 @@ import type { TreecrdtClient } from '@treecrdt/wa-sqlite/client';
 
 import { loadOrCreateDocPayloadKeyB64 } from '../../auth';
 import { ROOT_ID } from '../constants';
-import type { PayloadRecord } from '../types';
 
-export type RawPayloadUpdate = { node: string; payload: Uint8Array | null };
+type PayloadRecord = {
+  payload: Uint8Array | null;
+  encrypted?: boolean;
+};
 
 function bytesEqual(left: Uint8Array | null, right: Uint8Array | null): boolean {
   if (left === right) return true;
@@ -92,7 +94,7 @@ export function usePlaygroundPayloads(opts: {
   );
 
   const applyPayloadUpdatesFromRaw = React.useCallback(
-    async (updates: Iterable<RawPayloadUpdate>) => {
+    async (updates: Iterable<{ node: string; payload: Uint8Array | null }>) => {
       let changed = false;
       const payloads = payloadByNodeRef.current;
       for (const { node, payload } of updates) {
@@ -120,7 +122,7 @@ export function usePlaygroundPayloads(opts: {
   );
 
   const schedulePayloadEventUpdates = React.useCallback(
-    (updates: RawPayloadUpdate[]) => {
+    (updates: Array<{ node: string; payload: Uint8Array | null }>) => {
       if (updates.length === 0) return;
       const run = payloadEventQueueRef.current
         .catch(() => undefined)

--- a/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
@@ -1,0 +1,166 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { base64urlDecode } from '@treecrdt/auth';
+import { encryptTreecrdtPayloadV1, maybeDecryptTreecrdtPayloadV1 } from '@treecrdt/crypto';
+import type { TreecrdtClient } from '@treecrdt/wa-sqlite/client';
+
+import { loadOrCreateDocPayloadKeyB64 } from '../../auth';
+import { ROOT_ID } from '../constants';
+import type { PayloadRecord } from '../types';
+
+export type RawPayloadUpdate = { node: string; payload: Uint8Array | null };
+
+function bytesEqual(left: Uint8Array | null, right: Uint8Array | null): boolean {
+  if (left === right) return true;
+  if (left === null || right === null) return false;
+  if (left.length !== right.length) return false;
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) return false;
+  }
+  return true;
+}
+
+function payloadRecordsEqual(left: PayloadRecord | undefined, right: PayloadRecord): boolean {
+  if (!left) return false;
+  return (
+    Boolean(left.encrypted) === Boolean(right.encrypted) && bytesEqual(left.payload, right.payload)
+  );
+}
+
+export function usePlaygroundPayloads(opts: {
+  docId: string;
+  setError: (message: string) => void;
+}) {
+  const { docId, setError } = opts;
+  const [payloadVersion, setPayloadVersion] = useState(0);
+  const textDecoder = useMemo(() => new TextDecoder(), []);
+  const docPayloadKeyRef = useRef<Uint8Array | null>(null);
+  const payloadByNodeRef = useRef<Map<string, PayloadRecord>>(new Map());
+  const payloadEventQueueRef = useRef<Promise<void>>(Promise.resolve());
+
+  const resetPayloadCache = React.useCallback(() => {
+    payloadEventQueueRef.current = Promise.resolve();
+    payloadByNodeRef.current = new Map();
+    setPayloadVersion((v) => v + 1);
+  }, []);
+
+  const refreshDocPayloadKey = React.useCallback(async () => {
+    const keyB64 = await loadOrCreateDocPayloadKeyB64(docId);
+    docPayloadKeyRef.current = base64urlDecode(keyB64);
+    return docPayloadKeyRef.current;
+  }, [docId]);
+
+  useEffect(() => {
+    docPayloadKeyRef.current = null;
+    resetPayloadCache();
+    let cancelled = false;
+    void (async () => {
+      try {
+        await refreshDocPayloadKey();
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshDocPayloadKey, resetPayloadCache, setError]);
+
+  const requireDocPayloadKey = React.useCallback(async (): Promise<Uint8Array> => {
+    if (docPayloadKeyRef.current) return docPayloadKeyRef.current;
+    const next = await refreshDocPayloadKey();
+    if (!next) throw new Error('doc payload key is missing');
+    return next;
+  }, [refreshDocPayloadKey]);
+
+  const decodePayloadRecord = React.useCallback(
+    async (raw: Uint8Array | null): Promise<PayloadRecord> => {
+      if (raw === null) return { payload: null, encrypted: false };
+      try {
+        const key = await requireDocPayloadKey();
+        const res = await maybeDecryptTreecrdtPayloadV1({
+          docId,
+          payloadKey: key,
+          bytes: raw,
+        });
+        return { payload: res.plaintext, encrypted: res.encrypted };
+      } catch {
+        return { payload: null, encrypted: true };
+      }
+    },
+    [docId, requireDocPayloadKey],
+  );
+
+  const applyPayloadUpdatesFromRaw = React.useCallback(
+    async (updates: Iterable<RawPayloadUpdate>) => {
+      let changed = false;
+      const payloads = payloadByNodeRef.current;
+      for (const { node, payload } of updates) {
+        if (node === ROOT_ID) continue;
+        const next = await decodePayloadRecord(payload);
+        if (payloadRecordsEqual(payloads.get(node), next)) continue;
+        payloads.set(node, next);
+        changed = true;
+      }
+      if (changed) setPayloadVersion((v) => v + 1);
+    },
+    [decodePayloadRecord],
+  );
+
+  const refreshPayloadsForNodes = React.useCallback(
+    async (active: TreecrdtClient, nodeIds: Iterable<string>) => {
+      const unique = [...new Set(nodeIds)].filter((id) => id !== ROOT_ID);
+      if (unique.length === 0) return;
+      const updates = await Promise.all(
+        unique.map(async (node) => ({ node, payload: await active.tree.getPayload(node) })),
+      );
+      await applyPayloadUpdatesFromRaw(updates);
+    },
+    [applyPayloadUpdatesFromRaw],
+  );
+
+  const schedulePayloadEventUpdates = React.useCallback(
+    (updates: RawPayloadUpdate[]) => {
+      if (updates.length === 0) return;
+      const run = payloadEventQueueRef.current
+        .catch(() => undefined)
+        .then(() => applyPayloadUpdatesFromRaw(updates));
+      payloadEventQueueRef.current = run.catch((err) => {
+        console.error('Failed to apply payload materialization event', err);
+      });
+    },
+    [applyPayloadUpdatesFromRaw],
+  );
+
+  const encryptPayloadBytes = React.useCallback(
+    async (payload: Uint8Array | null): Promise<Uint8Array | null> => {
+      if (payload === null) return null;
+      const key = await requireDocPayloadKey();
+      return await encryptTreecrdtPayloadV1({ docId, payloadKey: key, plaintext: payload });
+    },
+    [docId, requireDocPayloadKey],
+  );
+
+  const payloadDisplayForNode = React.useCallback(
+    (id: string): { label: string; value: string } => {
+      if (id === ROOT_ID) return { label: 'Root', value: '' };
+      const record = payloadByNodeRef.current.get(id);
+      const payload = record?.payload ?? null;
+      if (payload === null) {
+        return { label: record?.encrypted ? '(encrypted)' : id, value: '' };
+      }
+      const value = textDecoder.decode(payload);
+      return { label: value.length === 0 ? '(empty)' : value, value };
+    },
+    [payloadVersion, textDecoder],
+  );
+
+  return {
+    encryptPayloadBytes,
+    payloadDisplayForNode,
+    refreshDocPayloadKey,
+    refreshPayloadsForNodes,
+    resetPayloadCache,
+    schedulePayloadEventUpdates,
+  };
+}

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -152,7 +152,7 @@ function formatRemoteErrorDetail(
   if (!bootstrapHost || bootstrapHost === host) return base;
   return `${base} via ${bootstrapHost}`;
 }
-export type PlaygroundSyncApi = {
+type PlaygroundSyncApi = {
   peers: PeerInfo[];
   remoteSyncStatus: RemoteSyncStatus;
   syncBusy: boolean;
@@ -172,7 +172,7 @@ export type PlaygroundSyncApi = {
   ) => boolean;
 };
 
-export type UsePlaygroundSyncOptions = {
+type UsePlaygroundSyncOptions = {
   client: TreecrdtClient | null;
   status: 'booting' | 'ready' | 'error';
   docId: string;

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -205,7 +205,7 @@ export type UsePlaygroundSyncOptions = {
     replicaPublicKey: Uint8Array;
   }) => void;
   onAuthGrantMessage?: (grant: AuthGrantMessageV1) => void;
-  onRemoteOpsApplied: (ops: Operation[], affectedNodeIds: string[]) => Promise<void> | void;
+  onRemoteOpsApplied: (ops: Operation[]) => Promise<void> | void;
 };
 
 export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyncApi {
@@ -982,8 +982,8 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
         if (debugSync && ops.length > 0) {
           console.debug(`[sync:${selfPeerId}] applyOps(${ops.length})`);
         }
-        const affected = ops.length > 0 ? await client.ops.appendMany(ops) : [];
-        await onRemoteOpsApplied(ops, affected);
+        if (ops.length > 0) await client.ops.appendMany(ops);
+        await onRemoteOpsApplied(ops);
       },
     };
 

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Operation } from '@treecrdt/interface';
 import { bytesToHex } from '@treecrdt/interface/ids';
-import { type TreecrdtIdentityChainV1 } from '@treecrdt/auth';
 import {
   createStringStoreRouteCache,
   isDiscoveryBootstrapUrl,
@@ -38,7 +37,7 @@ import {
   PLAYGROUND_SYNC_MAX_OPS_PER_BATCH,
   ROOT_ID,
 } from '../constants';
-import type { PeerInfo, RemoteSyncStatus, SyncTransportMode, TreeState } from '../types';
+import type { PeerInfo, RemoteSyncStatus, SyncTransportMode } from '../types';
 import type { StoredAuthMaterial } from '../../auth';
 
 const REMOTE_SYNC_CODEWORDS_PER_MESSAGE = 512;
@@ -190,18 +189,8 @@ export type UsePlaygroundSyncOptions = {
   joinMode: boolean;
   authCanSyncAll: boolean;
   viewRootId: string;
-  hardRevokedTokenIds: string[];
-  revocationCutoverEnabled: boolean;
-  revocationCutoverTokenId: string;
-  revocationCutoverCounter: string;
-  treeStateRef: React.MutableRefObject<TreeState>;
+  getLoadedParentIds: () => string[];
   refreshMeta: () => Promise<void>;
-  getLocalIdentityChain: () => Promise<TreecrdtIdentityChainV1 | null>;
-  onPeerIdentityChain: (chain: {
-    identityPublicKey: Uint8Array;
-    devicePublicKey: Uint8Array;
-    replicaPublicKey: Uint8Array;
-  }) => void;
   onAuthGrantMessage?: (grant: AuthGrantMessageV1) => void;
   onRemoteOpsImported: (ops: Operation[]) => Promise<void> | void;
 };
@@ -224,7 +213,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     joinMode,
     authCanSyncAll,
     viewRootId,
-    treeStateRef,
+    getLoadedParentIds,
     refreshMeta,
     onAuthGrantMessage,
     onRemoteOpsImported,
@@ -635,7 +624,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
   };
 
   const handleScopedSync = async () => {
-    const parents = new Set(Object.keys(treeStateRef.current.childrenByParent));
+    const parents = new Set(getLoadedParentIds());
     parents.add(viewRootId);
     if (viewRootId !== ROOT_ID) parents.delete(ROOT_ID);
     const parentIds = Array.from(parents).filter((id) => /^[0-9a-f]{32}$/i.test(id));

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Operation } from '@treecrdt/interface';
 import { bytesToHex } from '@treecrdt/interface/ids';
 import {

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -196,8 +196,6 @@ export type UsePlaygroundSyncOptions = {
   revocationCutoverCounter: string;
   treeStateRef: React.MutableRefObject<TreeState>;
   refreshMeta: () => Promise<void>;
-  refreshParents: (parentIds: string[]) => Promise<void>;
-  refreshNodeCount: () => Promise<void>;
   getLocalIdentityChain: () => Promise<TreecrdtIdentityChainV1 | null>;
   onPeerIdentityChain: (chain: {
     identityPublicKey: Uint8Array;
@@ -205,7 +203,7 @@ export type UsePlaygroundSyncOptions = {
     replicaPublicKey: Uint8Array;
   }) => void;
   onAuthGrantMessage?: (grant: AuthGrantMessageV1) => void;
-  onRemoteOpsApplied: (ops: Operation[]) => Promise<void> | void;
+  onRemoteOpsImported: (ops: Operation[]) => Promise<void> | void;
 };
 
 export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyncApi {
@@ -228,10 +226,8 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     viewRootId,
     treeStateRef,
     refreshMeta,
-    refreshParents,
-    refreshNodeCount,
     onAuthGrantMessage,
-    onRemoteOpsApplied,
+    onRemoteOpsImported,
   } = opts;
 
   const [syncBusy, setSyncBusy] = useState(false);
@@ -284,17 +280,6 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     merged.sort((a, b) => a.id.localeCompare(b.id));
     setPeers(merged);
   };
-
-  const refreshLoadedSyncState = useCallback(
-    async (extraParentIds: Iterable<string> = []) => {
-      await refreshMeta();
-      const parentIds = new Set(Object.keys(treeStateRef.current.childrenByParent));
-      for (const parentId of extraParentIds) parentIds.add(parentId);
-      await refreshParents(Array.from(parentIds));
-      await refreshNodeCount();
-    },
-    [refreshMeta, refreshNodeCount, refreshParents, treeStateRef]
-  );
 
   const isRemotePeerId = (peerId: string) => peerId.startsWith('remote:');
   const syncOnceOptionsForPeer = (peerId: string, localCodewordsPerMessage: number) => ({
@@ -640,7 +625,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
         if (lastErr) throw lastErr;
         throw new Error('No peers responded to sync.');
       }
-      await refreshLoadedSyncState();
+      await refreshMeta();
     } catch (err) {
       console.error('Sync failed', err);
       setSyncError(formatSyncError(err));
@@ -711,7 +696,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
         if (lastErr) throw lastErr;
         throw new Error('No peers responded to sync.');
       }
-      await refreshLoadedSyncState();
+      await refreshMeta();
     } catch (err) {
       console.error('Scoped sync failed', err);
       setSyncError(formatSyncError(err));
@@ -794,7 +779,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
           );
         }
 
-        await refreshLoadedSyncState([viewRootId]);
+        await refreshMeta();
 
         autoSyncDoneRef.current = true;
         if (typeof window !== 'undefined') {
@@ -822,7 +807,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     authMaterial.localTokensB64.length,
     autoSyncJoinTick,
     joinMode,
-    refreshLoadedSyncState,
+    refreshMeta,
     syncBusy,
     viewRootId,
   ]);
@@ -983,7 +968,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
           console.debug(`[sync:${selfPeerId}] applyOps(${ops.length})`);
         }
         if (ops.length > 0) await client.ops.appendMany(ops);
-        await onRemoteOpsApplied(ops);
+        await onRemoteOpsImported(ops);
       },
     };
 
@@ -1234,7 +1219,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     getMaxLamport,
     joinMode,
     onAuthGrantMessage,
-    onRemoteOpsApplied,
+    onRemoteOpsImported,
     selfPeerId,
     syncServerUrl,
     transportMode,

--- a/examples/playground/src/playground/materializationEvents.ts
+++ b/examples/playground/src/playground/materializationEvents.ts
@@ -1,9 +1,9 @@
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
 
-import type { RawPayloadUpdate } from './hooks/usePlaygroundPayloads';
+type PayloadUpdate = { node: string; payload: Uint8Array | null };
 
-export type MaterializationRefreshPlan = {
-  payloadUpdates: RawPayloadUpdate[];
+type MaterializationRefreshPlan = {
+  payloadUpdates: PayloadUpdate[];
   parentsToRefresh: Set<string>;
 };
 
@@ -11,7 +11,7 @@ export function materializationRefreshPlan(
   event: MaterializationEvent,
   loadedChildren: Record<string, readonly string[]>,
 ): MaterializationRefreshPlan {
-  const payloadUpdates: RawPayloadUpdate[] = [];
+  const payloadUpdates: PayloadUpdate[] = [];
   const parentsToRefresh = new Set<string>();
 
   const addLoadedParent = (id: string | null | undefined) => {

--- a/examples/playground/src/playground/materializationEvents.ts
+++ b/examples/playground/src/playground/materializationEvents.ts
@@ -1,0 +1,48 @@
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
+
+import type { RawPayloadUpdate } from './hooks/usePlaygroundPayloads';
+
+export type MaterializationRefreshPlan = {
+  payloadUpdates: RawPayloadUpdate[];
+  parentsToRefresh: Set<string>;
+};
+
+export function materializationRefreshPlan(
+  event: MaterializationEvent,
+  loadedChildren: Record<string, readonly string[]>,
+): MaterializationRefreshPlan {
+  const payloadUpdates: RawPayloadUpdate[] = [];
+  const parentsToRefresh = new Set<string>();
+
+  const addLoadedParent = (id: string | null | undefined) => {
+    if (id && Object.prototype.hasOwnProperty.call(loadedChildren, id)) {
+      parentsToRefresh.add(id);
+    }
+  };
+
+  for (const change of event.changes) {
+    if (change.kind === 'payload') {
+      payloadUpdates.push({ node: change.node, payload: change.payload });
+      continue;
+    }
+
+    if (change.kind === 'insert') {
+      payloadUpdates.push({ node: change.node, payload: change.payload });
+      addLoadedParent(change.parentAfter);
+    } else if (change.kind === 'move') {
+      addLoadedParent(change.parentBefore);
+      addLoadedParent(change.parentAfter);
+    } else if (change.kind === 'delete') {
+      addLoadedParent(change.parentBefore);
+    } else if (change.kind === 'restore') {
+      payloadUpdates.push({ node: change.node, payload: change.payload });
+      addLoadedParent(change.parentAfter);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(loadedChildren, change.node)) {
+      parentsToRefresh.add(change.node);
+    }
+  }
+
+  return { payloadUpdates, parentsToRefresh };
+}

--- a/examples/playground/src/playground/materializationEvents.ts
+++ b/examples/playground/src/playground/materializationEvents.ts
@@ -9,15 +9,12 @@ type MaterializationRefreshPlan = {
 
 export function materializationRefreshPlan(
   event: MaterializationEvent,
-  loadedChildren: Record<string, readonly string[]>,
 ): MaterializationRefreshPlan {
   const payloadUpdates: PayloadUpdate[] = [];
   const parentsToRefresh = new Set<string>();
 
-  const addLoadedParent = (id: string | null | undefined) => {
-    if (id && Object.prototype.hasOwnProperty.call(loadedChildren, id)) {
-      parentsToRefresh.add(id);
-    }
+  const addParent = (id: string | null | undefined) => {
+    if (id) parentsToRefresh.add(id);
   };
 
   for (const change of event.changes) {
@@ -28,20 +25,18 @@ export function materializationRefreshPlan(
 
     if (change.kind === 'insert') {
       payloadUpdates.push({ node: change.node, payload: change.payload });
-      addLoadedParent(change.parentAfter);
+      addParent(change.parentAfter);
     } else if (change.kind === 'move') {
-      addLoadedParent(change.parentBefore);
-      addLoadedParent(change.parentAfter);
+      addParent(change.parentBefore);
+      addParent(change.parentAfter);
     } else if (change.kind === 'delete') {
-      addLoadedParent(change.parentBefore);
+      addParent(change.parentBefore);
     } else if (change.kind === 'restore') {
       payloadUpdates.push({ node: change.node, payload: change.payload });
-      addLoadedParent(change.parentAfter);
+      addParent(change.parentAfter);
     }
 
-    if (Object.prototype.hasOwnProperty.call(loadedChildren, change.node)) {
-      parentsToRefresh.add(change.node);
-    }
+    parentsToRefresh.add(change.node);
   }
 
   return { payloadUpdates, parentsToRefresh };

--- a/examples/playground/src/playground/treeState.ts
+++ b/examples/playground/src/playground/treeState.ts
@@ -13,13 +13,13 @@ export function applyChildrenLoaded(
   const ensureNode = (id: string): NodeMeta => {
     const existing = nextIndex[id];
     if (existing) return existing;
-    const meta: NodeMeta = { parentId: null, order: 0, childCount: 0, deleted: false };
+    const meta: NodeMeta = { parentId: null, order: 0, childCount: 0 };
     nextIndex[id] = meta;
     return meta;
   };
 
   ensureNode(ROOT_ID);
-  nextIndex[ROOT_ID] = { ...nextIndex[ROOT_ID]!, parentId: null, deleted: false };
+  nextIndex[ROOT_ID] = { ...nextIndex[ROOT_ID]!, parentId: null };
   if (!Object.prototype.hasOwnProperty.call(nextChildrenByParent, ROOT_ID)) nextChildrenByParent[ROOT_ID] = [];
 
   const parentMeta = ensureNode(parentId);
@@ -28,7 +28,6 @@ export function applyChildrenLoaded(
   nextIndex[parentId] = {
     ...parentMeta,
     parentId: resolvedParentId,
-    deleted: false,
     childCount: children.length,
   };
 
@@ -49,7 +48,7 @@ export function applyChildrenLoaded(
     const existing = ensureNode(childId);
     const loaded = Object.prototype.hasOwnProperty.call(nextChildrenByParent, childId);
     const childCount = loaded ? nextChildrenByParent[childId]!.length : existing.childCount;
-    nextIndex[childId] = { ...existing, parentId, order: i, deleted: false, childCount };
+    nextIndex[childId] = { ...existing, parentId, order: i, childCount };
   }
 
   return { index: nextIndex, childrenByParent: nextChildrenByParent };

--- a/examples/playground/src/playground/treeState.ts
+++ b/examples/playground/src/playground/treeState.ts
@@ -1,5 +1,3 @@
-import type { Operation } from "@treecrdt/interface";
-
 import { ROOT_ID } from "./constants";
 import type { NodeMeta, TreeState } from "./types";
 
@@ -55,17 +53,6 @@ export function applyChildrenLoaded(
   }
 
   return { index: nextIndex, childrenByParent: nextChildrenByParent };
-}
-
-export function nodesAffectedByPayloadOps(ops: Operation[]): Set<string> {
-  const out = new Set<string>();
-  for (const op of ops) {
-    const kind = op.kind;
-    if (kind.type === "insert" || kind.type === "payload" || kind.type === "delete") {
-      out.add(kind.node);
-    }
-  }
-  return out;
 }
 
 export function flattenForSelectState(

--- a/examples/playground/src/playground/treeState.ts
+++ b/examples/playground/src/playground/treeState.ts
@@ -68,26 +68,6 @@ export function nodesAffectedByPayloadOps(ops: Operation[]): Set<string> {
   return out;
 }
 
-export function parentsAffectedByOps(state: TreeState, ops: Operation[]): Set<string> {
-  const out = new Set<string>();
-  for (const op of ops) {
-    const kind = op.kind;
-    if (kind.type === "insert") {
-      out.add(kind.parent);
-    } else if (kind.type === "move") {
-      out.add(kind.newParent);
-      const prevParent = state.index[kind.node]?.parentId;
-      if (prevParent) out.add(prevParent);
-    } else if (kind.type === "payload") {
-      // Payload ops do not affect tree structure.
-    } else {
-      const prevParent = state.index[kind.node]?.parentId;
-      if (prevParent) out.add(prevParent);
-    }
-  }
-  return out;
-}
-
 export function flattenForSelectState(
   childrenByParent: Record<string, string[]>,
   getLabel?: (id: string) => string,

--- a/examples/playground/src/playground/types.ts
+++ b/examples/playground/src/playground/types.ts
@@ -20,6 +20,13 @@ export type CollapseState = {
   overrides: Set<string>;
 };
 
+export type BulkAddProgress = {
+  total: number;
+  completed: number;
+  phase: "creating" | "applying";
+  startedAtMs: number;
+};
+
 export type Status = "booting" | "ready" | "error";
 export type StorageMode = "memory" | "opfs";
 export type SyncTransportMode = "local" | "remote" | "hybrid";
@@ -32,8 +39,3 @@ export type RemoteSyncStatus =
   | { state: "error"; detail: string };
 
 export type PeerInfo = { id: string; lastSeen: number };
-
-export type PayloadRecord = {
-  payload: Uint8Array | null;
-  encrypted?: boolean;
-};

--- a/examples/playground/src/playground/types.ts
+++ b/examples/playground/src/playground/types.ts
@@ -2,14 +2,12 @@ export type DisplayNode = {
   id: string;
   label: string;
   value: string;
-  children: DisplayNode[];
 };
 
 export type NodeMeta = {
   parentId: string | null;
   order: number;
   childCount: number;
-  deleted: boolean;
 };
 
 export type TreeState = {

--- a/examples/playground/tests/playground.spec.ts
+++ b/examples/playground/tests/playground.spec.ts
@@ -478,6 +478,39 @@ test("insert and delete node", async ({ page }) => {
   await expect(parentRow).toHaveCount(0, { timeout: 30_000 });
 });
 
+test("live payload editing commits each keystroke without clobbering the draft", async ({ page }) => {
+  test.setTimeout(90_000);
+
+  const doc = uniqueDocId("pw-playground-live-payload");
+  await waitForReady(page, `/?doc=${encodeURIComponent(doc)}`);
+  await expectAuthEnabledByDefault(page);
+  await waitForLocalAuthTokens(page);
+
+  await page.getByPlaceholder("Stored as payload bytes").fill("seed");
+  await treeRowByNodeId(page, ROOT_ID).getByRole("button", { name: "Add child" }).click();
+
+  const seedRow = treeRowByLabel(page, "seed");
+  await expect(seedRow).toBeVisible({ timeout: 30_000 });
+  const nodeId = await seedRow.getAttribute("data-node-id");
+  expect(nodeId).toBeTruthy();
+
+  const row = treeRowByNodeId(page, nodeId!);
+  await row.getByRole("button", { name: "seed" }).click();
+  const input = row.getByRole("textbox");
+  await expect(input).toHaveValue("seed", { timeout: 30_000 });
+
+  await input.fill("");
+  await input.pressSequentially("abcdef", { delay: 1 });
+  await expect(input).toHaveValue("abcdef");
+
+  await row.getByRole("button", { name: "Save" }).click();
+  await expect(treeRowByNodeId(page, nodeId!).getByRole("button", { name: "abcdef" })).toBeVisible({ timeout: 30_000 });
+
+  await page.getByTitle("Toggle operations panel").click();
+  const opsPanel = page.locator("aside", { hasText: "Operations" });
+  await expect(opsPanel.getByText("Ops: 8")).toBeVisible({ timeout: 30_000 });
+});
+
 test("switching remote sync server URL reconnects to the new endpoint", async ({ page }) => {
   test.setTimeout(120_000);
 

--- a/packages/sync/material/sqlite/src/proof-material/sqlite.ts
+++ b/packages/sync/material/sqlite/src/proof-material/sqlite.ts
@@ -128,28 +128,21 @@ RETURNING 1
     storePendingOps: async (pending) => {
       if (pending.length === 0) return;
 
-      await opts.runner.exec('BEGIN');
-      try {
-        for (const p of pending) {
-          const opRef = opRefForOp(p.op);
-          const opBytes = encodeTreecrdtSyncV0Operation(p.op);
-          const proofRef = p.auth.proofRef ?? null;
-          const message = p.message ?? null;
-          await opts.runner.getText(insertSql, [
-            opts.docId,
-            opRef,
-            opBytes,
-            p.auth.sig,
-            proofRef,
-            p.reason,
-            message,
-            nowMs(),
-          ]);
-        }
-        await opts.runner.exec('COMMIT');
-      } catch (err) {
-        await opts.runner.exec('ROLLBACK');
-        throw err;
+      for (const p of pending) {
+        const opRef = opRefForOp(p.op);
+        const opBytes = encodeTreecrdtSyncV0Operation(p.op);
+        const proofRef = p.auth.proofRef ?? null;
+        const message = p.message ?? null;
+        await opts.runner.getText(insertSql, [
+          opts.docId,
+          opRef,
+          opBytes,
+          p.auth.sig,
+          proofRef,
+          p.reason,
+          message,
+          nowMs(),
+        ]);
       }
     },
 
@@ -195,15 +188,8 @@ RETURNING 1
 
     deletePendingOps: async (ops) => {
       if (ops.length === 0) return;
-      await opts.runner.exec('BEGIN');
-      try {
-        for (const op of ops) {
-          await opts.runner.getText(deleteSql, [opts.docId, opRefForOp(op)]);
-        }
-        await opts.runner.exec('COMMIT');
-      } catch (err) {
-        await opts.runner.exec('ROLLBACK');
-        throw err;
+      for (const op of ops) {
+        await opts.runner.getText(deleteSql, [opts.docId, opRefForOp(op)]);
       }
     },
   };
@@ -249,22 +235,9 @@ FROM (
     storeOpAuth: async (entries) => {
       if (entries.length === 0) return;
 
-      await opts.runner.exec('BEGIN');
-      try {
-        for (const e of entries) {
-          const proofRef = e.auth.proofRef ?? null;
-          await opts.runner.getText(insertSql, [
-            opts.docId,
-            e.opRef,
-            e.auth.sig,
-            proofRef,
-            nowMs(),
-          ]);
-        }
-        await opts.runner.exec('COMMIT');
-      } catch (err) {
-        await opts.runner.exec('ROLLBACK');
-        throw err;
+      for (const e of entries) {
+        const proofRef = e.auth.proofRef ?? null;
+        await opts.runner.getText(insertSql, [opts.docId, e.opRef, e.auth.sig, proofRef, nowMs()]);
       }
     },
 
@@ -327,15 +300,8 @@ FROM (
     storeCapabilities: async (caps) => {
       if (caps.length === 0) return;
 
-      await opts.runner.exec('BEGIN');
-      try {
-        for (const cap of caps) {
-          await opts.runner.getText(insertSql, [opts.docId, cap.name, cap.value, nowMs()]);
-        }
-        await opts.runner.exec('COMMIT');
-      } catch (err) {
-        await opts.runner.exec('ROLLBACK');
-        throw err;
+      for (const cap of caps) {
+        await opts.runner.getText(insertSql, [opts.docId, cap.name, cap.value, nowMs()]);
       }
     },
 

--- a/packages/sync/protocol/tests/smoke.test.ts
+++ b/packages/sync/protocol/tests/smoke.test.ts
@@ -577,6 +577,15 @@ test('syncOnce waits for ribltStatus.more before sending another codeword batch'
   const a = new MemoryBackend(docId);
   const b = new MemoryBackend(docId);
 
+  const commonOp = makeOp(replicas.b, 1, 1, {
+    type: 'insert',
+    parent: root,
+    node: nodeIdFromInt(100),
+    orderKey: orderKeyFromPosition(100),
+  });
+  await a.applyOps([commonOp]);
+  await b.applyOps([commonOp]);
+
   const ops: Operation[] = [];
   for (let i = 1; i <= 12; i += 1) {
     ops.push(

--- a/packages/treecrdt-core/src/affected.rs
+++ b/packages/treecrdt-core/src/affected.rs
@@ -1,5 +1,6 @@
 use crate::ids::NodeId;
 use crate::ops::OperationKind;
+use crate::types::MaterializationChange;
 
 pub(crate) fn affected_parents(
     snapshot_parent: Option<NodeId>,
@@ -21,48 +22,178 @@ pub(crate) fn affected_parents(
     parents
 }
 
-pub(crate) fn sorted_node_ids(nodes: impl IntoIterator<Item = NodeId>) -> Vec<NodeId> {
-    let mut ids: Vec<NodeId> = nodes.into_iter().collect();
-    ids.sort();
-    ids.dedup();
-    ids
-}
-
 pub(crate) fn parent_hints_from(parent: Option<NodeId>) -> Vec<NodeId> {
     parent.into_iter().collect()
 }
 
-fn push_if_live(nodes: &mut Vec<NodeId>, id: NodeId) {
-    if id != NodeId::TRASH {
-        nodes.push(id);
-    }
-}
-
-fn push_snapshot_parent(nodes: &mut Vec<NodeId>, snapshot_parent: Option<NodeId>) {
-    if let Some(p) = snapshot_parent {
-        push_if_live(nodes, p);
-    }
-}
-
-pub(crate) fn direct_affected_nodes(
+pub(crate) fn direct_materialization_changes(
     snapshot_parent: Option<NodeId>,
     kind: &OperationKind,
-) -> Vec<NodeId> {
-    let mut nodes = Vec::new();
-    push_if_live(&mut nodes, kind.node());
+) -> Vec<MaterializationChange> {
     match kind {
-        OperationKind::Insert { parent, .. } => {
-            push_snapshot_parent(&mut nodes, snapshot_parent);
-            push_if_live(&mut nodes, *parent);
+        OperationKind::Insert {
+            parent,
+            node,
+            payload,
+            ..
+        } => {
+            let mut changes = vec![MaterializationChange::Insert {
+                node: *node,
+                parent_after: *parent,
+            }];
+            if payload.is_some() {
+                changes.push(MaterializationChange::Payload { node: *node });
+            }
+            changes
         }
-        OperationKind::Move { new_parent, .. } => {
-            push_snapshot_parent(&mut nodes, snapshot_parent);
-            push_if_live(&mut nodes, *new_parent);
-        }
-        OperationKind::Delete { .. } | OperationKind::Tombstone { .. } => {
-            push_snapshot_parent(&mut nodes, snapshot_parent);
-        }
-        OperationKind::Payload { .. } => {}
+        OperationKind::Move {
+            node, new_parent, ..
+        } => vec![MaterializationChange::Move {
+            node: *node,
+            parent_before: snapshot_parent.filter(|parent| *parent != NodeId::TRASH),
+            parent_after: *new_parent,
+        }],
+        OperationKind::Payload { node, .. } => vec![MaterializationChange::Payload { node: *node }],
+        OperationKind::Delete { .. } | OperationKind::Tombstone { .. } => Vec::new(),
     }
-    sorted_node_ids(nodes)
+}
+
+#[derive(Clone, Debug)]
+struct StructuralChange {
+    first_parent: Option<NodeId>,
+    final_parent: NodeId,
+    inserted: bool,
+}
+
+#[derive(Clone, Debug)]
+struct TombstoneChange {
+    first_is_restore: bool,
+    last_parent: Option<NodeId>,
+    count: usize,
+}
+
+pub(crate) fn coalesce_materialization_changes(
+    changes: Vec<MaterializationChange>,
+) -> Vec<MaterializationChange> {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut structural: BTreeMap<NodeId, StructuralChange> = BTreeMap::new();
+    let mut tombstone: BTreeMap<NodeId, TombstoneChange> = BTreeMap::new();
+    let mut payload: BTreeSet<NodeId> = BTreeSet::new();
+
+    for change in changes {
+        match change {
+            MaterializationChange::Insert { node, parent_after } => {
+                structural
+                    .entry(node)
+                    .and_modify(|existing| {
+                        existing.final_parent = parent_after;
+                        existing.inserted = true;
+                    })
+                    .or_insert(StructuralChange {
+                        first_parent: None,
+                        final_parent: parent_after,
+                        inserted: true,
+                    });
+            }
+            MaterializationChange::Move {
+                node,
+                parent_before,
+                parent_after,
+            } => {
+                structural
+                    .entry(node)
+                    .and_modify(|existing| existing.final_parent = parent_after)
+                    .or_insert(StructuralChange {
+                        first_parent: parent_before,
+                        final_parent: parent_after,
+                        inserted: false,
+                    });
+            }
+            MaterializationChange::Delete {
+                node,
+                parent_before,
+            } => {
+                tombstone
+                    .entry(node)
+                    .and_modify(|existing| {
+                        existing.last_parent = parent_before;
+                        existing.count += 1;
+                    })
+                    .or_insert(TombstoneChange {
+                        first_is_restore: false,
+                        last_parent: parent_before,
+                        count: 1,
+                    });
+            }
+            MaterializationChange::Restore { node, parent_after } => {
+                tombstone
+                    .entry(node)
+                    .and_modify(|existing| {
+                        existing.last_parent = parent_after;
+                        existing.count += 1;
+                    })
+                    .or_insert(TombstoneChange {
+                        first_is_restore: true,
+                        last_parent: parent_after,
+                        count: 1,
+                    });
+            }
+            MaterializationChange::Payload { node } => {
+                payload.insert(node);
+            }
+        }
+    }
+
+    let deleted_nodes: BTreeSet<NodeId> = tombstone
+        .iter()
+        .filter_map(|(node, change)| {
+            if change.count % 2 == 1 && !change.first_is_restore {
+                Some(*node)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let mut coalesced = Vec::new();
+    for (node, change) in structural {
+        if change.inserted {
+            coalesced.push(MaterializationChange::Insert {
+                node,
+                parent_after: change.final_parent,
+            });
+        } else {
+            coalesced.push(MaterializationChange::Move {
+                node,
+                parent_before: change.first_parent,
+                parent_after: change.final_parent,
+            });
+        }
+    }
+
+    for (node, change) in tombstone {
+        if change.count % 2 == 0 {
+            continue;
+        }
+        if change.first_is_restore {
+            coalesced.push(MaterializationChange::Restore {
+                node,
+                parent_after: change.last_parent,
+            });
+        } else {
+            coalesced.push(MaterializationChange::Delete {
+                node,
+                parent_before: change.last_parent,
+            });
+        }
+    }
+
+    for node in payload {
+        if !deleted_nodes.contains(&node) {
+            coalesced.push(MaterializationChange::Payload { node });
+        }
+    }
+
+    coalesced
 }

--- a/packages/treecrdt-core/src/affected.rs
+++ b/packages/treecrdt-core/src/affected.rs
@@ -2,6 +2,14 @@ use crate::ids::NodeId;
 use crate::ops::OperationKind;
 use crate::types::MaterializationChange;
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TombstoneDelta {
+    pub(crate) node: NodeId,
+    pub(crate) parent: Option<NodeId>,
+    pub(crate) previous: bool,
+    pub(crate) tombstoned: bool,
+}
+
 pub(crate) fn affected_parents(
     snapshot_parent: Option<NodeId>,
     kind: &OperationKind,
@@ -55,6 +63,27 @@ pub(crate) fn direct_materialization_changes(
         }],
         OperationKind::Payload { node, .. } => vec![MaterializationChange::Payload { node: *node }],
         OperationKind::Delete { .. } | OperationKind::Tombstone { .. } => Vec::new(),
+    }
+}
+
+pub(crate) fn materialization_change_from_tombstone_delta(
+    delta: TombstoneDelta,
+) -> Option<MaterializationChange> {
+    if delta.node == NodeId::TRASH {
+        return None;
+    }
+
+    let parent = delta.parent.filter(|parent| *parent != NodeId::TRASH);
+    match (delta.previous, delta.tombstoned) {
+        (true, false) => Some(MaterializationChange::Restore {
+            node: delta.node,
+            parent_after: parent,
+        }),
+        (false, true) => Some(MaterializationChange::Delete {
+            node: delta.node,
+            parent_before: parent,
+        }),
+        _ => None,
     }
 }
 

--- a/packages/treecrdt-core/src/affected.rs
+++ b/packages/treecrdt-core/src/affected.rs
@@ -2,12 +2,13 @@ use crate::ids::NodeId;
 use crate::ops::OperationKind;
 use crate::types::MaterializationChange;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct TombstoneDelta {
     pub(crate) node: NodeId,
     pub(crate) parent: Option<NodeId>,
     pub(crate) previous: bool,
     pub(crate) tombstoned: bool,
+    pub(crate) payload_after: Option<Vec<u8>>,
 }
 
 pub(crate) fn affected_parents(
@@ -45,14 +46,11 @@ pub(crate) fn direct_materialization_changes(
             payload,
             ..
         } => {
-            let mut changes = vec![MaterializationChange::Insert {
+            vec![MaterializationChange::Insert {
                 node: *node,
                 parent_after: *parent,
-            }];
-            if payload.is_some() {
-                changes.push(MaterializationChange::Payload { node: *node });
-            }
-            changes
+                payload: payload.clone(),
+            }]
         }
         OperationKind::Move {
             node, new_parent, ..
@@ -61,7 +59,10 @@ pub(crate) fn direct_materialization_changes(
             parent_before: snapshot_parent.filter(|parent| *parent != NodeId::TRASH),
             parent_after: *new_parent,
         }],
-        OperationKind::Payload { node, .. } => vec![MaterializationChange::Payload { node: *node }],
+        OperationKind::Payload { node, payload } => vec![MaterializationChange::Payload {
+            node: *node,
+            payload: payload.clone(),
+        }],
         OperationKind::Delete { .. } | OperationKind::Tombstone { .. } => Vec::new(),
     }
 }
@@ -78,6 +79,7 @@ pub(crate) fn materialization_change_from_tombstone_delta(
         (true, false) => Some(MaterializationChange::Restore {
             node: delta.node,
             parent_after: parent,
+            payload: delta.payload_after,
         }),
         (false, true) => Some(MaterializationChange::Delete {
             node: delta.node,
@@ -92,12 +94,14 @@ struct StructuralChange {
     first_parent: Option<NodeId>,
     final_parent: NodeId,
     inserted: bool,
+    payload_after: Option<Vec<u8>>,
 }
 
 #[derive(Clone, Debug)]
 struct TombstoneChange {
     first_is_restore: bool,
     last_parent: Option<NodeId>,
+    payload_after: Option<Vec<u8>>,
     count: usize,
 }
 
@@ -108,21 +112,27 @@ pub(crate) fn coalesce_materialization_changes(
 
     let mut structural: BTreeMap<NodeId, StructuralChange> = BTreeMap::new();
     let mut tombstone: BTreeMap<NodeId, TombstoneChange> = BTreeMap::new();
-    let mut payload: BTreeSet<NodeId> = BTreeSet::new();
+    let mut payload: BTreeMap<NodeId, Option<Vec<u8>>> = BTreeMap::new();
 
     for change in changes {
         match change {
-            MaterializationChange::Insert { node, parent_after } => {
+            MaterializationChange::Insert {
+                node,
+                parent_after,
+                payload,
+            } => {
                 structural
                     .entry(node)
                     .and_modify(|existing| {
                         existing.final_parent = parent_after;
                         existing.inserted = true;
+                        existing.payload_after = payload.clone();
                     })
                     .or_insert(StructuralChange {
                         first_parent: None,
                         final_parent: parent_after,
                         inserted: true,
+                        payload_after: payload,
                     });
             }
             MaterializationChange::Move {
@@ -137,6 +147,7 @@ pub(crate) fn coalesce_materialization_changes(
                         first_parent: parent_before,
                         final_parent: parent_after,
                         inserted: false,
+                        payload_after: None,
                     });
             }
             MaterializationChange::Delete {
@@ -152,24 +163,34 @@ pub(crate) fn coalesce_materialization_changes(
                     .or_insert(TombstoneChange {
                         first_is_restore: false,
                         last_parent: parent_before,
+                        payload_after: None,
                         count: 1,
                     });
             }
-            MaterializationChange::Restore { node, parent_after } => {
+            MaterializationChange::Restore {
+                node,
+                parent_after,
+                payload,
+            } => {
                 tombstone
                     .entry(node)
                     .and_modify(|existing| {
                         existing.last_parent = parent_after;
+                        existing.payload_after = payload.clone();
                         existing.count += 1;
                     })
                     .or_insert(TombstoneChange {
                         first_is_restore: true,
                         last_parent: parent_after,
+                        payload_after: payload,
                         count: 1,
                     });
             }
-            MaterializationChange::Payload { node } => {
-                payload.insert(node);
+            MaterializationChange::Payload {
+                node,
+                payload: payload_after,
+            } => {
+                payload.insert(node, payload_after);
             }
         }
     }
@@ -188,9 +209,11 @@ pub(crate) fn coalesce_materialization_changes(
     let mut coalesced = Vec::new();
     for (node, change) in structural {
         if change.inserted {
+            let payload_after = payload.remove(&node).unwrap_or(change.payload_after);
             coalesced.push(MaterializationChange::Insert {
                 node,
                 parent_after: change.final_parent,
+                payload: payload_after,
             });
         } else {
             coalesced.push(MaterializationChange::Move {
@@ -206,9 +229,11 @@ pub(crate) fn coalesce_materialization_changes(
             continue;
         }
         if change.first_is_restore {
+            let payload_after = payload.remove(&node).unwrap_or(change.payload_after);
             coalesced.push(MaterializationChange::Restore {
                 node,
                 parent_after: change.last_parent,
+                payload: payload_after,
             });
         } else {
             coalesced.push(MaterializationChange::Delete {
@@ -218,9 +243,12 @@ pub(crate) fn coalesce_materialization_changes(
         }
     }
 
-    for node in payload {
+    for (node, payload_after) in payload {
         if !deleted_nodes.contains(&node) {
-            coalesced.push(MaterializationChange::Payload { node });
+            coalesced.push(MaterializationChange::Payload {
+                node,
+                payload: payload_after,
+            });
         }
     }
 

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -34,5 +34,8 @@ pub use traits::{
     PayloadStore, Storage, TruncatingParentOpIndex,
 };
 pub use tree::TreeCrdt;
-pub use types::{ApplyDelta, LocalFinalizePlan, LocalPlacement, NodeExport, NodeSnapshotExport};
+pub use types::{
+    ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
+    NodeExport, NodeSnapshotExport,
+};
 pub use version_vector::VersionVector;

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 
+use crate::affected::coalesce_materialization_changes;
 use crate::ops::{cmp_op_key, cmp_ops, Operation};
 use crate::traits::{
     Clock, ExactNodeStore, ExactPayloadStore, LamportClock, MemoryNodeStore, MemoryPayloadStore,
@@ -8,7 +9,10 @@ use crate::traits::{
     TruncatingParentOpIndex,
 };
 use crate::tree::TreeCrdt;
-use crate::{Error, Lamport, NodeId, OperationId, ReplicaId, Result};
+use crate::{
+    Error, Lamport, MaterializationChange, MaterializationOutcome, NodeId, OperationId, ReplicaId,
+    Result,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MaterializationKey<R = Vec<u8>> {
@@ -154,24 +158,24 @@ impl FrontierRewindStorage for NoopStorage {}
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct IncrementalApplyResult {
     pub head: Option<MaterializationHead>,
-    pub affected_nodes: Vec<NodeId>,
+    pub outcome: MaterializationOutcome,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CatchUpResult {
     pub head: Option<MaterializationHead>,
-    pub affected_nodes: Vec<NodeId>,
+    pub outcome: MaterializationOutcome,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PersistedRemoteApplyResult {
     /// Number of ops from the input batch that were actually inserted by adapter-side dedupe.
     pub inserted_count: u64,
-    /// Nodes changed by core materialization when incremental replay succeeded.
+    /// Structured changes produced by core materialization when replay succeeded.
     ///
     /// This is empty when nothing was inserted or when the helper could not advance
     /// materialization immediately and had to hand catch-up work back to the caller.
-    pub affected_nodes: Vec<NodeId>,
+    pub outcome: MaterializationOutcome,
     /// True when the helper recorded/kept a replay frontier and expects the caller to perform
     /// catch-up.
     pub catch_up_needed: bool,
@@ -181,7 +185,7 @@ pub struct PersistedRemoteApplyResult {
 pub struct PayloadNoopShortcut {
     pub resumed_head: MaterializationHead,
     pub remaining_ops: Vec<Operation>,
-    pub affected_nodes: Vec<NodeId>,
+    pub outcome: MaterializationOutcome,
 }
 
 /// Backend-owned stores used to replay already-persisted remote ops through core semantics.
@@ -490,7 +494,6 @@ where
     }
 
     let mut skipped = 0u64;
-    let mut affected = HashSet::new();
     let mut remaining_ops = Vec::new();
 
     for op in ops {
@@ -513,16 +516,13 @@ where
         }
 
         skipped = skipped.saturating_add(1);
-        affected.insert(node);
     }
 
     if skipped == 0 {
         return Ok(None);
     }
 
-    let mut affected_nodes: Vec<NodeId> = affected.into_iter().collect();
-    affected_nodes.sort();
-
+    let resumed_seq = head.seq.saturating_add(skipped);
     Ok(Some(PayloadNoopShortcut {
         resumed_head: MaterializationHead {
             at: MaterializationKey {
@@ -530,16 +530,34 @@ where
                 replica: head.at.replica.to_vec(),
                 counter: head.at.counter,
             },
-            seq: head.seq.saturating_add(skipped),
+            seq: resumed_seq,
         },
         remaining_ops,
-        affected_nodes,
+        outcome: MaterializationOutcome::empty(resumed_seq),
     }))
 }
 
-/// Apply an incremental batch and return both head metadata and full affected-node delta.
-///
-/// `affected_nodes` is deduplicated and sorted (`NodeId` ascending) for stable consumers.
+fn outcome_from_changes(
+    head_seq: u64,
+    changes: Vec<MaterializationChange>,
+) -> MaterializationOutcome {
+    MaterializationOutcome {
+        head_seq,
+        changes: coalesce_materialization_changes(changes),
+    }
+}
+
+fn merge_outcomes(
+    head_seq: u64,
+    outcomes: impl IntoIterator<Item = MaterializationOutcome>,
+) -> MaterializationOutcome {
+    outcome_from_changes(
+        head_seq,
+        outcomes.into_iter().flat_map(|outcome| outcome.changes).collect(),
+    )
+}
+
+/// Apply an incremental batch and return both head metadata and the structured materialization delta.
 pub fn apply_incremental_ops_with_delta<S, C, N, P, I, M>(
     crdt: &mut TreeCrdt<S, C, N, P>,
     index: &mut I,
@@ -559,7 +577,7 @@ where
     if ops.is_empty() {
         return Ok(IncrementalApplyResult {
             head: None,
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(state.head_seq()),
         });
     }
     if state.replay_from.is_some() {
@@ -589,19 +607,16 @@ where
     }
 
     let mut seq = state.head_seq();
-    let mut affected = std::collections::HashSet::new();
+    let mut changes = Vec::new();
     for op in ops {
         if let Some(delta) = crdt.apply_remote_with_materialization_seq(op, index, &mut seq)? {
-            affected.extend(delta.affected_nodes);
+            changes.extend(delta.changes);
         }
     }
 
     let last = crdt
         .head_op()
         .ok_or_else(|| Error::Storage("expected head op after materialization".into()))?;
-
-    let mut affected_nodes: Vec<NodeId> = affected.into_iter().collect();
-    affected_nodes.sort();
 
     Ok(IncrementalApplyResult {
         head: Some(MaterializationHead {
@@ -612,7 +627,7 @@ where
             },
             seq,
         }),
-        affected_nodes,
+        outcome: outcome_from_changes(seq, changes),
     })
 }
 
@@ -641,7 +656,7 @@ where
     if ops.is_empty() {
         return Ok(IncrementalApplyResult {
             head: None,
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
         });
     }
 
@@ -668,7 +683,7 @@ fn replay_frontier_in_memory<S: Storage>(
     storage: &S,
     frontier: &MaterializationFrontier,
     replica_id: &ReplicaId,
-) -> Result<(PrefixSnapshot, u64, Vec<NodeId>)> {
+) -> Result<(PrefixSnapshot, u64, MaterializationOutcome)> {
     let mut crdt = TreeCrdt::with_stores(
         replica_id.clone(),
         NoopStorage,
@@ -679,7 +694,7 @@ fn replay_frontier_in_memory<S: Storage>(
     let mut index = RecordingIndex::default();
     let mut seq = 0u64;
     let mut head: Option<Operation> = None;
-    let mut affected = HashSet::new();
+    let mut changes = Vec::new();
     let mut prefix_seq = None;
 
     storage.scan_since(0, &mut |op| {
@@ -692,7 +707,7 @@ fn replay_frontier_in_memory<S: Storage>(
             Some(delta) => {
                 head = Some(op);
                 if in_suffix {
-                    affected.extend(delta.affected_nodes);
+                    changes.extend(delta.changes);
                 }
                 Ok(())
             }
@@ -702,8 +717,7 @@ fn replay_frontier_in_memory<S: Storage>(
         }
     })?;
 
-    let mut affected_nodes: Vec<NodeId> = affected.into_iter().collect();
-    affected_nodes.sort();
+    let outcome = outcome_from_changes(seq, changes);
     Ok((
         PrefixSnapshot {
             crdt,
@@ -712,7 +726,7 @@ fn replay_frontier_in_memory<S: Storage>(
             seq,
         },
         prefix_seq.unwrap_or(seq),
-        affected_nodes,
+        outcome,
     ))
 }
 
@@ -797,18 +811,15 @@ where
     // invalidated suffix. Replaying `full_suffix_ops` forward rebuilds only the corrected suffix.
     let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
 
-    let mut affected = HashSet::new();
+    let mut changes = Vec::new();
     let mut seq = prefix_seq;
     let mut replay_head: Option<Operation> = None;
     for op in full_suffix_ops {
         seq = seq.saturating_add(1);
         let delta = crdt.apply_sorted_remote_with_materialization(op.clone(), &mut index, seq)?;
-        affected.extend(delta.affected_nodes);
+        changes.extend(delta.changes);
         replay_head = Some(op);
     }
-
-    let mut affected_nodes: Vec<NodeId> = affected.into_iter().collect();
-    affected_nodes.sort();
 
     flush_nodes(crdt.node_store_mut())?;
     flush_index(&mut index)?;
@@ -822,7 +833,7 @@ where
             },
             seq,
         }),
-        affected_nodes,
+        outcome: outcome_from_changes(seq, changes),
     }))
 }
 
@@ -911,6 +922,7 @@ where
     };
 
     let Some(frontier) = replay_frontier.as_ref() else {
+        let head_seq = meta.state().head_seq();
         return Ok(CatchUpResult {
             head: meta.state().head.as_ref().map(|head| MaterializationHead {
                 at: MaterializationKey {
@@ -920,7 +932,7 @@ where
                 },
                 seq: head.seq,
             }),
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(head_seq),
         });
     };
 
@@ -932,8 +944,9 @@ where
         mut index,
     } = stores;
 
-    let (mut prefix, prefix_seq, affected_nodes) =
+    let (mut prefix, prefix_seq, outcome) =
         replay_frontier_in_memory(&storage, frontier, &replica_id)?;
+    let affected_nodes = outcome.affected_nodes();
     patch_final_state_in_place(
         &mut prefix,
         prefix_seq,
@@ -955,7 +968,7 @@ where
             },
             seq: prefix.seq,
         }),
-        affected_nodes,
+        outcome,
     })
 }
 
@@ -980,7 +993,7 @@ where
     if inserted_count == 0 {
         return Ok(PersistedRemoteApplyResult {
             inserted_count: 0,
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
             catch_up_needed: false,
         });
     }
@@ -989,7 +1002,7 @@ where
         schedule_replay(&frontier)?;
         return Ok(PersistedRemoteApplyResult {
             inserted_count,
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
             catch_up_needed: true,
         });
     }
@@ -1000,7 +1013,7 @@ where
                 schedule_replay(&start_replay_frontier())?;
                 return Ok(PersistedRemoteApplyResult {
                     inserted_count,
-                    affected_nodes: Vec::new(),
+                    outcome: MaterializationOutcome::empty(meta.state().head_seq()),
                     catch_up_needed: true,
                 });
             };
@@ -1008,14 +1021,14 @@ where
             if update_head(&head).is_ok() {
                 Ok(PersistedRemoteApplyResult {
                     inserted_count,
-                    affected_nodes: result.affected_nodes,
+                    outcome: result.outcome,
                     catch_up_needed: false,
                 })
             } else {
                 schedule_replay(&start_replay_frontier())?;
                 Ok(PersistedRemoteApplyResult {
                     inserted_count,
-                    affected_nodes: Vec::new(),
+                    outcome: MaterializationOutcome::empty(meta.state().head_seq()),
                     catch_up_needed: true,
                 })
             }
@@ -1024,7 +1037,7 @@ where
             schedule_replay(&start_replay_frontier())?;
             Ok(PersistedRemoteApplyResult {
                 inserted_count,
-                affected_nodes: Vec::new(),
+                outcome: MaterializationOutcome::empty(meta.state().head_seq()),
                 catch_up_needed: true,
             })
         }
@@ -1084,7 +1097,7 @@ where
     if inserted_count == 0 {
         return Ok(PersistedRemoteApplyResult {
             inserted_count: 0,
-            affected_nodes: Vec::new(),
+            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
             catch_up_needed: false,
         });
     }
@@ -1102,7 +1115,7 @@ where
             update_head(&shortcut.resumed_head)?;
             PersistedRemoteApplyResult {
                 inserted_count,
-                affected_nodes: shortcut.affected_nodes,
+                outcome: shortcut.outcome,
                 catch_up_needed: false,
             }
         } else {
@@ -1115,20 +1128,15 @@ where
                 schedule_replay(&start_replay_frontier())?;
                 return Ok(PersistedRemoteApplyResult {
                     inserted_count,
-                    affected_nodes: Vec::new(),
+                    outcome: MaterializationOutcome::empty(shortcut.resumed_head.seq),
                     catch_up_needed: true,
                 });
             };
             update_head(&head)?;
 
-            let mut affected_nodes = shortcut.affected_nodes;
-            affected_nodes.extend(result.affected_nodes);
-            affected_nodes.sort();
-            affected_nodes.dedup();
-
             PersistedRemoteApplyResult {
                 inserted_count,
-                affected_nodes,
+                outcome: merge_outcomes(head.seq, [shortcut.outcome, result.outcome]),
                 catch_up_needed: false,
             }
         }
@@ -1161,7 +1169,7 @@ where
 
     Ok(PersistedRemoteApplyResult {
         inserted_count: apply_result.inserted_count,
-        affected_nodes: catch_up_result.affected_nodes,
+        outcome: catch_up_result.outcome,
         catch_up_needed: false,
     })
 }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -47,6 +47,36 @@ impl<R: AsRef<[u8]>> MaterializationHead<R> {
             seq: self.seq,
         }
     }
+
+    fn owned(&self) -> MaterializationHead {
+        MaterializationHead {
+            at: MaterializationKey {
+                lamport: self.at.lamport,
+                replica: self.at.replica.as_ref().to_vec(),
+                counter: self.at.counter,
+            },
+            seq: self.seq,
+        }
+    }
+
+    fn with_seq(&self, seq: u64) -> MaterializationHead {
+        let mut head = self.owned();
+        head.seq = seq;
+        head
+    }
+}
+
+impl MaterializationHead {
+    fn from_op(op: &Operation, seq: u64) -> Self {
+        Self {
+            at: MaterializationKey {
+                lamport: op.meta.lamport,
+                replica: op.meta.id.replica.as_bytes().to_vec(),
+                counter: op.meta.id.counter,
+            },
+            seq,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -181,6 +211,32 @@ pub struct PersistedRemoteApplyResult {
     pub catch_up_needed: bool,
 }
 
+impl PersistedRemoteApplyResult {
+    fn empty(inserted_count: u64, head_seq: u64) -> Self {
+        Self {
+            inserted_count,
+            outcome: MaterializationOutcome::empty(head_seq),
+            catch_up_needed: false,
+        }
+    }
+
+    fn applied(inserted_count: u64, outcome: MaterializationOutcome) -> Self {
+        Self {
+            inserted_count,
+            outcome,
+            catch_up_needed: false,
+        }
+    }
+
+    fn needs_catch_up(inserted_count: u64, head_seq: u64) -> Self {
+        Self {
+            inserted_count,
+            outcome: MaterializationOutcome::empty(head_seq),
+            catch_up_needed: true,
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PayloadNoopShortcut {
     pub resumed_head: MaterializationHead,
@@ -225,7 +281,7 @@ impl TruncatingParentOpIndex for RecordingIndex {
     }
 }
 
-struct PrefixSnapshot {
+struct ReplaySnapshot {
     crdt: TreeCrdt<NoopStorage, LamportClock, MemoryNodeStore, MemoryPayloadStore>,
     index: RecordingIndex,
     head: Option<Operation>,
@@ -524,37 +580,26 @@ where
 
     let resumed_seq = head.seq.saturating_add(skipped);
     Ok(Some(PayloadNoopShortcut {
-        resumed_head: MaterializationHead {
-            at: MaterializationKey {
-                lamport: head.at.lamport,
-                replica: head.at.replica.to_vec(),
-                counter: head.at.counter,
-            },
-            seq: resumed_seq,
-        },
+        resumed_head: head.with_seq(resumed_seq),
         remaining_ops,
         outcome: MaterializationOutcome::empty(resumed_seq),
     }))
 }
 
-fn outcome_from_changes(
-    head_seq: u64,
-    changes: Vec<MaterializationChange>,
-) -> MaterializationOutcome {
-    MaterializationOutcome {
-        head_seq,
-        changes: coalesce_materialization_changes(changes),
+impl MaterializationOutcome {
+    fn from_changes(head_seq: u64, changes: Vec<MaterializationChange>) -> Self {
+        Self {
+            head_seq,
+            changes: coalesce_materialization_changes(changes),
+        }
     }
-}
 
-fn merge_outcomes(
-    head_seq: u64,
-    outcomes: impl IntoIterator<Item = MaterializationOutcome>,
-) -> MaterializationOutcome {
-    outcome_from_changes(
-        head_seq,
-        outcomes.into_iter().flat_map(|outcome| outcome.changes).collect(),
-    )
+    fn merge(head_seq: u64, outcomes: impl IntoIterator<Item = MaterializationOutcome>) -> Self {
+        Self::from_changes(
+            head_seq,
+            outcomes.into_iter().flat_map(|outcome| outcome.changes).collect(),
+        )
+    }
 }
 
 /// Apply an incremental batch and return both head metadata and the structured materialization delta.
@@ -619,15 +664,8 @@ where
         .ok_or_else(|| Error::Storage("expected head op after materialization".into()))?;
 
     Ok(IncrementalApplyResult {
-        head: Some(MaterializationHead {
-            at: MaterializationKey {
-                lamport: last.meta.lamport,
-                replica: last.meta.id.replica.as_bytes().to_vec(),
-                counter: last.meta.id.counter,
-            },
-            seq,
-        }),
-        outcome: outcome_from_changes(seq, changes),
+        head: Some(MaterializationHead::from_op(last, seq)),
+        outcome: MaterializationOutcome::from_changes(seq, changes),
     })
 }
 
@@ -683,7 +721,7 @@ fn replay_frontier_in_memory<S: Storage>(
     storage: &S,
     frontier: &MaterializationFrontier,
     replica_id: &ReplicaId,
-) -> Result<(PrefixSnapshot, u64, MaterializationOutcome)> {
+) -> Result<(ReplaySnapshot, u64, MaterializationOutcome)> {
     let mut crdt = TreeCrdt::with_stores(
         replica_id.clone(),
         NoopStorage,
@@ -717,9 +755,9 @@ fn replay_frontier_in_memory<S: Storage>(
         }
     })?;
 
-    let outcome = outcome_from_changes(seq, changes);
+    let outcome = MaterializationOutcome::from_changes(seq, changes);
     Ok((
-        PrefixSnapshot {
+        ReplaySnapshot {
             crdt,
             index,
             head,
@@ -825,20 +863,13 @@ where
     flush_index(&mut index)?;
 
     Ok(Some(CatchUpResult {
-        head: replay_head.map(|head| MaterializationHead {
-            at: MaterializationKey {
-                lamport: head.meta.lamport,
-                replica: head.meta.id.replica.as_bytes().to_vec(),
-                counter: head.meta.id.counter,
-            },
-            seq,
-        }),
-        outcome: outcome_from_changes(seq, changes),
+        head: replay_head.as_ref().map(|head| MaterializationHead::from_op(head, seq)),
+        outcome: MaterializationOutcome::from_changes(seq, changes),
     }))
 }
 
 fn patch_final_state_in_place<N, P, I>(
-    prefix: &mut PrefixSnapshot,
+    replay: &mut ReplaySnapshot,
     prefix_seq: u64,
     affected_nodes: &[NodeId],
     nodes: &mut N,
@@ -859,30 +890,30 @@ where
         nodes.ensure_node(*node)?;
         nodes.detach(*node)?;
 
-        if let Some(parent) = prefix.crdt.node_store_mut().parent(*node)? {
-            let order_key = prefix.crdt.node_store_mut().order_key(*node)?.unwrap_or_default();
+        if let Some(parent) = replay.crdt.node_store_mut().parent(*node)? {
+            let order_key = replay.crdt.node_store_mut().order_key(*node)?.unwrap_or_default();
             nodes.attach(*node, parent, order_key)?;
         }
 
-        nodes.set_tombstone(*node, prefix.crdt.node_store_mut().tombstone(*node)?)?;
+        nodes.set_tombstone(*node, replay.crdt.node_store_mut().tombstone(*node)?)?;
 
         // These are exact setters on purpose: the backend may already contain newer-looking merged
         // values from the stale suffix, so fallback catch-up must overwrite them with the rebuilt
         // post-replay state rather than merge again.
-        let last_change = prefix.crdt.node_store_mut().last_change(*node)?;
+        let last_change = replay.crdt.node_store_mut().last_change(*node)?;
         nodes.set_last_change_exact(*node, &last_change)?;
 
-        let deleted_at = prefix.crdt.node_store_mut().deleted_at(*node)?;
+        let deleted_at = replay.crdt.node_store_mut().deleted_at(*node)?;
         nodes.set_deleted_at_exact(*node, deleted_at.as_ref())?;
 
-        if let Some(writer) = prefix.crdt.payload_last_writer(*node)? {
-            payloads.set_payload(*node, prefix.crdt.payload(*node)?, writer)?;
+        if let Some(writer) = replay.crdt.payload_last_writer(*node)? {
+            payloads.set_payload(*node, replay.crdt.payload(*node)?, writer)?;
         } else {
             payloads.clear_payload(*node)?;
         }
     }
 
-    let mut records: Vec<_> = prefix
+    let mut records: Vec<_> = replay
         .index
         .records
         .iter()
@@ -924,14 +955,7 @@ where
     let Some(frontier) = replay_frontier.as_ref() else {
         let head_seq = meta.state().head_seq();
         return Ok(CatchUpResult {
-            head: meta.state().head.as_ref().map(|head| MaterializationHead {
-                at: MaterializationKey {
-                    lamport: head.at.lamport,
-                    replica: head.at.replica.to_vec(),
-                    counter: head.at.counter,
-                },
-                seq: head.seq,
-            }),
+            head: meta.state().head.as_ref().map(MaterializationHead::owned),
             outcome: MaterializationOutcome::empty(head_seq),
         });
     };
@@ -944,11 +968,11 @@ where
         mut index,
     } = stores;
 
-    let (mut prefix, prefix_seq, outcome) =
+    let (mut replay, prefix_seq, outcome) =
         replay_frontier_in_memory(&storage, frontier, &replica_id)?;
     let affected_nodes = outcome.affected_nodes();
     patch_final_state_in_place(
-        &mut prefix,
+        &mut replay,
         prefix_seq,
         &affected_nodes,
         &mut nodes,
@@ -960,14 +984,7 @@ where
     flush_index(&mut index)?;
 
     Ok(CatchUpResult {
-        head: prefix.head.map(|head| MaterializationHead {
-            at: MaterializationKey {
-                lamport: head.meta.lamport,
-                replica: head.meta.id.replica.as_bytes().to_vec(),
-                counter: head.meta.id.counter,
-            },
-            seq: prefix.seq,
-        }),
+        head: replay.head.as_ref().map(|head| MaterializationHead::from_op(head, replay.seq)),
         outcome,
     })
 }
@@ -989,57 +1006,49 @@ where
     M: MaterializationCursor,
 {
     let inserted_count = inserted_ops.len().min(u64::MAX as usize) as u64;
+    let head_seq = meta.state().head_seq();
 
     if inserted_count == 0 {
-        return Ok(PersistedRemoteApplyResult {
-            inserted_count: 0,
-            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-            catch_up_needed: false,
-        });
+        return Ok(PersistedRemoteApplyResult::empty(0, head_seq));
     }
 
     if let Some(frontier) = next_replay_frontier(meta, &inserted_ops) {
         schedule_replay(&frontier)?;
-        return Ok(PersistedRemoteApplyResult {
+        return Ok(PersistedRemoteApplyResult::needs_catch_up(
             inserted_count,
-            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-            catch_up_needed: true,
-        });
+            head_seq,
+        ));
     }
 
     match materialize_inserted(inserted_ops) {
         Ok(result) => {
             let Some(head) = result.head else {
                 schedule_replay(&start_replay_frontier())?;
-                return Ok(PersistedRemoteApplyResult {
+                return Ok(PersistedRemoteApplyResult::needs_catch_up(
                     inserted_count,
-                    outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-                    catch_up_needed: true,
-                });
+                    head_seq,
+                ));
             };
 
             if update_head(&head).is_ok() {
-                Ok(PersistedRemoteApplyResult {
+                Ok(PersistedRemoteApplyResult::applied(
                     inserted_count,
-                    outcome: result.outcome,
-                    catch_up_needed: false,
-                })
+                    result.outcome,
+                ))
             } else {
                 schedule_replay(&start_replay_frontier())?;
-                Ok(PersistedRemoteApplyResult {
+                Ok(PersistedRemoteApplyResult::needs_catch_up(
                     inserted_count,
-                    outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-                    catch_up_needed: true,
-                })
+                    head_seq,
+                ))
             }
         }
         Err(_) => {
             schedule_replay(&start_replay_frontier())?;
-            Ok(PersistedRemoteApplyResult {
+            Ok(PersistedRemoteApplyResult::needs_catch_up(
                 inserted_count,
-                outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-                catch_up_needed: true,
-            })
+                head_seq,
+            ))
         }
     }
 }
@@ -1094,12 +1103,9 @@ where
     MissingHead: FnMut(&'static str) -> E,
 {
     let inserted_count = inserted_ops.len().min(u64::MAX as usize) as u64;
+    let head_seq = meta.state().head_seq();
     if inserted_count == 0 {
-        return Ok(PersistedRemoteApplyResult {
-            inserted_count: 0,
-            outcome: MaterializationOutcome::empty(meta.state().head_seq()),
-            catch_up_needed: false,
-        });
+        return Ok(PersistedRemoteApplyResult::empty(0, head_seq));
     }
 
     let inserted_op_ids: HashSet<OperationId> =
@@ -1113,11 +1119,7 @@ where
     } {
         if shortcut.remaining_ops.is_empty() {
             update_head(&shortcut.resumed_head)?;
-            PersistedRemoteApplyResult {
-                inserted_count,
-                outcome: shortcut.outcome,
-                catch_up_needed: false,
-            }
+            PersistedRemoteApplyResult::applied(inserted_count, shortcut.outcome)
         } else {
             let shortcut_meta = MaterializationState {
                 head: Some(shortcut.resumed_head.clone()),
@@ -1126,19 +1128,17 @@ where
             let result = materialize_inserted(&shortcut_meta, shortcut.remaining_ops)?;
             let Some(head) = result.head else {
                 schedule_replay(&start_replay_frontier())?;
-                return Ok(PersistedRemoteApplyResult {
+                return Ok(PersistedRemoteApplyResult::needs_catch_up(
                     inserted_count,
-                    outcome: MaterializationOutcome::empty(shortcut.resumed_head.seq),
-                    catch_up_needed: true,
-                });
+                    shortcut.resumed_head.seq,
+                ));
             };
             update_head(&head)?;
 
-            PersistedRemoteApplyResult {
+            PersistedRemoteApplyResult::applied(
                 inserted_count,
-                outcome: merge_outcomes(head.seq, [shortcut.outcome, result.outcome]),
-                catch_up_needed: false,
-            }
+                MaterializationOutcome::merge(head.seq, [shortcut.outcome, result.outcome]),
+            )
         }
     } else {
         apply_persisted_remote_ops_with_delta(
@@ -1167,9 +1167,8 @@ where
         .ok_or_else(|| missing_head_error("expected head after immediate catch-up"))?;
     update_head(head)?;
 
-    Ok(PersistedRemoteApplyResult {
-        inserted_count: apply_result.inserted_count,
-        outcome: catch_up_result.outcome,
-        catch_up_needed: false,
-    })
+    Ok(PersistedRemoteApplyResult::applied(
+        apply_result.inserted_count,
+        catch_up_result.outcome,
+    ))
 }

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -875,7 +875,7 @@ fn patch_final_state_in_place<N, P, I>(
     nodes: &mut N,
     payloads: &mut P,
     index: &mut I,
-) -> Result<()>
+) -> Result<Vec<MaterializationChange>>
 where
     N: ExactNodeStore,
     P: ExactPayloadStore,
@@ -886,16 +886,46 @@ where
     // suffix first, then repopulate only the rebuilt suffix records below.
     index.truncate_from(truncate_from)?;
 
+    let mut patch_changes = Vec::new();
+
     for node in affected_nodes {
+        let existed_before = nodes.exists(*node)?;
+        let previous_parent = if existed_before {
+            nodes.parent(*node)?
+        } else {
+            None
+        };
+        let previous_tombstone = if existed_before {
+            Some(nodes.tombstone(*node)?)
+        } else {
+            None
+        };
+        let final_parent = replay.crdt.node_store_mut().parent(*node)?;
+        let final_tombstone = replay.crdt.node_store_mut().tombstone(*node)?;
+
         nodes.ensure_node(*node)?;
         nodes.detach(*node)?;
 
-        if let Some(parent) = replay.crdt.node_store_mut().parent(*node)? {
+        if let Some(parent) = final_parent {
             let order_key = replay.crdt.node_store_mut().order_key(*node)?.unwrap_or_default();
             nodes.attach(*node, parent, order_key)?;
         }
 
-        nodes.set_tombstone(*node, replay.crdt.node_store_mut().tombstone(*node)?)?;
+        nodes.set_tombstone(*node, final_tombstone)?;
+
+        if let Some(previous_tombstone) = previous_tombstone {
+            match (previous_tombstone, final_tombstone) {
+                (true, false) => patch_changes.push(MaterializationChange::Restore {
+                    node: *node,
+                    parent_after: final_parent.filter(|parent| *parent != NodeId::TRASH),
+                }),
+                (false, true) => patch_changes.push(MaterializationChange::Delete {
+                    node: *node,
+                    parent_before: previous_parent.filter(|parent| *parent != NodeId::TRASH),
+                }),
+                _ => {}
+            }
+        }
 
         // These are exact setters on purpose: the backend may already contain newer-looking merged
         // values from the stale suffix, so fallback catch-up must overwrite them with the rebuilt
@@ -925,7 +955,7 @@ where
         index.record(parent, &op_id, seq)?;
     }
 
-    Ok(())
+    Ok(MaterializationOutcome::from_changes(replay.seq, patch_changes).changes)
 }
 
 /// Catch backend materialized state up from a replay frontier by patching affected backend rows
@@ -968,10 +998,22 @@ where
         mut index,
     } = stores;
 
-    let (mut replay, prefix_seq, outcome) =
+    let (mut replay, prefix_seq, replay_outcome) =
         replay_frontier_in_memory(&storage, frontier, &replica_id)?;
-    let affected_nodes = outcome.affected_nodes();
-    patch_final_state_in_place(
+    let mut affected_nodes = replay_outcome.affected_nodes();
+    let mut seen_nodes: HashSet<NodeId> = affected_nodes.iter().copied().collect();
+    let mut idx = 0usize;
+    while idx < affected_nodes.len() {
+        if let Some(parent) = replay.crdt.node_store_mut().parent(affected_nodes[idx])? {
+            if parent != NodeId::ROOT && parent != NodeId::TRASH && seen_nodes.insert(parent) {
+                affected_nodes.push(parent);
+            }
+        }
+        idx += 1;
+    }
+    affected_nodes.sort();
+    affected_nodes.dedup();
+    let patch_changes = patch_final_state_in_place(
         &mut replay,
         prefix_seq,
         &affected_nodes,
@@ -985,7 +1027,13 @@ where
 
     Ok(CatchUpResult {
         head: replay.head.as_ref().map(|head| MaterializationHead::from_op(head, replay.seq)),
-        outcome,
+        outcome: MaterializationOutcome::merge(
+            replay.seq,
+            [
+                replay_outcome,
+                MaterializationOutcome::from_changes(replay.seq, patch_changes),
+            ],
+        ),
     })
 }
 

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -918,6 +918,7 @@ where
                 (true, false) => patch_changes.push(MaterializationChange::Restore {
                     node: *node,
                     parent_after: final_parent.filter(|parent| *parent != NodeId::TRASH),
+                    payload: replay.crdt.payload(*node)?,
                 }),
                 (false, true) => patch_changes.push(MaterializationChange::Delete {
                     node: *node,

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use crate::affected::{
-    affected_parents, direct_affected_nodes, parent_hints_from, sorted_node_ids,
+    affected_parents, coalesce_materialization_changes, direct_materialization_changes,
+    parent_hints_from,
 };
 use crate::error::{Error, Result};
 use crate::ids::{Lamport, NodeId, OperationId, ReplicaId};
@@ -9,13 +10,24 @@ use crate::ops::{cmp_op_key, Operation, OperationKind};
 use crate::traits::{
     Clock, MemoryNodeStore, MemoryPayloadStore, NodeStore, ParentOpIndex, PayloadStore, Storage,
 };
-use crate::types::{ApplyDelta, LocalFinalizePlan, LocalPlacement, NodeExport, NodeSnapshotExport};
+use crate::types::{
+    ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
+    NodeExport, NodeSnapshotExport,
+};
 use crate::version_vector::VersionVector;
 
 #[derive(Clone)]
 struct NodeSnapshot {
     parent: Option<NodeId>,
     order_key: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TombstoneDelta {
+    node: NodeId,
+    parent: Option<NodeId>,
+    previous: bool,
+    tombstoned: bool,
 }
 
 /// Generic Tree CRDT facade that wires clock and storage together.
@@ -140,6 +152,7 @@ where
         payload: Option<Vec<u8>>,
     ) -> Result<(Operation, LocalFinalizePlan)> {
         let after = self.resolve_after_for_placement(parent, placement, None)?;
+        let has_payload = payload.is_some();
         let (replica, counter, lamport, seed) = self.next_op_meta();
         let order_key = self.allocate_child_key_after(parent, node, after, &seed)?;
         let op = Operation::insert_with_optional_payload(
@@ -151,6 +164,16 @@ where
             LocalFinalizePlan {
                 parent_hints: vec![parent],
                 extra_index_records: Vec::new(),
+                changes: {
+                    let mut changes = vec![MaterializationChange::Insert {
+                        node,
+                        parent_after: parent,
+                    }];
+                    if has_payload {
+                        changes.push(MaterializationChange::Payload { node });
+                    }
+                    changes
+                },
             },
         ))
     }
@@ -185,6 +208,11 @@ where
             LocalFinalizePlan {
                 parent_hints,
                 extra_index_records,
+                changes: vec![MaterializationChange::Move {
+                    node,
+                    parent_before: old_parent,
+                    parent_after: new_parent,
+                }],
             },
         ))
     }
@@ -200,6 +228,7 @@ where
             LocalFinalizePlan {
                 parent_hints: parent_hints_from(old_parent),
                 extra_index_records: Vec::new(),
+                changes: Vec::new(),
             },
         ))
     }
@@ -222,6 +251,7 @@ where
             LocalFinalizePlan {
                 parent_hints: parent_hints_from(parent),
                 extra_index_records: Vec::new(),
+                changes: vec![MaterializationChange::Payload { node }],
             },
         ))
     }
@@ -252,13 +282,13 @@ where
             self.op_count += 1;
             self.head = Some(op.clone());
 
-            let affected_nodes = direct_affected_nodes(snapshot.parent, &op.kind);
+            let changes = direct_materialization_changes(snapshot.parent, &op.kind);
             return Ok(Some(ApplyDelta {
                 snapshot: NodeSnapshotExport {
                     parent: snapshot.parent,
                     order_key: snapshot.order_key,
                 },
-                affected_nodes,
+                changes,
             }));
         }
 
@@ -288,13 +318,9 @@ where
             *seq = (*seq).saturating_sub(1);
             return Ok(None);
         };
-        let affected_nodes = direct_affected_nodes(snapshot.parent, &op.kind);
+        let changes = direct_materialization_changes(snapshot.parent, &op.kind);
         Ok(Some(self.finalize_materialized_apply(
-            snapshot,
-            &op,
-            index,
-            *seq,
-            affected_nodes,
+            snapshot, &op, index, *seq, changes,
         )?))
     }
 
@@ -319,8 +345,8 @@ where
         self.op_count = seq;
         self.head = Some(op.clone());
 
-        let affected_nodes = direct_affected_nodes(snapshot.parent, &op.kind);
-        self.finalize_materialized_apply(snapshot, &op, index, seq, affected_nodes)
+        let changes = direct_materialization_changes(snapshot.parent, &op.kind);
+        self.finalize_materialized_apply(snapshot, &op, index, seq, changes)
     }
 
     /// Finalize adapter-owned local ops by refreshing tombstones and recording parent-op index rows.
@@ -333,7 +359,7 @@ where
         op: &Operation,
         index: &mut I,
         seq: u64,
-        mut affected_nodes: Vec<NodeId>,
+        mut changes: Vec<MaterializationChange>,
     ) -> Result<ApplyDelta> {
         let op_node = op.kind.node();
         let parent_after = match &op.kind {
@@ -363,29 +389,45 @@ where
         let mut starts = parents;
         starts.push(op_node);
         let tombstone_changed = self.refresh_tombstones_upward_with_delta(starts)?;
-        affected_nodes.extend(tombstone_changed.into_iter().filter(|node| *node != NodeId::TRASH));
-        affected_nodes = sorted_node_ids(affected_nodes);
+        changes.extend(
+            tombstone_changed.into_iter().filter(|delta| delta.node != NodeId::TRASH).map(
+                |delta| {
+                    if delta.previous && !delta.tombstoned {
+                        MaterializationChange::Restore {
+                            node: delta.node,
+                            parent_after: delta.parent.filter(|parent| *parent != NodeId::TRASH),
+                        }
+                    } else {
+                        MaterializationChange::Delete {
+                            node: delta.node,
+                            parent_before: delta.parent.filter(|parent| *parent != NodeId::TRASH),
+                        }
+                    }
+                },
+            ),
+        );
 
         Ok(ApplyDelta {
             snapshot: NodeSnapshotExport {
                 parent: snapshot.parent,
                 order_key: snapshot.order_key,
             },
-            affected_nodes,
+            changes: coalesce_materialization_changes(changes),
         })
     }
-    pub fn finalize_local<I: ParentOpIndex>(
+
+    pub fn finalize_local_with_outcome<I: ParentOpIndex>(
         &mut self,
         op: &Operation,
         index: &mut I,
         head_seq: u64,
         plan: &LocalFinalizePlan,
-    ) -> Result<u64> {
+    ) -> Result<MaterializationOutcome> {
         let seq = head_seq.saturating_add(1);
 
         let mut refresh_starts: Vec<NodeId> = plan.parent_hints.to_vec();
         refresh_starts.push(op.kind.node());
-        self.refresh_tombstones_upward(refresh_starts)?;
+        let tombstone_changed = self.refresh_tombstones_upward_with_delta(refresh_starts)?;
 
         let mut seen: HashSet<NodeId> = HashSet::new();
         for parent in &plan.parent_hints {
@@ -402,7 +444,39 @@ where
             index.record(*parent, op_id, seq)?;
         }
 
-        Ok(seq)
+        let mut changes = plan.changes.clone();
+        changes.extend(
+            tombstone_changed.into_iter().filter(|delta| delta.node != NodeId::TRASH).map(
+                |delta| {
+                    if delta.previous && !delta.tombstoned {
+                        MaterializationChange::Restore {
+                            node: delta.node,
+                            parent_after: delta.parent.filter(|parent| *parent != NodeId::TRASH),
+                        }
+                    } else {
+                        MaterializationChange::Delete {
+                            node: delta.node,
+                            parent_before: delta.parent.filter(|parent| *parent != NodeId::TRASH),
+                        }
+                    }
+                },
+            ),
+        );
+
+        Ok(MaterializationOutcome {
+            head_seq: seq,
+            changes: coalesce_materialization_changes(changes),
+        })
+    }
+
+    pub fn finalize_local<I: ParentOpIndex>(
+        &mut self,
+        op: &Operation,
+        index: &mut I,
+        head_seq: u64,
+        plan: &LocalFinalizePlan,
+    ) -> Result<u64> {
+        Ok(self.finalize_local_with_outcome(op, index, head_seq, plan)?.head_seq)
     }
 
     fn refresh_tombstones_upward<I>(&mut self, starts: I) -> Result<()>
@@ -416,13 +490,13 @@ where
     /// Refresh tombstone cache for nodes on the upward closure of `starts`.
     ///
     /// Returns every node whose cached tombstone value actually changed.
-    fn refresh_tombstones_upward_with_delta<I>(&mut self, starts: I) -> Result<Vec<NodeId>>
+    fn refresh_tombstones_upward_with_delta<I>(&mut self, starts: I) -> Result<Vec<TombstoneDelta>>
     where
         I: IntoIterator<Item = NodeId>,
     {
         let mut stack: Vec<NodeId> = starts.into_iter().collect();
         let mut visited: HashSet<NodeId> = HashSet::new();
-        let mut changed: Vec<NodeId> = Vec::new();
+        let mut changed: Vec<TombstoneDelta> = Vec::new();
 
         while let Some(node) = stack.pop() {
             if node == NodeId::ROOT || node == NodeId::TRASH {
@@ -440,7 +514,12 @@ where
                 let tombstoned = self.is_tombstoned(node)?;
                 if previous != tombstoned {
                     self.nodes.set_tombstone(node, tombstoned)?;
-                    changed.push(node);
+                    changed.push(TombstoneDelta {
+                        node,
+                        parent,
+                        previous,
+                        tombstoned,
+                    });
                 }
             }
 
@@ -449,7 +528,9 @@ where
             }
         }
 
-        Ok(sorted_node_ids(changed))
+        changed.sort_by(|left, right| left.node.cmp(&right.node));
+        changed.dedup_by(|left, right| left.node == right.node);
+        Ok(changed)
     }
 
     pub fn operations_since(&self, lamport: Lamport) -> Result<Vec<Operation>> {

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use crate::affected::{
     affected_parents, coalesce_materialization_changes, direct_materialization_changes,
-    parent_hints_from,
+    materialization_change_from_tombstone_delta, parent_hints_from, TombstoneDelta,
 };
 use crate::error::{Error, Result};
 use crate::ids::{Lamport, NodeId, OperationId, ReplicaId};
@@ -20,14 +20,6 @@ use crate::version_vector::VersionVector;
 struct NodeSnapshot {
     parent: Option<NodeId>,
     order_key: Option<Vec<u8>>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct TombstoneDelta {
-    node: NodeId,
-    parent: Option<NodeId>,
-    previous: bool,
-    tombstoned: bool,
 }
 
 /// Generic Tree CRDT facade that wires clock and storage together.
@@ -390,21 +382,9 @@ where
         starts.push(op_node);
         let tombstone_changed = self.refresh_tombstones_upward_with_delta(starts)?;
         changes.extend(
-            tombstone_changed.into_iter().filter(|delta| delta.node != NodeId::TRASH).map(
-                |delta| {
-                    if delta.previous && !delta.tombstoned {
-                        MaterializationChange::Restore {
-                            node: delta.node,
-                            parent_after: delta.parent.filter(|parent| *parent != NodeId::TRASH),
-                        }
-                    } else {
-                        MaterializationChange::Delete {
-                            node: delta.node,
-                            parent_before: delta.parent.filter(|parent| *parent != NodeId::TRASH),
-                        }
-                    }
-                },
-            ),
+            tombstone_changed
+                .into_iter()
+                .filter_map(materialization_change_from_tombstone_delta),
         );
 
         Ok(ApplyDelta {
@@ -446,21 +426,9 @@ where
 
         let mut changes = plan.changes.clone();
         changes.extend(
-            tombstone_changed.into_iter().filter(|delta| delta.node != NodeId::TRASH).map(
-                |delta| {
-                    if delta.previous && !delta.tombstoned {
-                        MaterializationChange::Restore {
-                            node: delta.node,
-                            parent_after: delta.parent.filter(|parent| *parent != NodeId::TRASH),
-                        }
-                    } else {
-                        MaterializationChange::Delete {
-                            node: delta.node,
-                            parent_before: delta.parent.filter(|parent| *parent != NodeId::TRASH),
-                        }
-                    }
-                },
-            ),
+            tombstone_changed
+                .into_iter()
+                .filter_map(materialization_change_from_tombstone_delta),
         );
 
         Ok(MaterializationOutcome {

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -496,7 +496,7 @@ where
             }
         }
 
-        changed.sort_by(|left, right| left.node.cmp(&right.node));
+        changed.sort_by_key(|delta| delta.node);
         changed.dedup_by(|left, right| left.node == right.node);
         Ok(changed)
     }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -220,7 +220,10 @@ where
             LocalFinalizePlan {
                 parent_hints: parent_hints_from(old_parent),
                 extra_index_records: Vec::new(),
-                changes: Vec::new(),
+                changes: vec![MaterializationChange::Delete {
+                    node,
+                    parent_before: old_parent.filter(|parent| *parent != NodeId::TRASH),
+                }],
             },
         ))
     }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -144,7 +144,7 @@ where
         payload: Option<Vec<u8>>,
     ) -> Result<(Operation, LocalFinalizePlan)> {
         let after = self.resolve_after_for_placement(parent, placement, None)?;
-        let has_payload = payload.is_some();
+        let payload_after = payload.clone();
         let (replica, counter, lamport, seed) = self.next_op_meta();
         let order_key = self.allocate_child_key_after(parent, node, after, &seed)?;
         let op = Operation::insert_with_optional_payload(
@@ -156,16 +156,11 @@ where
             LocalFinalizePlan {
                 parent_hints: vec![parent],
                 extra_index_records: Vec::new(),
-                changes: {
-                    let mut changes = vec![MaterializationChange::Insert {
-                        node,
-                        parent_after: parent,
-                    }];
-                    if has_payload {
-                        changes.push(MaterializationChange::Payload { node });
-                    }
-                    changes
-                },
+                changes: vec![MaterializationChange::Insert {
+                    node,
+                    parent_after: parent,
+                    payload: payload_after,
+                }],
             },
         ))
     }
@@ -234,6 +229,7 @@ where
         payload: Option<Vec<u8>>,
     ) -> Result<(Operation, LocalFinalizePlan)> {
         let parent = self.parent(node)?;
+        let payload_after = payload.clone();
         let (replica, counter, lamport, _seed) = self.next_op_meta();
         let op = if let Some(payload) = payload {
             Operation::set_payload(&replica, counter, lamport, node, payload)
@@ -246,7 +242,10 @@ where
             LocalFinalizePlan {
                 parent_hints: parent_hints_from(parent),
                 extra_index_records: Vec::new(),
-                changes: vec![MaterializationChange::Payload { node }],
+                changes: vec![MaterializationChange::Payload {
+                    node,
+                    payload: payload_after,
+                }],
             },
         ))
     }
@@ -490,6 +489,11 @@ where
                         parent,
                         previous,
                         tombstoned,
+                        payload_after: if tombstoned {
+                            None
+                        } else {
+                            self.payloads.payload(node)?
+                        },
                     });
                 }
             }

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -31,6 +31,7 @@ pub enum MaterializationChange {
     Insert {
         node: NodeId,
         parent_after: NodeId,
+        payload: Option<Vec<u8>>,
     },
     Move {
         node: NodeId,
@@ -44,9 +45,11 @@ pub enum MaterializationChange {
     Restore {
         node: NodeId,
         parent_after: Option<NodeId>,
+        payload: Option<Vec<u8>>,
     },
     Payload {
         node: NodeId,
+        payload: Option<Vec<u8>>,
     },
 }
 
@@ -57,7 +60,7 @@ impl MaterializationChange {
             | Self::Move { node, .. }
             | Self::Delete { node, .. }
             | Self::Restore { node, .. }
-            | Self::Payload { node } => *node,
+            | Self::Payload { node, .. } => *node,
         }
     }
 

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -2,6 +2,9 @@ use crate::error::{Error, Result};
 use crate::ids::{NodeId, OperationId};
 use crate::version_vector::VersionVector;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[derive(Clone, Debug)]
 pub struct NodeExport {
     pub node: NodeId,
@@ -17,10 +20,112 @@ pub struct NodeSnapshotExport {
     pub order_key: Option<Vec<u8>>,
 }
 
+/// A coalesced visible change produced while advancing materialized state.
+///
+/// This is intentionally higher-level than raw operations: a replay pass may collapse multiple
+/// operations for the same node into one final visible insert/move/delete/restore/payload change.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "kind", rename_all = "camelCase"))]
+pub enum MaterializationChange {
+    Insert {
+        node: NodeId,
+        parent_after: NodeId,
+    },
+    Move {
+        node: NodeId,
+        parent_before: Option<NodeId>,
+        parent_after: NodeId,
+    },
+    Delete {
+        node: NodeId,
+        parent_before: Option<NodeId>,
+    },
+    Restore {
+        node: NodeId,
+        parent_after: Option<NodeId>,
+    },
+    Payload {
+        node: NodeId,
+    },
+}
+
+impl MaterializationChange {
+    pub fn node(&self) -> NodeId {
+        match self {
+            Self::Insert { node, .. }
+            | Self::Move { node, .. }
+            | Self::Delete { node, .. }
+            | Self::Restore { node, .. }
+            | Self::Payload { node } => *node,
+        }
+    }
+
+    /// Convert a structured change to the node ids that may need storage row patching.
+    ///
+    /// Adapters should expose `MaterializationChange`/`MaterializationOutcome` to consumers rather
+    /// than this derived helper. The helper exists so storage backends can keep their existing
+    /// "patch rows for these ids" machinery without making affected ids part of the public event API.
+    pub fn affected_nodes(&self) -> Vec<NodeId> {
+        let mut nodes = vec![self.node()];
+        match self {
+            Self::Insert { parent_after, .. } => {
+                nodes.push(*parent_after);
+            }
+            Self::Move {
+                parent_before,
+                parent_after,
+                ..
+            } => {
+                nodes.extend(parent_before.into_iter().copied());
+                nodes.push(*parent_after);
+            }
+            Self::Delete { parent_before, .. } => nodes.extend(parent_before.into_iter().copied()),
+            Self::Restore { parent_after, .. } => nodes.extend(parent_after.into_iter().copied()),
+            Self::Payload { .. } => {}
+        }
+        nodes.retain(|node| *node != NodeId::TRASH);
+        nodes
+    }
+}
+
+/// The result of one materialization pass.
+///
+/// `head_seq` is the materialized op-log frontier after the pass. Empty `changes` means the pass
+/// did not change any visible materialized state and should not emit a public event.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct MaterializationOutcome {
+    pub head_seq: u64,
+    pub changes: Vec<MaterializationChange>,
+}
+
+impl MaterializationOutcome {
+    pub fn empty(head_seq: u64) -> Self {
+        Self {
+            head_seq,
+            changes: Vec::new(),
+        }
+    }
+
+    pub fn affected_nodes(&self) -> Vec<NodeId> {
+        let mut nodes: Vec<NodeId> =
+            self.changes.iter().flat_map(MaterializationChange::affected_nodes).collect();
+        nodes.sort();
+        nodes.dedup();
+        nodes
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.changes.is_empty()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct ApplyDelta {
     pub snapshot: NodeSnapshotExport,
-    pub affected_nodes: Vec<NodeId>,
+    pub changes: Vec<MaterializationChange>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -52,4 +157,5 @@ impl LocalPlacement {
 pub struct LocalFinalizePlan {
     pub parent_hints: Vec<NodeId>,
     pub extra_index_records: Vec<(NodeId, OperationId)>,
+    pub changes: Vec<MaterializationChange>,
 }

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -116,10 +116,6 @@ impl MaterializationOutcome {
         nodes.dedup();
         nodes
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.changes.is_empty()
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -77,11 +77,11 @@ impl MaterializationChange {
                 parent_after,
                 ..
             } => {
-                nodes.extend(parent_before.into_iter().copied());
+                nodes.extend(parent_before.iter().copied());
                 nodes.push(*parent_after);
             }
-            Self::Delete { parent_before, .. } => nodes.extend(parent_before.into_iter().copied()),
-            Self::Restore { parent_after, .. } => nodes.extend(parent_after.into_iter().copied()),
+            Self::Delete { parent_before, .. } => nodes.extend(parent_before.iter().copied()),
+            Self::Restore { parent_after, .. } => nodes.extend(parent_after.iter().copied()),
             Self::Payload { .. } => {}
         }
         nodes.retain(|node| *node != NodeId::TRASH);

--- a/packages/treecrdt-core/tests/defensive_delete.rs
+++ b/packages/treecrdt-core/tests/defensive_delete.rs
@@ -823,9 +823,14 @@ fn materialized_apply_delta_includes_parent_restored_by_unseen_payload_change() 
         !crdt_a.is_tombstoned(parent).unwrap(),
         "parent should be restored by unseen payload change"
     );
-    assert!(delta.affected_nodes.contains(&child));
+    let affected = treecrdt_core::MaterializationOutcome {
+        head_seq: seq_a,
+        changes: delta.changes,
+    }
+    .affected_nodes();
+    assert!(affected.contains(&child));
     assert!(
-        delta.affected_nodes.contains(&parent),
+        affected.contains(&parent),
         "delta should include ancestor tombstone flip"
     );
 }

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -4,10 +4,10 @@ use treecrdt_core::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     catch_up_materialized_state, materialize_persisted_remote_ops_with_delta,
     try_shortcut_out_of_order_payload_noops, Lamport, LamportClock, LocalFinalizePlan,
-    LocalPlacement, MaterializationCursor, MaterializationHead, MaterializationKey,
-    MaterializationState, MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId,
-    NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PersistedRemoteStores, ReplicaId,
-    Storage, TreeCrdt,
+    LocalPlacement, MaterializationChange, MaterializationCursor, MaterializationHead,
+    MaterializationKey, MaterializationOutcome, MaterializationState, MemoryNodeStore,
+    MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation, OperationId,
+    ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt,
 };
 
 #[derive(Default)]
@@ -135,6 +135,7 @@ fn finalize_local_records_unique_hints_and_extras() {
             (parent, extra_op_id.clone()),
             (NodeId::TRASH, extra_op_id.clone()),
         ],
+        changes: Vec::new(),
     };
 
     let mut index = RecordingIndex::default();
@@ -264,7 +265,10 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
 
     let head = res.head.expect("expected materialization head");
     assert_eq!(head.at.counter, 2);
-    assert_eq!(res.affected_nodes, vec![NodeId::ROOT, parent, child],);
+    assert_eq!(
+        res.outcome.affected_nodes(),
+        vec![NodeId::ROOT, parent, child],
+    );
 }
 
 #[test]
@@ -290,7 +294,10 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
                     },
                     seq: 2,
                 }),
-                affected_nodes: vec![NodeId(2)],
+                outcome: MaterializationOutcome {
+                    head_seq: 2,
+                    changes: vec![MaterializationChange::Payload { node: NodeId(2) }],
+                },
             })
         },
         |head| {
@@ -303,7 +310,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
 
     assert_eq!(seen_counters, vec![2, 3]);
     assert_eq!(result.inserted_count, 2);
-    assert_eq!(result.affected_nodes, vec![NodeId(2)]);
+    assert_eq!(result.outcome.affected_nodes(), vec![NodeId(2)]);
     assert!(!result.catch_up_needed);
     assert_eq!(
         updated_head,
@@ -333,7 +340,7 @@ fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing()
             runs += 1;
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
                 head: None,
-                affected_nodes: Vec::new(),
+                outcome: MaterializationOutcome::empty(0),
             })
         },
         |_| Ok::<_, ()>(()),
@@ -347,7 +354,7 @@ fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing()
     assert_eq!(runs, 1);
     assert_eq!(scheduled_replay, 1);
     assert_eq!(result.inserted_count, 1);
-    assert_eq!(result.affected_nodes, Vec::<NodeId>::new());
+    assert_eq!(result.outcome.affected_nodes(), Vec::<NodeId>::new());
     assert!(result.catch_up_needed);
 }
 
@@ -371,7 +378,13 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
                     },
                     seq: 9,
                 }),
-                affected_nodes: vec![NodeId(1), NodeId(2)],
+                outcome: MaterializationOutcome {
+                    head_seq: 9,
+                    changes: vec![
+                        MaterializationChange::Payload { node: NodeId(1) },
+                        MaterializationChange::Payload { node: NodeId(2) },
+                    ],
+                },
             })
         },
         |_| Err::<(), ()>(()),
@@ -384,7 +397,7 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
 
     assert_eq!(scheduled_replay, 1);
     assert_eq!(result.inserted_count, 1);
-    assert!(result.affected_nodes.is_empty());
+    assert!(result.outcome.changes.is_empty());
     assert!(result.catch_up_needed);
 }
 
@@ -410,7 +423,7 @@ fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
             materialize_runs += 1;
             Ok::<_, ()>(treecrdt_core::IncrementalApplyResult {
                 head: None,
-                affected_nodes: Vec::new(),
+                outcome: MaterializationOutcome::empty(0),
             })
         },
         |_| Ok::<_, ()>(()),
@@ -423,7 +436,7 @@ fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
 
     assert_eq!(materialize_runs, 0);
     assert_eq!(result.inserted_count, 2);
-    assert!(result.affected_nodes.is_empty());
+    assert!(result.outcome.changes.is_empty());
     assert!(result.catch_up_needed);
     assert_eq!(
         replay_frontier,
@@ -463,7 +476,7 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
     .unwrap();
 
     assert_eq!(result.inserted_count, 1);
-    assert!(result.affected_nodes.is_empty());
+    assert!(result.outcome.changes.is_empty());
     assert!(result.catch_up_needed);
     assert_eq!(
         replay_frontier,
@@ -517,7 +530,7 @@ fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
     assert_eq!(flushed_index, 1);
     assert_eq!(head.at.counter, 2);
     assert_eq!(
-        result.affected_nodes,
+        result.outcome.affected_nodes(),
         vec![NodeId::ROOT, NodeId(10), NodeId(11)]
     );
 }
@@ -551,7 +564,7 @@ fn payload_noop_shortcut_skips_out_of_order_payload_dominated_by_current_winner(
     assert_eq!(shortcut.resumed_head.at.counter, 10);
     assert_eq!(shortcut.resumed_head.seq, 6);
     assert!(shortcut.remaining_ops.is_empty());
-    assert_eq!(shortcut.affected_nodes, vec![node]);
+    assert!(shortcut.outcome.changes.is_empty());
 }
 
 #[test]
@@ -578,7 +591,7 @@ fn payload_noop_shortcut_keeps_later_in_order_payload_for_incremental_materializ
 
     assert_eq!(shortcut.resumed_head.seq, 6);
     assert_eq!(shortcut.remaining_ops, vec![newer]);
-    assert_eq!(shortcut.affected_nodes, vec![node]);
+    assert!(shortcut.outcome.changes.is_empty());
 }
 
 #[test]
@@ -674,7 +687,7 @@ fn catch_up_materialized_state_scans_storage_once() {
     assert_eq!(scan_count.get(), 1);
     assert_eq!(result.head.expect("expected head").seq, 2);
     assert_eq!(
-        result.affected_nodes,
+        result.outcome.affected_nodes(),
         vec![NodeId::ROOT, NodeId(1), NodeId(2)]
     );
 }

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::rc::Rc;
+use treecrdt_core::NodeStore;
 use treecrdt_core::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
     catch_up_materialized_state, materialize_persisted_remote_ops_with_delta,
@@ -7,7 +8,7 @@ use treecrdt_core::{
     LocalPlacement, MaterializationChange, MaterializationCursor, MaterializationHead,
     MaterializationKey, MaterializationOutcome, MaterializationState, MemoryNodeStore,
     MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation, OperationId,
-    ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt,
+    ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt, VersionVector,
 };
 
 #[derive(Default)]
@@ -689,5 +690,72 @@ fn catch_up_materialized_state_scans_storage_once() {
     assert_eq!(
         result.outcome.affected_nodes(),
         vec![NodeId::ROOT, NodeId(1), NodeId(2)]
+    );
+}
+
+#[test]
+fn catch_up_materialized_state_reports_rows_restored_by_replay_patch() {
+    let author = ReplicaId::new(b"author");
+    let deleter = ReplicaId::new(b"deleter");
+    let parent = NodeId(10);
+    let child = NodeId(11);
+
+    let parent_op = Operation::insert(&author, 1, 1, NodeId::ROOT, parent, vec![0x10]);
+    let child_op = Operation::insert(&author, 2, 2, parent, child, vec![0x20]);
+    let mut known_state = VersionVector::new();
+    known_state.observe(&author, 1);
+    let delete_op = Operation::delete(&deleter, 1, 3, parent, Some(known_state.clone()));
+
+    let mut storage = MemoryStorage::default();
+    storage.apply(parent_op.clone()).unwrap();
+    storage.apply(child_op.clone()).unwrap();
+    storage.apply(delete_op.clone()).unwrap();
+
+    let mut deleted_at = known_state;
+    deleted_at.observe(&deleter, 1);
+
+    // Simulate the stale materialized backend state before catch-up: the parent insert and later
+    // delete were materialized, but the out-of-order child insert has not been replayed yet.
+    let mut nodes = MemoryNodeStore::default();
+    nodes.ensure_node(parent).unwrap();
+    nodes.attach(parent, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.merge_deleted_at(parent, &deleted_at).unwrap();
+    nodes.set_tombstone(parent, true).unwrap();
+
+    let meta = Cursor {
+        head_lamport: delete_op.meta.lamport,
+        head_replica: delete_op.meta.id.replica.as_bytes().to_vec(),
+        head_counter: delete_op.meta.id.counter,
+        head_seq: 2,
+        replay_lamport: Some(child_op.meta.lamport),
+        replay_replica: Some(child_op.meta.id.replica.as_bytes().to_vec()),
+        replay_counter: Some(child_op.meta.id.counter),
+    };
+
+    let result = catch_up_materialized_state(
+        storage,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"adapter"),
+            clock: LamportClock::default(),
+            nodes,
+            payloads: MemoryPayloadStore::default(),
+            index: NoopParentOpIndex,
+        },
+        &meta,
+        |_| Ok(()),
+        |_| Ok(()),
+    )
+    .unwrap();
+
+    assert!(
+        result.outcome.changes.contains(&MaterializationChange::Restore {
+            node: parent,
+            parent_after: Some(NodeId::ROOT),
+        }),
+        "catch-up must report rows restored by patching stale backend state"
+    );
+    assert_eq!(
+        result.outcome.affected_nodes(),
+        vec![NodeId::ROOT, parent, child],
     );
 }

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -297,7 +297,10 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
                 }),
                 outcome: MaterializationOutcome {
                     head_seq: 2,
-                    changes: vec![MaterializationChange::Payload { node: NodeId(2) }],
+                    changes: vec![MaterializationChange::Payload {
+                        node: NodeId(2),
+                        payload: Some(vec![9]),
+                    }],
                 },
             })
         },
@@ -382,8 +385,14 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
                 outcome: MaterializationOutcome {
                     head_seq: 9,
                     changes: vec![
-                        MaterializationChange::Payload { node: NodeId(1) },
-                        MaterializationChange::Payload { node: NodeId(2) },
+                        MaterializationChange::Payload {
+                            node: NodeId(1),
+                            payload: None,
+                        },
+                        MaterializationChange::Payload {
+                            node: NodeId(2),
+                            payload: None,
+                        },
                     ],
                 },
             })
@@ -751,6 +760,7 @@ fn catch_up_materialized_state_reports_rows_restored_by_replay_patch() {
         result.outcome.changes.contains(&MaterializationChange::Restore {
             node: parent,
             parent_after: Some(NodeId::ROOT),
+            payload: None,
         }),
         "catch-up must report rows restored by patching stale backend state"
     );

--- a/packages/treecrdt-core/tests/operations.rs
+++ b/packages/treecrdt-core/tests/operations.rs
@@ -150,7 +150,7 @@ fn materialization_seq_advances_only_for_new_ops() {
 }
 
 #[test]
-fn apply_remote_with_materialization_reports_affected_nodes() {
+fn apply_remote_with_materialization_reports_changes() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"a"),
         MemoryStorage::default(),
@@ -166,14 +166,19 @@ fn apply_remote_with_materialization_reports_affected_nodes() {
         .apply_remote_with_materialization_seq(insert, &mut index, &mut seq)
         .unwrap()
         .unwrap();
-    assert_eq!(insert_delta.affected_nodes, vec![NodeId::ROOT, NodeId(1)]);
+    assert_eq!(insert_delta.changes.len(), 1);
+    assert_eq!(
+        insert_delta.changes[0].affected_nodes(),
+        vec![NodeId(1), NodeId::ROOT]
+    );
 
     let payload = Operation::set_payload(&replica, 2, 2, NodeId(1), b"hello".to_vec());
     let payload_delta = crdt
         .apply_remote_with_materialization_seq(payload, &mut index, &mut seq)
         .unwrap()
         .unwrap();
-    assert_eq!(payload_delta.affected_nodes, vec![NodeId(1)]);
+    assert_eq!(payload_delta.changes.len(), 1);
+    assert_eq!(payload_delta.changes[0].affected_nodes(), vec![NodeId(1)]);
 }
 
 #[test]

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -604,16 +604,19 @@ async function scenarioMaterializationEventPayloadCoalescing(
   const root = nodeIdFromInt(0);
   const node = nodeIdFromInt(21);
 
+  await engine.ops.append(
+    makeInsertOp({
+      replica,
+      counter: 1,
+      lamport: 1,
+      parent: root,
+      node,
+      orderKey: orderKeyFromPosition(0),
+    }),
+  );
+
   const events = await captureMaterializationEvents(engine, () =>
     engine.ops.appendMany([
-      makeInsertOp({
-        replica,
-        counter: 1,
-        lamport: 1,
-        parent: root,
-        node,
-        orderKey: orderKeyFromPosition(0),
-      }),
       makePayloadOp({
         replica,
         counter: 2,
@@ -633,12 +636,15 @@ async function scenarioMaterializationEventPayloadCoalescing(
   assertEqual(events.length, 1, 'appendMany payload coalescing should emit one event');
   const refs = materializationEventNodeRefs(events[0]!);
   assertEventNodeRefsSortedUnique(refs, 'appendMany coalesced event node refs');
-  assertEventNodeRefsContain(refs, [root, node], 'appendMany event should include root+node');
-  assertEqual(
-    events[0]!.changes.filter((change) => change.kind === 'payload' && change.node === node).length,
-    1,
-    'payload changes should be coalesced by node',
+  assertEventNodeRefsContain(refs, [node], 'appendMany event should include changed node');
+  const payloadChanges = events[0]!.changes.filter(
+    (change) => change.kind === 'payload' && change.node === node,
   );
+  assertEqual(payloadChanges.length, 1, 'payload changes should be coalesced by node');
+  if (payloadChanges[0]?.kind !== 'payload') {
+    throw new Error('expected payload change');
+  }
+  assertBytesEqual(payloadChanges[0].payload, new Uint8Array([2]), 'payload change final bytes');
 }
 
 async function scenarioMaterializationEventDefensiveRestore(

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1,4 +1,4 @@
-import type { TreecrdtEngine } from '@treecrdt/interface/engine';
+import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
@@ -138,16 +138,16 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioAppendIdempotentAndHeadLamportMonotonic,
     },
     {
-      name: 'appendMany: returns affected ids for structural batch',
-      run: scenarioAppendManyReturnsAffectedIdsStructuralBatch,
+      name: 'materialization events: structural batch',
+      run: scenarioMaterializationEventStructuralBatch,
     },
     {
-      name: 'appendMany: returns deduped deterministic affected ids',
-      run: scenarioAppendManyReturnsDedupedDeterministicIds,
+      name: 'materialization events: payload coalescing',
+      run: scenarioMaterializationEventPayloadCoalescing,
     },
     {
-      name: 'appendMany: returns indirect affected ids on defensive restore',
-      run: scenarioAppendManyReturnsIndirectAffectedIdsOnDefensiveRestore,
+      name: 'materialization events: defensive restore',
+      run: scenarioMaterializationEventDefensiveRestore,
     },
     {
       name: 'tree: childrenPage uses keyset cursor',
@@ -270,7 +270,7 @@ function assertArrayEqual(actual: string[], expected: string[], message: string)
   }
 }
 
-function assertAffectedIdsShape(ids: string[], message: string): void {
+function assertEventNodeRefsShape(ids: string[], message: string): void {
   for (const id of ids) {
     if (!/^[0-9a-f]{32}$/.test(id)) {
       throw new Error(`${message}: expected canonical NodeId hex, got ${JSON.stringify(id)}`);
@@ -278,8 +278,8 @@ function assertAffectedIdsShape(ids: string[], message: string): void {
   }
 }
 
-function assertAffectedIdsSortedUnique(ids: string[], message: string): void {
-  assertAffectedIdsShape(ids, message);
+function assertEventNodeRefsSortedUnique(ids: string[], message: string): void {
+  assertEventNodeRefsShape(ids, message);
   const sorted = ids.slice().sort();
   for (let i = 0; i < ids.length; i += 1) {
     if (ids[i] !== sorted[i]) {
@@ -291,13 +291,37 @@ function assertAffectedIdsSortedUnique(ids: string[], message: string): void {
   }
 }
 
-function assertAffectedIdsContain(ids: string[], expected: string[], message: string): void {
+function assertEventNodeRefsContain(ids: string[], expected: string[], message: string): void {
   const set = new Set(ids);
   for (const id of expected) {
     if (!set.has(id)) {
       throw new Error(`${message}: expected ${JSON.stringify(id)} in ${JSON.stringify(ids)}`);
     }
   }
+}
+
+function materializationEventNodeRefs(event: MaterializationEvent): string[] {
+  const ids = new Set<string>();
+  for (const change of event.changes) {
+    ids.add(change.node);
+    if ('parentAfter' in change && change.parentAfter) ids.add(change.parentAfter);
+    if ('parentBefore' in change && change.parentBefore) ids.add(change.parentBefore);
+  }
+  return [...ids].sort();
+}
+
+async function captureMaterializationEvents(
+  engine: TreecrdtEngine,
+  fn: () => Promise<void>,
+): Promise<MaterializationEvent[]> {
+  const events: MaterializationEvent[] = [];
+  const unsubscribe = engine.onMaterialized((event) => events.push(event));
+  try {
+    await fn();
+  } finally {
+    unsubscribe();
+  }
+  return events;
 }
 
 function assertBytesEqual(
@@ -533,7 +557,7 @@ async function scenarioAppendIdempotentAndHeadLamportMonotonic(
   assertEqual(await engine.meta.headLamport(), 7, 'meta.headLamport after duplicate append');
 }
 
-async function scenarioAppendManyReturnsAffectedIdsStructuralBatch(
+async function scenarioMaterializationEventStructuralBatch(
   ctx: TreecrdtEngineConformanceContext,
 ): Promise<void> {
   const engine = ctx.engine;
@@ -542,33 +566,37 @@ async function scenarioAppendManyReturnsAffectedIdsStructuralBatch(
   const parent = nodeIdFromInt(11);
   const child = nodeIdFromInt(12);
 
-  const affected = await engine.ops.appendMany([
-    makeInsertOp({
-      replica,
-      counter: 1,
-      lamport: 1,
-      parent: root,
-      node: parent,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makeInsertOp({
-      replica,
-      counter: 2,
-      lamport: 2,
-      parent,
-      node: child,
-      orderKey: orderKeyFromPosition(0),
-    }),
-  ]);
-  assertAffectedIdsSortedUnique(affected, 'appendMany structural affected ids');
-  assertAffectedIdsContain(
-    affected,
+  const events = await captureMaterializationEvents(engine, () =>
+    engine.ops.appendMany([
+      makeInsertOp({
+        replica,
+        counter: 1,
+        lamport: 1,
+        parent: root,
+        node: parent,
+        orderKey: orderKeyFromPosition(0),
+      }),
+      makeInsertOp({
+        replica,
+        counter: 2,
+        lamport: 2,
+        parent,
+        node: child,
+        orderKey: orderKeyFromPosition(0),
+      }),
+    ]),
+  );
+  assertEqual(events.length, 1, 'appendMany structural should emit one materialization event');
+  const refs = materializationEventNodeRefs(events[0]!);
+  assertEventNodeRefsSortedUnique(refs, 'appendMany structural event node refs');
+  assertEventNodeRefsContain(
+    refs,
     [root, parent, child],
     'appendMany structural should include root+parent+child',
   );
 }
 
-async function scenarioAppendManyReturnsDedupedDeterministicIds(
+async function scenarioMaterializationEventPayloadCoalescing(
   ctx: TreecrdtEngineConformanceContext,
 ): Promise<void> {
   const engine = ctx.engine;
@@ -576,35 +604,44 @@ async function scenarioAppendManyReturnsDedupedDeterministicIds(
   const root = nodeIdFromInt(0);
   const node = nodeIdFromInt(21);
 
-  const affected = await engine.ops.appendMany([
-    makeInsertOp({
-      replica,
-      counter: 1,
-      lamport: 1,
-      parent: root,
-      node,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makePayloadOp({
-      replica,
-      counter: 2,
-      lamport: 2,
-      node,
-      payload: new Uint8Array([1]),
-    }),
-    makePayloadOp({
-      replica,
-      counter: 3,
-      lamport: 3,
-      node,
-      payload: new Uint8Array([2]),
-    }),
-  ]);
-  assertAffectedIdsSortedUnique(affected, 'appendMany dedupe affected ids');
-  assertAffectedIdsContain(affected, [root, node], 'appendMany dedupe should include root+node');
+  const events = await captureMaterializationEvents(engine, () =>
+    engine.ops.appendMany([
+      makeInsertOp({
+        replica,
+        counter: 1,
+        lamport: 1,
+        parent: root,
+        node,
+        orderKey: orderKeyFromPosition(0),
+      }),
+      makePayloadOp({
+        replica,
+        counter: 2,
+        lamport: 2,
+        node,
+        payload: new Uint8Array([1]),
+      }),
+      makePayloadOp({
+        replica,
+        counter: 3,
+        lamport: 3,
+        node,
+        payload: new Uint8Array([2]),
+      }),
+    ]),
+  );
+  assertEqual(events.length, 1, 'appendMany payload coalescing should emit one event');
+  const refs = materializationEventNodeRefs(events[0]!);
+  assertEventNodeRefsSortedUnique(refs, 'appendMany coalesced event node refs');
+  assertEventNodeRefsContain(refs, [root, node], 'appendMany event should include root+node');
+  assertEqual(
+    events[0]!.changes.filter((change) => change.kind === 'payload' && change.node === node).length,
+    1,
+    'payload changes should be coalesced by node',
+  );
 }
 
-async function scenarioAppendManyReturnsIndirectAffectedIdsOnDefensiveRestore(
+async function scenarioMaterializationEventDefensiveRestore(
   ctx: TreecrdtEngineConformanceContext,
 ): Promise<void> {
   const a = ctx.engine;
@@ -629,11 +666,13 @@ async function scenarioAppendManyReturnsIndirectAffectedIdsOnDefensiveRestore(
 
   const childInsert = await b.local.insert(rB, parent, child, { type: 'last' }, null);
   await a.local.delete(rA, parent);
-  const affected = await a.ops.appendMany([childInsert]);
+  const events = await captureMaterializationEvents(a, () => a.ops.appendMany([childInsert]));
+  assertEqual(events.length, 1, 'defensive restore should emit one materialization event');
+  const refs = materializationEventNodeRefs(events[0]!);
 
-  assertAffectedIdsSortedUnique(affected, 'appendMany defensive restore affected ids');
-  assertAffectedIdsContain(
-    affected,
+  assertEventNodeRefsSortedUnique(refs, 'appendMany defensive restore event node refs');
+  assertEventNodeRefsContain(
+    refs,
     [parent, child],
     'appendMany defensive restore should include restored parent+child',
   );
@@ -1202,8 +1241,14 @@ async function scenarioSyncKnownStatePropagation(
   );
 
   // Sync A -> B. The delete MUST carry known_state so B doesn't treat it as aware of the child.
-  const affectedOnB = await b.ops.appendMany(await a.ops.all());
-  assertAffectedIdsSortedUnique(affectedOnB, 'sync known_state: appendMany affected ids shape');
+  const eventsOnB = await captureMaterializationEvents(b, async () => {
+    await b.ops.appendMany(await a.ops.all());
+  });
+  assert(eventsOnB.length > 0, 'sync known_state should emit a materialization event on B');
+  assertEventNodeRefsSortedUnique(
+    materializationEventNodeRefs(eventsOnB[eventsOnB.length - 1]!),
+    'sync known_state: materialization event node refs shape',
+  );
 
   assertArrayEqual(await b.tree.children(root), [parent], 'parent restored after sync delete');
   assertArrayEqual(await b.tree.children(parent), [child], 'child still present after sync delete');

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -79,6 +79,7 @@ pub struct NativeMaterializationChange {
     pub node: Buffer,
     pub parent_before: Option<Buffer>,
     pub parent_after: Option<Buffer>,
+    pub payload: Option<Buffer>,
 }
 
 #[napi(object)]
@@ -98,11 +99,16 @@ fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOu
         .changes
         .into_iter()
         .map(|change| match change {
-            MaterializationChange::Insert { node, parent_after } => NativeMaterializationChange {
+            MaterializationChange::Insert {
+                node,
+                parent_after,
+                payload,
+            } => NativeMaterializationChange {
                 kind: "insert".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: Some(node_buffer(parent_after)),
+                payload: payload.map(Buffer::from),
             },
             MaterializationChange::Move {
                 node,
@@ -113,6 +119,7 @@ fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOu
                 node: node_buffer(node),
                 parent_before: parent_before.map(node_buffer),
                 parent_after: Some(node_buffer(parent_after)),
+                payload: None,
             },
             MaterializationChange::Delete {
                 node,
@@ -122,18 +129,25 @@ fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOu
                 node: node_buffer(node),
                 parent_before: parent_before.map(node_buffer),
                 parent_after: None,
+                payload: None,
             },
-            MaterializationChange::Restore { node, parent_after } => NativeMaterializationChange {
+            MaterializationChange::Restore {
+                node,
+                parent_after,
+                payload,
+            } => NativeMaterializationChange {
                 kind: "restore".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: parent_after.map(node_buffer),
+                payload: payload.map(Buffer::from),
             },
-            MaterializationChange::Payload { node } => NativeMaterializationChange {
+            MaterializationChange::Payload { node, payload } => NativeMaterializationChange {
                 kind: "payload".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: None,
+                payload: payload.map(Buffer::from),
             },
         })
         .collect();

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -4,8 +4,8 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use postgres::{Client, NoTls};
 use treecrdt_core::{
-    Error as CoreError, Lamport, NodeId, Operation, OperationId, OperationKind, ReplicaId,
-    Result as CoreResult, VersionVector,
+    Error as CoreError, Lamport, MaterializationChange, MaterializationOutcome, NodeId, Operation,
+    OperationId, OperationKind, ReplicaId, Result as CoreResult, VersionVector,
 };
 
 fn map_err(e: impl std::fmt::Display) -> napi::Error {
@@ -31,6 +31,10 @@ fn bytes16_to_node(bytes: &[u8]) -> CoreResult<NodeId> {
 
 fn node_to_bytes16(node: NodeId) -> [u8; 16] {
     node.0.to_be_bytes()
+}
+
+fn node_buffer(node: NodeId) -> Buffer {
+    Buffer::from(node_to_bytes16(node).to_vec())
 }
 
 fn vv_from_bytes(bytes: &[u8]) -> CoreResult<VersionVector> {
@@ -67,6 +71,76 @@ pub struct NativeTreeRow {
     pub parent: Option<Buffer>,
     pub order_key: Option<Buffer>,
     pub tombstone: bool,
+}
+
+#[napi(object)]
+pub struct NativeMaterializationChange {
+    pub kind: String,
+    pub node: Buffer,
+    pub parent_before: Option<Buffer>,
+    pub parent_after: Option<Buffer>,
+}
+
+#[napi(object)]
+pub struct NativeMaterializationOutcome {
+    pub head_seq: BigInt,
+    pub changes: Vec<NativeMaterializationChange>,
+}
+
+#[napi(object)]
+pub struct NativeLocalOpResult {
+    pub op: NativeOp,
+    pub outcome: NativeMaterializationOutcome,
+}
+
+fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOutcome {
+    let changes = outcome
+        .changes
+        .into_iter()
+        .map(|change| match change {
+            MaterializationChange::Insert { node, parent_after } => NativeMaterializationChange {
+                kind: "insert".to_string(),
+                node: node_buffer(node),
+                parent_before: None,
+                parent_after: Some(node_buffer(parent_after)),
+            },
+            MaterializationChange::Move {
+                node,
+                parent_before,
+                parent_after,
+            } => NativeMaterializationChange {
+                kind: "move".to_string(),
+                node: node_buffer(node),
+                parent_before: parent_before.map(node_buffer),
+                parent_after: Some(node_buffer(parent_after)),
+            },
+            MaterializationChange::Delete {
+                node,
+                parent_before,
+            } => NativeMaterializationChange {
+                kind: "delete".to_string(),
+                node: node_buffer(node),
+                parent_before: parent_before.map(node_buffer),
+                parent_after: None,
+            },
+            MaterializationChange::Restore { node, parent_after } => NativeMaterializationChange {
+                kind: "restore".to_string(),
+                node: node_buffer(node),
+                parent_before: None,
+                parent_after: parent_after.map(node_buffer),
+            },
+            MaterializationChange::Payload { node } => NativeMaterializationChange {
+                kind: "payload".to_string(),
+                node: node_buffer(node),
+                parent_before: None,
+                parent_after: None,
+            },
+        })
+        .collect();
+    NativeMaterializationOutcome {
+        head_seq: BigInt::from(outcome.head_seq),
+        changes,
+    }
 }
 
 fn bigint_to_u64(name: &str, v: BigInt) -> CoreResult<u64> {
@@ -474,7 +548,7 @@ impl PgBackend {
     }
 
     #[napi]
-    pub fn apply_ops(&self, ops: Vec<NativeOp>) -> napi::Result<Vec<Buffer>> {
+    pub fn apply_ops(&self, ops: Vec<NativeOp>) -> napi::Result<NativeMaterializationOutcome> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -483,13 +557,23 @@ impl PgBackend {
             core_ops.push(native_to_core_op(op).map_err(map_core_err)?);
         }
 
-        let affected =
-            treecrdt_postgres::append_ops_with_affected_nodes(&client, &self.doc_id, &core_ops)
-                .map_err(map_core_err)?;
-        Ok(affected
-            .into_iter()
-            .map(|node| Buffer::from(node_to_bytes16(node).to_vec()))
-            .collect())
+        let outcome = treecrdt_postgres::append_ops_with_materialization_outcome(
+            &client,
+            &self.doc_id,
+            &core_ops,
+        )
+        .map_err(map_core_err)?;
+        Ok(outcome_to_native(outcome))
+    }
+
+    #[napi]
+    pub fn ensure_materialized(&self) -> napi::Result<NativeMaterializationOutcome> {
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+
+        let outcome =
+            treecrdt_postgres::ensure_materialized(&client, &self.doc_id).map_err(map_core_err)?;
+        Ok(outcome_to_native(outcome))
     }
 
     #[napi]
@@ -501,7 +585,7 @@ impl PgBackend {
         placement: String,
         after: Option<Buffer>,
         payload: Option<Buffer>,
-    ) -> napi::Result<NativeOp> {
+    ) -> napi::Result<NativeLocalOpResult> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -513,7 +597,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let op = treecrdt_postgres::local_insert(
+        let result = treecrdt_postgres::local_insert(
             &client,
             &self.doc_id,
             &replica,
@@ -524,7 +608,10 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        core_to_native_op(op).map_err(map_core_err)
+        Ok(NativeLocalOpResult {
+            op: core_to_native_op(result.op).map_err(map_core_err)?,
+            outcome: outcome_to_native(result.outcome),
+        })
     }
 
     #[napi]
@@ -535,7 +622,7 @@ impl PgBackend {
         new_parent: Buffer,
         placement: String,
         after: Option<Buffer>,
-    ) -> napi::Result<NativeOp> {
+    ) -> napi::Result<NativeLocalOpResult> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -547,7 +634,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let op = treecrdt_postgres::local_move(
+        let result = treecrdt_postgres::local_move(
             &client,
             &self.doc_id,
             &replica,
@@ -557,19 +644,25 @@ impl PgBackend {
             after_id,
         )
         .map_err(map_core_err)?;
-        core_to_native_op(op).map_err(map_core_err)
+        Ok(NativeLocalOpResult {
+            op: core_to_native_op(result.op).map_err(map_core_err)?,
+            outcome: outcome_to_native(result.outcome),
+        })
     }
 
     #[napi]
-    pub fn local_delete(&self, replica: Buffer, node: Buffer) -> napi::Result<NativeOp> {
+    pub fn local_delete(&self, replica: Buffer, node: Buffer) -> napi::Result<NativeLocalOpResult> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let op = treecrdt_postgres::local_delete(&client, &self.doc_id, &replica, node)
+        let result = treecrdt_postgres::local_delete(&client, &self.doc_id, &replica, node)
             .map_err(map_core_err)?;
-        core_to_native_op(op).map_err(map_core_err)
+        Ok(NativeLocalOpResult {
+            op: core_to_native_op(result.op).map_err(map_core_err)?,
+            outcome: outcome_to_native(result.outcome),
+        })
     }
 
     #[napi]
@@ -578,13 +671,13 @@ impl PgBackend {
         replica: Buffer,
         node: Buffer,
         payload: Option<Buffer>,
-    ) -> napi::Result<NativeOp> {
+    ) -> napi::Result<NativeLocalOpResult> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let op = treecrdt_postgres::local_payload(
+        let result = treecrdt_postgres::local_payload(
             &client,
             &self.doc_id,
             &replica,
@@ -592,6 +685,9 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        core_to_native_op(op).map_err(map_core_err)
+        Ok(NativeLocalOpResult {
+            op: core_to_native_op(result.op).map_err(map_core_err)?,
+            outcome: outcome_to_native(result.outcome),
+        })
     }
 }

--- a/packages/treecrdt-postgres-napi/src/adapter.ts
+++ b/packages/treecrdt-postgres-napi/src/adapter.ts
@@ -4,7 +4,7 @@ import type {
   SerializeReplica,
   TreecrdtAdapter,
 } from '@treecrdt/interface';
-import type { MaterializationOutcome } from '@treecrdt/interface/engine';
+import { emptyMaterializationOutcome } from '@treecrdt/interface/engine';
 import { nodeIdToBytes16 } from '@treecrdt/interface/ids';
 
 import {
@@ -41,8 +41,6 @@ function opToNative(
 ) {
   return operationToNativeWithSerializers(op, serializeNodeId, serializeReplica);
 }
-
-const EMPTY_OUTCOME: MaterializationOutcome = { headSeq: 0, changes: [] };
 
 export function createPostgresNapiAdapterFactory(url: string): PostgresNapiAdapterFactory {
   ensureNonEmptyString('url', url);
@@ -106,7 +104,7 @@ export function createPostgresNapiAdapterFactory(url: string): PostgresNapiAdapt
           );
         },
         appendOps: async (ops, serializeNodeId, serializeReplica) => {
-          if (ops.length === 0) return EMPTY_OUTCOME;
+          if (ops.length === 0) return emptyMaterializationOutcome();
           return nativeToMaterializationOutcome(
             backend.applyOps(ops.map((op) => opToNative(op, serializeNodeId, serializeReplica))),
           );

--- a/packages/treecrdt-postgres-napi/src/adapter.ts
+++ b/packages/treecrdt-postgres-napi/src/adapter.ts
@@ -4,9 +4,14 @@ import type {
   SerializeReplica,
   TreecrdtAdapter,
 } from '@treecrdt/interface';
+import type { MaterializationOutcome } from '@treecrdt/interface/engine';
 import { nodeIdToBytes16 } from '@treecrdt/interface/ids';
 
-import { nativeOpToSqliteRow, operationToNativeWithSerializers } from './codec.js';
+import {
+  nativeOpToSqliteRow,
+  nativeToMaterializationOutcome,
+  operationToNativeWithSerializers,
+} from './codec.js';
 import { loadNative } from './native.js';
 
 export type PostgresNapiAdapterFactory = {
@@ -36,6 +41,8 @@ function opToNative(
 ) {
   return operationToNativeWithSerializers(op, serializeNodeId, serializeReplica);
 }
+
+const EMPTY_OUTCOME: MaterializationOutcome = { headSeq: 0, changes: [] };
 
 export function createPostgresNapiAdapterFactory(url: string): PostgresNapiAdapterFactory {
   ensureNonEmptyString('url', url);
@@ -94,12 +101,14 @@ export function createPostgresNapiAdapterFactory(url: string): PostgresNapiAdapt
         replicaMaxCounter: async (replica) =>
           bigintToSafeNumber('replicaMaxCounter', backend.replicaMaxCounter(replica)),
         appendOp: async (op, serializeNodeId, serializeReplica) => {
-          backend.applyOps([opToNative(op, serializeNodeId, serializeReplica)]);
+          return nativeToMaterializationOutcome(
+            backend.applyOps([opToNative(op, serializeNodeId, serializeReplica)]),
+          );
         },
         appendOps: async (ops, serializeNodeId, serializeReplica) => {
-          if (ops.length === 0) return [];
-          return backend.applyOps(
-            ops.map((op) => opToNative(op, serializeNodeId, serializeReplica)),
+          if (ops.length === 0) return EMPTY_OUTCOME;
+          return nativeToMaterializationOutcome(
+            backend.applyOps(ops.map((op) => opToNative(op, serializeNodeId, serializeReplica))),
           );
         },
         opsSince: async (lamport, root) => {

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -9,7 +9,11 @@ import {
   nativeToOperation,
   operationToNativeWithSerializers,
 } from './codec.js';
-import { loadNative } from './native.js';
+import {
+  loadNative,
+  type NativeLocalOpResult,
+  type NativeMaterializationOutcome,
+} from './native.js';
 
 function ensureNonEmptyString(name: string, value: string): void {
   if (typeof value !== 'string' || value.length === 0) {
@@ -53,9 +57,15 @@ export async function createTreecrdtPostgresClient(
 
   const backend = factory.open(docId);
   const materialized = createMaterializationDispatcher();
+  const emitNativeOutcome = (nativeOutcome: NativeMaterializationOutcome) => {
+    materialized.emitOutcome(nativeToMaterializationOutcome(nativeOutcome));
+  };
+  const finishLocalOp = (result: NativeLocalOpResult): Operation => {
+    emitNativeOutcome(result.outcome);
+    return nativeToOperation(result.op);
+  };
   const ensureMaterializedImpl = () => {
-    const outcome = nativeToMaterializationOutcome(backend.ensureMaterialized());
-    materialized.emitOutcome(outcome);
+    emitNativeOutcome(backend.ensureMaterialized());
   };
 
   const encodeReplica = (replica: Operation['meta']['id']['replica']): Uint8Array =>
@@ -146,9 +156,7 @@ export async function createTreecrdtPostgresClient(
       after,
       payload,
     );
-    const outcome = nativeToMaterializationOutcome(result.outcome);
-    materialized.emitOutcome(outcome);
-    return nativeToOperation(result.op);
+    return finishLocalOp(result);
   };
 
   const localMoveImpl = async (
@@ -165,23 +173,17 @@ export async function createTreecrdtPostgresClient(
       type,
       after,
     );
-    const outcome = nativeToMaterializationOutcome(result.outcome);
-    materialized.emitOutcome(outcome);
-    return nativeToOperation(result.op);
+    return finishLocalOp(result);
   };
 
   const localDeleteImpl = async (replica: ReplicaId, node: string) => {
     const result = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
-    const outcome = nativeToMaterializationOutcome(result.outcome);
-    materialized.emitOutcome(outcome);
-    return nativeToOperation(result.op);
+    return finishLocalOp(result);
   };
 
   const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) => {
     const result = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
-    const outcome = nativeToMaterializationOutcome(result.outcome);
-    materialized.emitOutcome(outcome);
-    return nativeToOperation(result.op);
+    return finishLocalOp(result);
   };
 
   return {

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -1,9 +1,19 @@
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import { nodeIdFromBytes16, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
-import type { TreecrdtEngine } from '@treecrdt/interface/engine';
+import type {
+  MaterializationEvent,
+  MaterializationListener,
+  MaterializationOutcome,
+  TreecrdtEngine,
+  WriteOptions,
+} from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
-import { nativeToOperation, operationToNativeWithSerializers } from './codec.js';
+import {
+  nativeToMaterializationOutcome,
+  nativeToOperation,
+  operationToNativeWithSerializers,
+} from './codec.js';
 import { loadNative } from './native.js';
 
 function ensureNonEmptyString(name: string, value: string): void {
@@ -47,6 +57,19 @@ export async function createTreecrdtPostgresClient(
   ensureNonEmptyString('docId', docId);
 
   const backend = factory.open(docId);
+  const listeners = new Set<MaterializationListener>();
+  const emitMaterialized = (outcome: MaterializationOutcome, writeId?: string) => {
+    if (outcome.changes.length === 0) return;
+    const event: MaterializationEvent = {
+      ...outcome,
+      ...(writeId ? { writeIds: [writeId] } : {}),
+    };
+    for (const listener of listeners) listener(event);
+  };
+  const ensureMaterializedImpl = () => {
+    const outcome = nativeToMaterializationOutcome(backend.ensureMaterialized());
+    emitMaterialized(outcome);
+  };
 
   const encodeReplica = (replica: Operation['meta']['id']['replica']): Uint8Array =>
     replicaIdToBytes(replica);
@@ -57,22 +80,27 @@ export async function createTreecrdtPostgresClient(
   };
 
   const opRefsAllImpl = async () => backend.listOpRefsAll();
-  const opRefsChildrenImpl = async (parent: string) =>
-    backend.listOpRefsChildren(nodeIdToBytes16(parent));
+  const opRefsChildrenImpl = async (parent: string) => {
+    ensureMaterializedImpl();
+    return backend.listOpRefsChildren(nodeIdToBytes16(parent));
+  };
 
   const opsByOpRefsImpl = async (opRefs: Uint8Array[]) => {
     if (opRefs.length === 0) return [];
     return backend.getOpsByOpRefs(opRefs).map(nativeToOperation);
   };
 
-  const treeChildrenImpl = async (parent: string) =>
-    backend.treeChildren(nodeIdToBytes16(parent)).map((b) => nodeIdFromBytes16(b));
+  const treeChildrenImpl = async (parent: string) => {
+    ensureMaterializedImpl();
+    return backend.treeChildren(nodeIdToBytes16(parent)).map((b) => nodeIdFromBytes16(b));
+  };
 
   const treeChildrenPageImpl = async (
     parent: string,
     cursor: { orderKey: Uint8Array; node: Uint8Array } | null,
     limit: number,
   ) => {
+    ensureMaterializedImpl();
     const rows = backend.treeChildrenPage(
       nodeIdToBytes16(parent),
       cursor?.orderKey ?? null,
@@ -83,6 +111,7 @@ export async function createTreecrdtPostgresClient(
   };
 
   const treeDumpImpl = async () => {
+    ensureMaterializedImpl();
     const rows = backend.treeDump();
     return rows.map((r) => ({
       node: nodeIdFromBytes16(r.node),
@@ -92,14 +121,21 @@ export async function createTreecrdtPostgresClient(
     }));
   };
 
-  const treeNodeCountImpl = async () =>
-    bigintToSafeNumber('treeNodeCount', backend.treeNodeCount());
+  const treeNodeCountImpl = async () => {
+    ensureMaterializedImpl();
+    return bigintToSafeNumber('treeNodeCount', backend.treeNodeCount());
+  };
   const treeParentImpl = async (node: string) => {
+    ensureMaterializedImpl();
     const result = backend.treeParent(nodeIdToBytes16(node));
     return result === null || result === undefined ? null : nodeIdFromBytes16(result);
   };
-  const treeExistsImpl = async (node: string) => backend.treeExists(nodeIdToBytes16(node));
+  const treeExistsImpl = async (node: string) => {
+    ensureMaterializedImpl();
+    return backend.treeExists(nodeIdToBytes16(node));
+  };
   const treeGetPayloadImpl = async (node: string) => {
+    ensureMaterializedImpl();
     const result = backend.treePayload(nodeIdToBytes16(node));
     return result === null || result === undefined ? null : result;
   };
@@ -115,7 +151,7 @@ export async function createTreecrdtPostgresClient(
     payload: Uint8Array | null,
   ) => {
     const { type, after } = placementToArgs(placement);
-    const op = backend.localInsert(
+    const result = backend.localInsert(
       encodeReplica(replica),
       nodeIdToBytes16(parent),
       nodeIdToBytes16(node),
@@ -123,7 +159,9 @@ export async function createTreecrdtPostgresClient(
       after,
       payload,
     );
-    return nativeToOperation(op);
+    const outcome = nativeToMaterializationOutcome(result.outcome);
+    emitMaterialized(outcome);
+    return nativeToOperation(result.op);
   };
 
   const localMoveImpl = async (
@@ -133,24 +171,30 @@ export async function createTreecrdtPostgresClient(
     placement: TreecrdtSqlitePlacement,
   ) => {
     const { type, after } = placementToArgs(placement);
-    const op = backend.localMove(
+    const result = backend.localMove(
       encodeReplica(replica),
       nodeIdToBytes16(node),
       nodeIdToBytes16(newParent),
       type,
       after,
     );
-    return nativeToOperation(op);
+    const outcome = nativeToMaterializationOutcome(result.outcome);
+    emitMaterialized(outcome);
+    return nativeToOperation(result.op);
   };
 
   const localDeleteImpl = async (replica: ReplicaId, node: string) => {
-    const op = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
-    return nativeToOperation(op);
+    const result = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
+    const outcome = nativeToMaterializationOutcome(result.outcome);
+    emitMaterialized(outcome);
+    return nativeToOperation(result.op);
   };
 
   const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) => {
-    const op = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
-    return nativeToOperation(op);
+    const result = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
+    const outcome = nativeToMaterializationOutcome(result.outcome);
+    emitMaterialized(outcome);
+    return nativeToOperation(result.op);
   };
 
   return {
@@ -158,15 +202,20 @@ export async function createTreecrdtPostgresClient(
     storage: 'postgres',
     docId,
     ops: {
-      append: async (op) => {
-        backend.applyOps([operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)]);
-      },
-      appendMany: async (ops) => {
-        if (ops.length === 0) return [];
-        const affected = backend.applyOps(
-          ops.map((op) => operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)),
+      append: async (op, writeOpts?: WriteOptions) => {
+        const outcome = nativeToMaterializationOutcome(
+          backend.applyOps([operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)]),
         );
-        return affected.map((node) => nodeIdFromBytes16(node));
+        emitMaterialized(outcome, writeOpts?.writeId);
+      },
+      appendMany: async (ops, writeOpts?: WriteOptions) => {
+        if (ops.length === 0) return;
+        const outcome = nativeToMaterializationOutcome(
+          backend.applyOps(
+            ops.map((op) => operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)),
+          ),
+        );
+        emitMaterialized(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),
       since: opsSinceImpl,
@@ -195,6 +244,12 @@ export async function createTreecrdtPostgresClient(
       move: localMoveImpl,
       delete: localDeleteImpl,
       payload: localPayloadImpl,
+    },
+    onMaterialized: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     },
     close: async () => {
       // no-op: native layer opens per-call connections

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -1,12 +1,7 @@
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import { nodeIdFromBytes16, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
-import type {
-  MaterializationEvent,
-  MaterializationListener,
-  MaterializationOutcome,
-  TreecrdtEngine,
-  WriteOptions,
-} from '@treecrdt/interface/engine';
+import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 import {
@@ -57,18 +52,10 @@ export async function createTreecrdtPostgresClient(
   ensureNonEmptyString('docId', docId);
 
   const backend = factory.open(docId);
-  const listeners = new Set<MaterializationListener>();
-  const emitMaterialized = (outcome: MaterializationOutcome, writeId?: string) => {
-    if (outcome.changes.length === 0) return;
-    const event: MaterializationEvent = {
-      ...outcome,
-      ...(writeId ? { writeIds: [writeId] } : {}),
-    };
-    for (const listener of listeners) listener(event);
-  };
+  const materialized = createMaterializationDispatcher();
   const ensureMaterializedImpl = () => {
     const outcome = nativeToMaterializationOutcome(backend.ensureMaterialized());
-    emitMaterialized(outcome);
+    materialized.emitOutcome(outcome);
   };
 
   const encodeReplica = (replica: Operation['meta']['id']['replica']): Uint8Array =>
@@ -160,7 +147,7 @@ export async function createTreecrdtPostgresClient(
       payload,
     );
     const outcome = nativeToMaterializationOutcome(result.outcome);
-    emitMaterialized(outcome);
+    materialized.emitOutcome(outcome);
     return nativeToOperation(result.op);
   };
 
@@ -179,21 +166,21 @@ export async function createTreecrdtPostgresClient(
       after,
     );
     const outcome = nativeToMaterializationOutcome(result.outcome);
-    emitMaterialized(outcome);
+    materialized.emitOutcome(outcome);
     return nativeToOperation(result.op);
   };
 
   const localDeleteImpl = async (replica: ReplicaId, node: string) => {
     const result = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
     const outcome = nativeToMaterializationOutcome(result.outcome);
-    emitMaterialized(outcome);
+    materialized.emitOutcome(outcome);
     return nativeToOperation(result.op);
   };
 
   const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) => {
     const result = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
     const outcome = nativeToMaterializationOutcome(result.outcome);
-    emitMaterialized(outcome);
+    materialized.emitOutcome(outcome);
     return nativeToOperation(result.op);
   };
 
@@ -206,7 +193,7 @@ export async function createTreecrdtPostgresClient(
         const outcome = nativeToMaterializationOutcome(
           backend.applyOps([operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)]),
         );
-        emitMaterialized(outcome, writeOpts?.writeId);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       appendMany: async (ops, writeOpts?: WriteOptions) => {
         if (ops.length === 0) return;
@@ -215,7 +202,7 @@ export async function createTreecrdtPostgresClient(
             ops.map((op) => operationToNativeWithSerializers(op, nodeIdToBytes16, encodeReplica)),
           ),
         );
-        emitMaterialized(outcome, writeOpts?.writeId);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),
       since: opsSinceImpl,
@@ -245,12 +232,7 @@ export async function createTreecrdtPostgresClient(
       delete: localDeleteImpl,
       payload: localPayloadImpl,
     },
-    onMaterialized: (listener) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
+    onMaterialized: materialized.onMaterialized,
     close: async () => {
       // no-op: native layer opens per-call connections
     },

--- a/packages/treecrdt-postgres-napi/src/codec.ts
+++ b/packages/treecrdt-postgres-napi/src/codec.ts
@@ -180,6 +180,7 @@ export function nativeOpToSqliteRow(row: NativeOp): Record<string, unknown> {
 export function nativeToMaterializationOutcome(
   outcome: NativeMaterializationOutcome,
 ): MaterializationOutcome {
+  const payloadOrNull = (payload: Uint8Array | null | undefined) => payload ?? null;
   return {
     headSeq: parseSafeInteger('headSeq', outcome.headSeq),
     changes: outcome.changes.map((change) => {
@@ -190,6 +191,7 @@ export function nativeToMaterializationOutcome(
           kind,
           node: nodeIdFromBytes16(change.node),
           parentAfter: nodeIdFromBytes16(change.parentAfter),
+          payload: payloadOrNull(change.payload),
         };
       }
       if (kind === 'move') {
@@ -213,10 +215,15 @@ export function nativeToMaterializationOutcome(
           kind,
           node: nodeIdFromBytes16(change.node),
           parentAfter: change.parentAfter ? nodeIdFromBytes16(change.parentAfter) : null,
+          payload: payloadOrNull(change.payload),
         };
       }
       if (kind === 'payload') {
-        return { kind, node: nodeIdFromBytes16(change.node) };
+        return {
+          kind,
+          node: nodeIdFromBytes16(change.node),
+          payload: payloadOrNull(change.payload),
+        };
       }
       throw new Error(`unknown native materialization change kind: ${kind}`);
     }),

--- a/packages/treecrdt-postgres-napi/src/codec.ts
+++ b/packages/treecrdt-postgres-napi/src/codec.ts
@@ -5,8 +5,9 @@ import {
   nodeIdToBytes16,
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
+import type { MaterializationOutcome } from '@treecrdt/interface/engine';
 
-import type { NativeOp } from './native.js';
+import type { NativeMaterializationOutcome, NativeOp } from './native.js';
 
 function assertSafeNonNegativeInteger(name: string, value: number): void {
   if (!Number.isSafeInteger(value) || value < 0) {
@@ -173,5 +174,51 @@ export function nativeOpToSqliteRow(row: NativeOp): Record<string, unknown> {
     order_key: row.orderKey ?? null,
     payload: row.payload ?? null,
     known_state: row.knownState ?? null,
+  };
+}
+
+export function nativeToMaterializationOutcome(
+  outcome: NativeMaterializationOutcome,
+): MaterializationOutcome {
+  return {
+    headSeq: parseSafeInteger('headSeq', outcome.headSeq),
+    changes: outcome.changes.map((change) => {
+      const kind = String(change.kind);
+      if (kind === 'insert') {
+        if (!change.parentAfter) throw new Error('native insert change missing parentAfter');
+        return {
+          kind,
+          node: nodeIdFromBytes16(change.node),
+          parentAfter: nodeIdFromBytes16(change.parentAfter),
+        };
+      }
+      if (kind === 'move') {
+        if (!change.parentAfter) throw new Error('native move change missing parentAfter');
+        return {
+          kind,
+          node: nodeIdFromBytes16(change.node),
+          parentBefore: change.parentBefore ? nodeIdFromBytes16(change.parentBefore) : null,
+          parentAfter: nodeIdFromBytes16(change.parentAfter),
+        };
+      }
+      if (kind === 'delete') {
+        return {
+          kind,
+          node: nodeIdFromBytes16(change.node),
+          parentBefore: change.parentBefore ? nodeIdFromBytes16(change.parentBefore) : null,
+        };
+      }
+      if (kind === 'restore') {
+        return {
+          kind,
+          node: nodeIdFromBytes16(change.node),
+          parentAfter: change.parentAfter ? nodeIdFromBytes16(change.parentAfter) : null,
+        };
+      }
+      if (kind === 'payload') {
+        return { kind, node: nodeIdFromBytes16(change.node) };
+      }
+      throw new Error(`unknown native materialization change kind: ${kind}`);
+    }),
   };
 }

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -18,6 +18,23 @@ export type NativeOp = {
   knownState?: Uint8Array | null;
 };
 
+export type NativeMaterializationChange = {
+  kind: string;
+  node: Uint8Array;
+  parentBefore?: Uint8Array | null;
+  parentAfter?: Uint8Array | null;
+};
+
+export type NativeMaterializationOutcome = {
+  headSeq: bigint | number;
+  changes: NativeMaterializationChange[];
+};
+
+export type NativeLocalOpResult = {
+  op: NativeOp;
+  outcome: NativeMaterializationOutcome;
+};
+
 export type NativeBackend = {
   maxLamport(): bigint;
   listOpRefsAll(): Uint8Array[];
@@ -43,7 +60,8 @@ export type NativeBackend = {
   treeExists(node: Uint8Array): boolean;
   treePayload(node: Uint8Array): Uint8Array | null;
   replicaMaxCounter(replica: Uint8Array): bigint;
-  applyOps(ops: NativeOp[]): Uint8Array[];
+  applyOps(ops: NativeOp[]): NativeMaterializationOutcome;
+  ensureMaterialized(): NativeMaterializationOutcome;
   localInsert(
     replica: Uint8Array,
     parent: Uint8Array,
@@ -51,16 +69,20 @@ export type NativeBackend = {
     placement: string,
     after: Uint8Array | null,
     payload: Uint8Array | null,
-  ): NativeOp;
+  ): NativeLocalOpResult;
   localMove(
     replica: Uint8Array,
     node: Uint8Array,
     newParent: Uint8Array,
     placement: string,
     after: Uint8Array | null,
-  ): NativeOp;
-  localDelete(replica: Uint8Array, node: Uint8Array): NativeOp;
-  localPayload(replica: Uint8Array, node: Uint8Array, payload: Uint8Array | null): NativeOp;
+  ): NativeLocalOpResult;
+  localDelete(replica: Uint8Array, node: Uint8Array): NativeLocalOpResult;
+  localPayload(
+    replica: Uint8Array,
+    node: Uint8Array,
+    payload: Uint8Array | null,
+  ): NativeLocalOpResult;
 };
 
 export type NativeFactory = {

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -23,6 +23,7 @@ export type NativeMaterializationChange = {
   node: Uint8Array;
   parentBefore?: Uint8Array | null;
   parentAfter?: Uint8Array | null;
+  payload?: Uint8Array | null;
 };
 
 export type NativeMaterializationOutcome = {

--- a/packages/treecrdt-postgres-napi/tests/conformance.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/conformance.test.ts
@@ -65,11 +65,11 @@ function internalDocId(publicDocId: string, key: string): string {
   return `${publicDocId}::${key}::${randomUUID()}`;
 }
 
-test('conformance registry includes affected-id scenarios', () => {
+test('conformance registry includes materialization-event scenarios', () => {
   const names = treecrdtEngineConformanceScenarios().map((s) => s.name);
-  expect(names).toContain('appendMany: returns affected ids for structural batch');
-  expect(names).toContain('appendMany: returns deduped deterministic affected ids');
-  expect(names).toContain('appendMany: returns indirect affected ids on defensive restore');
+  expect(names).toContain('materialization events: structural batch');
+  expect(names).toContain('materialization events: payload coalescing');
+  expect(names).toContain('materialization events: defensive restore');
 });
 
 maybeDescribe('engine conformance scenarios (postgres-napi engine)', () => {

--- a/packages/treecrdt-postgres-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-rs/src/lib.rs
@@ -19,4 +19,4 @@ pub use reads::{
     tree_payload, TreeChildRow, TreeRow,
 };
 pub use schema::{ensure_schema, reset_doc_for_tests};
-pub use store::{append_ops, append_ops_with_affected_nodes, ensure_materialized};
+pub use store::{append_ops, append_ops_with_materialization_outcome, ensure_materialized};

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -4,8 +4,8 @@ use std::rc::Rc;
 use postgres::Client;
 
 use treecrdt_core::{
-    Error, LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor, NodeId,
-    Operation, ReplicaId, Result, TreeCrdt,
+    Error, LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor,
+    MaterializationOutcome, NodeId, Operation, ReplicaId, Result, TreeCrdt,
 };
 
 use crate::store::{
@@ -21,6 +21,20 @@ struct LocalOpSession {
     meta: TreeMeta,
     nodes: PgNodeStore,
     crdt: LocalCrdt,
+}
+
+#[derive(Clone, Debug)]
+pub struct LocalOpResult {
+    pub op: Operation,
+    pub outcome: MaterializationOutcome,
+}
+
+impl std::ops::Deref for LocalOpResult {
+    type Target = Operation;
+
+    fn deref(&self) -> &Self::Target {
+        &self.op
+    }
 }
 
 fn run_in_tx<T>(client: &Rc<RefCell<Client>>, f: impl FnOnce() -> Result<T>) -> Result<T> {
@@ -79,19 +93,21 @@ fn finish_local_core_op(
     session: &mut LocalOpSession,
     op: &Operation,
     plan: LocalFinalizePlan,
-) -> Result<()> {
+) -> Result<MaterializationOutcome> {
     let mut post_materialization_ok = true;
-    let mut seq = 0u64;
+    let mut outcome = MaterializationOutcome::empty(session.meta.state().head_seq());
 
     let mut op_index = PgParentOpIndex::new(session.ctx.clone());
     // commit_local() already persisted the op and updated node/payload state. The finalize step
     // refreshes adapter-owned derived state that lives outside TreeCrdt itself.
-    match session
-        .crdt
-        .finalize_local(op, &mut op_index, session.meta.state().head_seq(), &plan)
-    {
+    match session.crdt.finalize_local_with_outcome(
+        op,
+        &mut op_index,
+        session.meta.state().head_seq(),
+        &plan,
+    ) {
         Ok(v) => {
-            seq = v;
+            outcome = v;
             if session.nodes.flush_last_change().is_err() || op_index.flush().is_err() {
                 post_materialization_ok = false;
             }
@@ -105,7 +121,7 @@ fn finish_local_core_op(
             replica: op.meta.id.replica.as_bytes(),
             counter: op.meta.id.counter,
         },
-        seq,
+        seq: outcome.head_seq,
     };
     if post_materialization_ok
         && update_tree_meta_head(&session.ctx.client, &session.ctx.doc_id, Some(&head)).is_err()
@@ -125,7 +141,7 @@ fn finish_local_core_op(
         )?;
     }
 
-    Ok(())
+    Ok(outcome)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -138,13 +154,13 @@ pub fn local_insert(
     placement: &str,
     after: Option<NodeId>,
     payload: Option<Vec<u8>>,
-) -> Result<Operation> {
+) -> Result<LocalOpResult> {
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let placement = LocalPlacement::from_parts(placement, after)?;
         let (op, plan) = session.crdt.local_insert(parent, node, placement, payload)?;
-        finish_local_core_op(&mut session, &op, plan)?;
-        Ok(op)
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        Ok(LocalOpResult { op, outcome })
     })
 }
 
@@ -156,13 +172,13 @@ pub fn local_move(
     new_parent: NodeId,
     placement: &str,
     after: Option<NodeId>,
-) -> Result<Operation> {
+) -> Result<LocalOpResult> {
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let placement = LocalPlacement::from_parts(placement, after)?;
         let (op, plan) = session.crdt.local_move(node, new_parent, placement)?;
-        finish_local_core_op(&mut session, &op, plan)?;
-        Ok(op)
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        Ok(LocalOpResult { op, outcome })
     })
 }
 
@@ -171,12 +187,12 @@ pub fn local_delete(
     doc_id: &str,
     replica: &ReplicaId,
     node: NodeId,
-) -> Result<Operation> {
+) -> Result<LocalOpResult> {
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let (op, plan) = session.crdt.local_delete(node)?;
-        finish_local_core_op(&mut session, &op, plan)?;
-        Ok(op)
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        Ok(LocalOpResult { op, outcome })
     })
 }
 
@@ -186,11 +202,11 @@ pub fn local_payload(
     replica: &ReplicaId,
     node: NodeId,
     payload: Option<Vec<u8>>,
-) -> Result<Operation> {
+) -> Result<LocalOpResult> {
     run_in_tx(client, || {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let (op, plan) = session.crdt.local_payload(node, payload)?;
-        finish_local_core_op(&mut session, &op, plan)?;
-        Ok(op)
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        Ok(LocalOpResult { op, outcome })
     })
 }

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -17,7 +17,7 @@ use treecrdt_core::{
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
 
 pub(crate) use self::append::ensure_materialized_in_tx;
-pub use self::append::{append_ops, append_ops_with_affected_nodes, ensure_materialized};
+pub use self::append::{append_ops, append_ops_with_materialization_outcome, ensure_materialized};
 pub(crate) use self::meta::{
     ensure_doc_meta, load_tree_meta_for_update, set_tree_meta_replay_frontier,
     update_tree_meta_head, PgCtx, TreeMeta,

--- a/packages/treecrdt-postgres-rs/src/store/append.rs
+++ b/packages/treecrdt-postgres-rs/src/store/append.rs
@@ -7,8 +7,8 @@ use postgres::Client;
 use treecrdt_core::{
     catch_up_materialized_state, materialize_persisted_remote_ops_with_delta,
     orchestrate_persisted_remote_append, try_direct_rewind_catch_up_materialized_state, Error,
-    LamportClock, MaterializationCursor, MaterializationHead, NodeId, Operation, OperationKind,
-    PersistedRemoteStores, ReplicaId, Result,
+    LamportClock, MaterializationCursor, MaterializationHead, MaterializationOutcome, Operation,
+    OperationKind, PersistedRemoteStores, ReplicaId, Result,
 };
 
 use crate::profile::{append_profile_enabled, PgAppendProfile};
@@ -68,11 +68,11 @@ pub fn append_ops(client: &Rc<RefCell<Client>>, doc_id: &str, ops: &[Operation])
     }
 }
 
-pub fn append_ops_with_affected_nodes(
+pub fn append_ops_with_materialization_outcome(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     ops: &[Operation],
-) -> Result<Vec<NodeId>> {
+) -> Result<MaterializationOutcome> {
     {
         let mut c = client.borrow_mut();
         c.batch_execute("BEGIN").map_err(|e| Error::Storage(e.to_string()))?;
@@ -84,7 +84,7 @@ pub fn append_ops_with_affected_nodes(
         Ok(v) => {
             let mut c = client.borrow_mut();
             c.batch_execute("COMMIT").map_err(|e| Error::Storage(e.to_string()))?;
-            Ok(v.affected_nodes)
+            Ok(v.outcome)
         }
         Err(e) => {
             let mut c = client.borrow_mut();
@@ -97,7 +97,7 @@ pub fn append_ops_with_affected_nodes(
 #[derive(Default)]
 struct AppendOpsResult {
     inserted_count: u64,
-    affected_nodes: Vec<NodeId>,
+    outcome: MaterializationOutcome,
 }
 
 fn append_ops_in_tx(
@@ -207,11 +207,14 @@ fn append_ops_in_tx(
 
     Ok(AppendOpsResult {
         inserted_count: apply_result.inserted_count,
-        affected_nodes: apply_result.affected_nodes,
+        outcome: apply_result.outcome,
     })
 }
 
-pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
+pub fn ensure_materialized(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+) -> Result<MaterializationOutcome> {
     {
         let mut c = client.borrow_mut();
         c.batch_execute("BEGIN").map_err(|e| Error::Storage(e.to_string()))?;
@@ -220,10 +223,10 @@ pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result
     let res = ensure_materialized_in_tx(client, doc_id);
 
     match res {
-        Ok(()) => {
+        Ok(outcome) => {
             let mut c = client.borrow_mut();
             c.batch_execute("COMMIT").map_err(|e| Error::Storage(e.to_string()))?;
-            Ok(())
+            Ok(outcome)
         }
         Err(e) => {
             let mut c = client.borrow_mut();
@@ -233,16 +236,19 @@ pub fn ensure_materialized(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result
     }
 }
 
-pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
+pub(crate) fn ensure_materialized_in_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+) -> Result<MaterializationOutcome> {
     let meta = load_tree_meta(client, doc_id)?;
     if meta.state().replay_from.is_none() {
-        return Ok(());
+        return Ok(MaterializationOutcome::empty(meta.state().head_seq()));
     }
 
     // Take a per-doc lock so catch-up can't race with concurrent append/materialization.
     let meta = load_tree_meta_for_update(client, doc_id)?;
     if meta.state().replay_from.is_none() {
-        return Ok(());
+        return Ok(MaterializationOutcome::empty(meta.state().head_seq()));
     }
 
     let ctx = PgCtx::new(client.clone(), doc_id)?;
@@ -263,5 +269,5 @@ pub(crate) fn ensure_materialized_in_tx(client: &Rc<RefCell<Client>>, doc_id: &s
 
     update_tree_meta_head(client, doc_id, catch_up.head.as_ref())?;
 
-    Ok(())
+    Ok(catch_up.outcome)
 }

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -5,9 +5,9 @@ use std::sync::OnceLock;
 use postgres::{Client, NoTls};
 use uuid::Uuid;
 
-use treecrdt_core::{NodeId, Operation, ReplicaId, VersionVector};
+use treecrdt_core::{MaterializationOutcome, NodeId, Operation, ReplicaId, VersionVector};
 use treecrdt_postgres::{
-    append_ops, append_ops_with_affected_nodes, ensure_materialized, ensure_schema,
+    append_ops, append_ops_with_materialization_outcome, ensure_materialized, ensure_schema,
     get_ops_by_op_refs, list_op_refs_all, list_op_refs_children, local_delete, local_insert,
     local_move, local_payload, max_lamport, replica_max_counter, reset_doc_for_tests,
     tree_children, tree_payload,
@@ -41,8 +41,8 @@ impl MaterializationConformanceHarness for PgConformanceHarness {
         append_ops(&self.client, &self.doc_id, ops).unwrap();
     }
 
-    fn append_ops_with_affected_nodes(&self, ops: &[Operation]) -> Vec<NodeId> {
-        append_ops_with_affected_nodes(&self.client, &self.doc_id, ops).unwrap()
+    fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome {
+        append_ops_with_materialization_outcome(&self.client, &self.doc_id, ops).unwrap()
     }
 
     fn visible_children(&self, parent: NodeId) -> Vec<NodeId> {
@@ -189,7 +189,7 @@ fn postgres_backend_append_batch_materializes_only_inserted_ops() {
 }
 
 #[test]
-fn postgres_backend_append_with_affected_nodes_matches_representative_remote_batch() {
+fn postgres_backend_append_with_materialization_outcome_matches_representative_remote_batch() {
     let Some(harness) = setup_conformance_harness() else {
         return;
     };
@@ -313,7 +313,8 @@ fn postgres_backend_failed_immediate_catch_up_rolls_back_inserted_ops_and_meta()
     }
 
     let append_err =
-        append_ops_with_affected_nodes(&client, &doc_id, std::slice::from_ref(&first)).unwrap_err();
+        append_ops_with_materialization_outcome(&client, &doc_id, std::slice::from_ref(&first))
+            .unwrap_err();
     assert!(append_err.to_string().contains("forced catch-up failure"));
 
     let (op_count, replay_lamport, replay_replica, replay_counter, head_seq, children) = {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
@@ -1,3 +1,4 @@
+use super::materialize::json_outcome_from_core;
 use super::util::sqlite_result_json;
 use super::*;
 
@@ -150,7 +151,7 @@ pub(super) unsafe extern "C" fn treecrdt_append_op(
     };
 
     match append_ops_impl(db, &doc_id, "treecrdt_append_op", std::slice::from_ref(&op)) {
-        Ok(_) => sqlite_result_int(ctx, 1),
+        Ok(outcome) => sqlite_result_json(ctx, &json_outcome_from_core(&outcome)),
         Err(rc) => sqlite_result_error_code(ctx, rc),
     }
 }
@@ -172,7 +173,7 @@ pub(super) struct JsonAppendOp {
 }
 
 /// Batch append: accepts a single JSON array argument with fields matching the ops table.
-/// Returns JSON array of affected 16-byte node IDs.
+/// Returns a JSON materialization outcome.
 pub(super) unsafe extern "C" fn treecrdt_append_ops(
     ctx: *mut sqlite3_context,
     argc: c_int,
@@ -219,7 +220,10 @@ pub(super) unsafe extern "C" fn treecrdt_append_ops(
         }
     };
     if ops.is_empty() {
-        sqlite_result_json(ctx, &Vec::<Vec<u8>>::new());
+        sqlite_result_json(
+            ctx,
+            &json_outcome_from_core(&treecrdt_core::MaterializationOutcome::empty(0)),
+        );
         return;
     }
 
@@ -261,11 +265,7 @@ pub(super) unsafe extern "C" fn treecrdt_append_ops(
     }
 
     match append_ops_impl(db, &doc_id, "treecrdt_append_ops", &ops) {
-        Ok(affected_nodes) => {
-            let out: Vec<Vec<u8>> =
-                affected_nodes.into_iter().map(|id| id.0.to_be_bytes().to_vec()).collect();
-            sqlite_result_json(ctx, &out);
-        }
+        Ok(outcome) => sqlite_result_json(ctx, &json_outcome_from_core(&outcome)),
         Err(rc) => sqlite_result_error_code(ctx, rc),
     }
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -1,3 +1,4 @@
+use super::materialize::{json_outcome_from_core, JsonMaterializationOutcome};
 use super::node_store::SqliteNodeStore;
 use super::op_index::SqliteParentOpIndex;
 use super::op_storage::SqliteOpStorage;
@@ -24,6 +25,13 @@ struct JsonOp {
     order_key: Option<Vec<u8>>,
     known_state: Option<Vec<u8>>,
     payload: Option<Vec<u8>>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonLocalOpResult {
+    op: JsonOp,
+    outcome: JsonMaterializationOutcome,
 }
 
 type LocalCrdt = TreeCrdt<SqliteOpStorage, LamportClock, SqliteNodeStore, SqlitePayloadStore>;
@@ -196,10 +204,10 @@ fn finish_local_core_op(
     mut session: LocalOpSession,
     op: Operation,
     plan: LocalFinalizePlan,
-) -> Result<JsonOp, c_int> {
+) -> Result<JsonLocalOpResult, c_int> {
     let mut post_materialization_ok = true;
-    let mut next_seq = 0u64;
     let mut head_seq = 0u64;
+    let mut outcome = treecrdt_core::MaterializationOutcome::empty(0);
     match load_tree_meta(session.db) {
         Ok(meta) => head_seq = meta.state().head_seq(),
         Err(_) => post_materialization_ok = false,
@@ -208,12 +216,12 @@ fn finish_local_core_op(
         let finalize_rc = match SqliteParentOpIndex::prepare(session.db, session.doc_id.clone()) {
             Ok(mut op_index) => session
                 .crdt
-                .finalize_local(&op, &mut op_index, head_seq, &plan)
+                .finalize_local_with_outcome(&op, &mut op_index, head_seq, &plan)
                 .map_err(|_| SQLITE_ERROR as c_int),
             Err(_) => Err(SQLITE_ERROR as c_int),
         };
         match finalize_rc {
-            Ok(seq) => next_seq = seq,
+            Ok(next) => outcome = next,
             Err(_) => post_materialization_ok = false,
         }
     }
@@ -223,7 +231,7 @@ fn finish_local_core_op(
             replica: op.meta.id.replica.as_bytes(),
             counter: op.meta.id.counter,
         },
-        seq: next_seq,
+        seq: outcome.head_seq,
     };
     if post_materialization_ok && update_tree_meta_head(session.db, Some(&head)).is_err() {
         post_materialization_ok = false;
@@ -239,7 +247,7 @@ fn finish_local_core_op(
         )?;
     }
 
-    let out = match json_op_from_operation(op) {
+    let op = match json_op_from_operation(op) {
         Ok(v) => v,
         Err(rc) => {
             sqlite_exec(
@@ -271,7 +279,10 @@ fn finish_local_core_op(
         return Err(commit_rc);
     }
 
-    Ok(out)
+    Ok(JsonLocalOpResult {
+        op,
+        outcome: json_outcome_from_core(&outcome),
+    })
 }
 
 fn run_local_core_op<F>(
@@ -280,7 +291,7 @@ fn run_local_core_op<F>(
     replica: Vec<u8>,
     savepoint_name: &str,
     build: F,
-) -> Result<JsonOp, c_int>
+) -> Result<JsonLocalOpResult, c_int>
 where
     F: FnOnce(&mut LocalCrdt) -> treecrdt_core::Result<(Operation, LocalFinalizePlan)>,
 {
@@ -393,7 +404,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_insert(
         }
     };
 
-    sqlite_result_json(ctx, &vec![out]);
+    sqlite_result_json(ctx, &out);
 }
 
 pub(super) unsafe extern "C" fn treecrdt_local_move(
@@ -495,7 +506,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_move(
             return;
         }
     };
-    sqlite_result_json(ctx, &vec![out]);
+    sqlite_result_json(ctx, &out);
 }
 
 pub(super) unsafe extern "C" fn treecrdt_local_delete(
@@ -565,7 +576,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_delete(
             return;
         }
     };
-    sqlite_result_json(ctx, &vec![out]);
+    sqlite_result_json(ctx, &out);
 }
 
 pub(super) unsafe extern "C" fn treecrdt_local_payload(
@@ -637,5 +648,5 @@ pub(super) unsafe extern "C" fn treecrdt_local_payload(
             return;
         }
     };
-    sqlite_result_json(ctx, &vec![out]);
+    sqlite_result_json(ctx, &out);
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -3,14 +3,100 @@ use super::node_store::SqliteNodeStore;
 use super::op_index::SqliteParentOpIndex;
 use super::payload_store::SqlitePayloadStore;
 use super::schema::set_tree_meta_replay_frontier;
-use super::util::sqlite_err_from_core;
+use super::util::{sqlite_err_from_core, sqlite_result_json};
 use super::*;
 use treecrdt_core::PayloadStore;
 use treecrdt_core::Storage;
 use treecrdt_core::{
     orchestrate_persisted_remote_append, try_direct_rewind_catch_up_materialized_state,
-    LamportClock, MaterializationCursor, ReplicaId,
+    LamportClock, MaterializationChange, MaterializationCursor, MaterializationOutcome, ReplicaId,
 };
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct JsonMaterializationOutcome {
+    head_seq: u64,
+    changes: Vec<JsonMaterializationChange>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+enum JsonMaterializationChange {
+    Insert {
+        node: String,
+        parent_after: String,
+    },
+    Move {
+        node: String,
+        parent_before: Option<String>,
+        parent_after: String,
+    },
+    Delete {
+        node: String,
+        parent_before: Option<String>,
+    },
+    Restore {
+        node: String,
+        parent_after: Option<String>,
+    },
+    Payload {
+        node: String,
+    },
+}
+
+fn node_hex(node: NodeId) -> String {
+    format!("{:032x}", node.0)
+}
+
+pub(super) fn json_outcome_from_core(
+    outcome: &MaterializationOutcome,
+) -> JsonMaterializationOutcome {
+    let changes = outcome
+        .changes
+        .iter()
+        .map(|change| match change {
+            MaterializationChange::Insert { node, parent_after } => {
+                JsonMaterializationChange::Insert {
+                    node: node_hex(*node),
+                    parent_after: node_hex(*parent_after),
+                }
+            }
+            MaterializationChange::Move {
+                node,
+                parent_before,
+                parent_after,
+            } => JsonMaterializationChange::Move {
+                node: node_hex(*node),
+                parent_before: parent_before.map(node_hex),
+                parent_after: node_hex(*parent_after),
+            },
+            MaterializationChange::Delete {
+                node,
+                parent_before,
+            } => JsonMaterializationChange::Delete {
+                node: node_hex(*node),
+                parent_before: parent_before.map(node_hex),
+            },
+            MaterializationChange::Restore { node, parent_after } => {
+                JsonMaterializationChange::Restore {
+                    node: node_hex(*node),
+                    parent_after: parent_after.map(node_hex),
+                }
+            }
+            MaterializationChange::Payload { node } => JsonMaterializationChange::Payload {
+                node: node_hex(*node),
+            },
+        })
+        .collect();
+    JsonMaterializationOutcome {
+        head_seq: outcome.head_seq,
+        changes,
+    }
+}
 
 fn parse_node_id(bytes: &[u8]) -> Result<NodeId, c_int> {
     if bytes.len() != 16 {
@@ -115,10 +201,10 @@ fn materialize_inserted_ops(
     .map_err(|_| SQLITE_ERROR as c_int)
 }
 
-pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<(), c_int> {
+pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<MaterializationOutcome, c_int> {
     let meta = load_tree_meta(db)?;
     if meta.state().replay_from.is_none() {
-        return Ok(());
+        return Ok(MaterializationOutcome::empty(meta.state().head_seq()));
     }
     catch_up_materialized_from_frontier(db)
 }
@@ -138,12 +224,12 @@ pub(super) unsafe extern "C" fn treecrdt_ensure_materialized(
 
     let db = sqlite_context_db_handle(ctx);
     match ensure_materialized(db) {
-        Ok(()) => sqlite_result_int(ctx, 1),
+        Ok(outcome) => sqlite_result_json(ctx, &json_outcome_from_core(&outcome)),
         Err(rc) => sqlite_result_error_code(ctx, rc),
     }
 }
 
-fn catch_up_materialized_from_frontier(db: *mut sqlite3) -> Result<(), c_int> {
+fn catch_up_materialized_from_frontier(db: *mut sqlite3) -> Result<MaterializationOutcome, c_int> {
     let begin = CString::new("SAVEPOINT treecrdt_materialize").expect("static");
     let commit = CString::new("RELEASE treecrdt_materialize").expect("static");
     let rollback = CString::new("ROLLBACK TO treecrdt_materialize; RELEASE treecrdt_materialize")
@@ -210,7 +296,7 @@ fn catch_up_materialized_from_frontier(db: *mut sqlite3) -> Result<(), c_int> {
     let head_rc = update_tree_meta_head(db, catch_up.head.as_ref());
     if head_rc.is_err() {
         sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
-        return head_rc;
+        return Err(head_rc.err().unwrap_or(SQLITE_ERROR as c_int));
     }
 
     let commit_rc = sqlite_exec(db, commit.as_ptr(), None, null_mut(), null_mut());
@@ -218,7 +304,7 @@ fn catch_up_materialized_from_frontier(db: *mut sqlite3) -> Result<(), c_int> {
         sqlite_exec(db, rollback.as_ptr(), None, null_mut(), null_mut());
         return Err(commit_rc);
     }
-    Ok(())
+    Ok(catch_up.outcome)
 }
 
 pub(super) fn append_ops_impl(
@@ -226,9 +312,10 @@ pub(super) fn append_ops_impl(
     doc_id: &[u8],
     savepoint_name: &str,
     ops: &[JsonAppendOp],
-) -> Result<Vec<NodeId>, c_int> {
+) -> Result<MaterializationOutcome, c_int> {
     if ops.is_empty() {
-        return Ok(Vec::new());
+        let meta = load_tree_meta(db)?;
+        return Ok(MaterializationOutcome::empty(meta.state().head_seq()));
     }
 
     let meta = load_tree_meta(db)?;
@@ -322,5 +409,5 @@ pub(super) fn append_ops_impl(
         return Err(commit_rc);
     }
 
-    Ok(apply_result.affected_nodes)
+    Ok(apply_result.outcome)
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -29,6 +29,7 @@ enum JsonMaterializationChange {
     Insert {
         node: String,
         parent_after: String,
+        payload: Option<Vec<u8>>,
     },
     Move {
         node: String,
@@ -42,9 +43,11 @@ enum JsonMaterializationChange {
     Restore {
         node: String,
         parent_after: Option<String>,
+        payload: Option<Vec<u8>>,
     },
     Payload {
         node: String,
+        payload: Option<Vec<u8>>,
     },
 }
 
@@ -59,12 +62,15 @@ pub(super) fn json_outcome_from_core(
         .changes
         .iter()
         .map(|change| match change {
-            MaterializationChange::Insert { node, parent_after } => {
-                JsonMaterializationChange::Insert {
-                    node: node_hex(*node),
-                    parent_after: node_hex(*parent_after),
-                }
-            }
+            MaterializationChange::Insert {
+                node,
+                parent_after,
+                payload,
+            } => JsonMaterializationChange::Insert {
+                node: node_hex(*node),
+                parent_after: node_hex(*parent_after),
+                payload: payload.clone(),
+            },
             MaterializationChange::Move {
                 node,
                 parent_before,
@@ -81,15 +87,21 @@ pub(super) fn json_outcome_from_core(
                 node: node_hex(*node),
                 parent_before: parent_before.map(node_hex),
             },
-            MaterializationChange::Restore { node, parent_after } => {
-                JsonMaterializationChange::Restore {
+            MaterializationChange::Restore {
+                node,
+                parent_after,
+                payload,
+            } => JsonMaterializationChange::Restore {
+                node: node_hex(*node),
+                parent_after: parent_after.map(node_hex),
+                payload: payload.clone(),
+            },
+            MaterializationChange::Payload { node, payload } => {
+                JsonMaterializationChange::Payload {
                     node: node_hex(*node),
-                    parent_after: parent_after.map(node_hex),
+                    payload: payload.clone(),
                 }
             }
-            MaterializationChange::Payload { node } => JsonMaterializationChange::Payload {
-                node: node_hex(*node),
-            },
         })
         .collect();
     JsonMaterializationOutcome {

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use treecrdt_core::{
-    order_key::allocate_between, NodeId, Operation, OperationKind, ReplicaId, VersionVector,
+    order_key::allocate_between, MaterializationChange, MaterializationOutcome, NodeId, Operation,
+    OperationKind, ReplicaId, VersionVector,
 };
 use treecrdt_test_support::{
     self as materialization_conformance, MaterializationConformanceHarness,
@@ -25,12 +26,109 @@ struct JsonOp {
     payload: Option<Vec<u8>>,
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonMaterializationOutcome {
+    head_seq: u64,
+    changes: Vec<JsonMaterializationChange>,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+enum JsonMaterializationChange {
+    Insert {
+        node: String,
+        parent_after: String,
+    },
+    Move {
+        node: String,
+        parent_before: Option<String>,
+        parent_after: String,
+    },
+    Delete {
+        node: String,
+        parent_before: Option<String>,
+    },
+    Restore {
+        node: String,
+        parent_after: Option<String>,
+    },
+    Payload {
+        node: String,
+    },
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonLocalOpResult {
+    op: JsonOp,
+    outcome: JsonMaterializationOutcome,
+}
+
 fn node_bytes_from_id(node: NodeId) -> Vec<u8> {
     node.0.to_be_bytes().to_vec()
 }
 
 fn bytes_to_node_id(bytes: &[u8]) -> NodeId {
     NodeId(u128::from_be_bytes(bytes.try_into().unwrap()))
+}
+
+fn hex_to_node_id(hex: &str) -> NodeId {
+    NodeId(u128::from_str_radix(hex, 16).unwrap())
+}
+
+fn json_outcome_to_core(outcome: JsonMaterializationOutcome) -> MaterializationOutcome {
+    MaterializationOutcome {
+        head_seq: outcome.head_seq,
+        changes: outcome
+            .changes
+            .into_iter()
+            .map(|change| match change {
+                JsonMaterializationChange::Insert { node, parent_after } => {
+                    MaterializationChange::Insert {
+                        node: hex_to_node_id(&node),
+                        parent_after: hex_to_node_id(&parent_after),
+                    }
+                }
+                JsonMaterializationChange::Move {
+                    node,
+                    parent_before,
+                    parent_after,
+                } => MaterializationChange::Move {
+                    node: hex_to_node_id(&node),
+                    parent_before: parent_before.as_deref().map(hex_to_node_id),
+                    parent_after: hex_to_node_id(&parent_after),
+                },
+                JsonMaterializationChange::Delete {
+                    node,
+                    parent_before,
+                } => MaterializationChange::Delete {
+                    node: hex_to_node_id(&node),
+                    parent_before: parent_before.as_deref().map(hex_to_node_id),
+                },
+                JsonMaterializationChange::Restore { node, parent_after } => {
+                    MaterializationChange::Restore {
+                        node: hex_to_node_id(&node),
+                        parent_after: parent_after.as_deref().map(hex_to_node_id),
+                    }
+                }
+                JsonMaterializationChange::Payload { node } => MaterializationChange::Payload {
+                    node: hex_to_node_id(&node),
+                },
+            })
+            .collect(),
+    }
+}
+
+fn decode_ops_or_local_result(json: &str) -> Vec<JsonOp> {
+    if let Ok(ops) = serde_json::from_str::<Vec<JsonOp>>(json) {
+        return ops;
+    }
+    vec![serde_json::from_str::<JsonLocalOpResult>(json).unwrap().op]
 }
 
 fn vv_to_bytes(vv: &VersionVector) -> Vec<u8> {
@@ -114,7 +212,7 @@ fn read_replay_frontier(conn: &Connection) -> (Option<i64>, Option<Vec<u8>>, Opt
     .unwrap()
 }
 
-fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (Vec<Vec<u8>>, i64) {
+fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (MaterializationOutcome, i64) {
     let json = serde_json::to_string(ops).unwrap();
     let affected_json: String = conn
         .query_row(
@@ -123,9 +221,9 @@ fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (Vec<Vec<u8>>, i64) {
             |row| row.get(0),
         )
         .unwrap();
-    let affected: Vec<Vec<u8>> = serde_json::from_str(&affected_json).unwrap();
+    let outcome: JsonMaterializationOutcome = serde_json::from_str(&affected_json).unwrap();
     let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0)).unwrap();
-    (affected, count)
+    (json_outcome_to_core(outcome), count)
 }
 
 fn visible_children(conn: &Connection, parent: &[u8]) -> Vec<Vec<u8>> {
@@ -188,9 +286,9 @@ impl MaterializationConformanceHarness for SqliteConformanceHarness {
         append_ops_json(&self.conn, &json_ops(ops));
     }
 
-    fn append_ops_with_affected_nodes(&self, ops: &[Operation]) -> Vec<NodeId> {
-        let (affected, _) = append_ops_json(&self.conn, &json_ops(ops));
-        affected.iter().map(|bytes| bytes_to_node_id(bytes)).collect()
+    fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome {
+        let (outcome, _) = append_ops_json(&self.conn, &json_ops(ops));
+        outcome
     }
 
     fn visible_children(&self, parent: NodeId) -> Vec<NodeId> {
@@ -241,7 +339,7 @@ impl MaterializationConformanceHarness for SqliteConformanceHarness {
     }
 
     fn ensure_materialized(&self) {
-        let _: i64 = self
+        let _: String = self
             .conn
             .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
                 row.get(0)
@@ -283,7 +381,7 @@ fn append_and_fetch_ops_via_extension() {
     let node = node_bytes(1);
     let order_key = (1u16).to_be_bytes().to_vec();
 
-    let _: i64 = conn
+    let _: String = conn
         .query_row(
             "SELECT treecrdt_append_op(?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, NULL)",
             rusqlite::params![
@@ -300,7 +398,7 @@ fn append_and_fetch_ops_via_extension() {
         .unwrap();
 
     // Move node to the end again
-    let _: i64 = conn
+    let _: String = conn
         .query_row(
             "SELECT treecrdt_append_op(?1, ?2, ?3, ?4, NULL, ?5, ?6, ?7, NULL)",
             rusqlite::params![
@@ -319,7 +417,7 @@ fn append_and_fetch_ops_via_extension() {
     let json: String =
         conn.query_row("SELECT treecrdt_ops_since(0)", [], |row| row.get(0)).unwrap();
 
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 2);
     assert_eq!(ops[0].kind, "insert");
     assert_eq!(ops[1].kind, "move");
@@ -343,7 +441,7 @@ fn append_and_fetch_ops_via_extension() {
             |row| row.get(0),
         )
         .unwrap();
-    let filtered: Vec<JsonOp> = serde_json::from_str(&json_filtered).unwrap();
+    let filtered: Vec<JsonOp> = decode_ops_or_local_result(&json_filtered);
     assert_eq!(filtered.len(), 2);
 }
 
@@ -363,7 +461,7 @@ fn local_insert_returns_appended_insert_op() {
         )
         .unwrap();
 
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "insert");
@@ -525,7 +623,7 @@ fn local_insert_after_is_deterministic_for_single_gap() {
 
     // A(1), B(3)
     for (counter, (node, order_key)) in [(1i64, (&node_a, &key_a)), (2i64, (&node_b, &key_b))] {
-        let _: i64 = conn
+        let _: String = conn
             .query_row(
                 "SELECT treecrdt_append_op(?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, NULL)",
                 rusqlite::params![
@@ -550,7 +648,7 @@ fn local_insert_after_is_deterministic_for_single_gap() {
             |row| row.get(0),
         )
         .unwrap();
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "insert");
@@ -570,7 +668,7 @@ fn local_insert_last_is_deterministic_for_single_gap() {
     let node_b = node_bytes(2);
 
     let key_a = (0xfffdu16).to_be_bytes().to_vec();
-    let _: i64 = conn
+    let _: String = conn
         .query_row(
             "SELECT treecrdt_append_op(?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, NULL)",
             rusqlite::params![replica.clone(), 1i64, 1i64, "insert", parent, node_a, key_a],
@@ -585,7 +683,7 @@ fn local_insert_last_is_deterministic_for_single_gap() {
             |row| row.get(0),
         )
         .unwrap();
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "insert");
@@ -633,7 +731,7 @@ fn local_move_allocates_key_excluding_self() {
         (2i64, (&node_b, &key_b)),
         (3i64, (&node_c, &key_c)),
     ] {
-        let _: i64 = conn
+        let _: String = conn
             .query_row(
                 "SELECT treecrdt_append_op(?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7, NULL)",
                 rusqlite::params![
@@ -664,7 +762,7 @@ fn local_move_allocates_key_excluding_self() {
         )
         .unwrap();
 
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "move");
@@ -716,7 +814,7 @@ fn local_move_to_trash_returns_empty_order_key() {
             |row| row.get(0),
         )
         .unwrap();
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "move");
@@ -747,7 +845,7 @@ fn local_delete_includes_known_state_bytes() {
             |row| row.get(0),
         )
         .unwrap();
-    let ops: Vec<JsonOp> = serde_json::from_str(&json).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "delete");
@@ -842,7 +940,7 @@ fn local_payload_set_and_clear_updates_meta() {
             |row| row.get(0),
         )
         .unwrap();
-    let set_ops: Vec<JsonOp> = serde_json::from_str(&set_json).unwrap();
+    let set_ops: Vec<JsonOp> = decode_ops_or_local_result(&set_json);
     assert_eq!(set_ops.len(), 1);
     assert_eq!(set_ops[0].kind, "payload");
     assert_eq!(set_ops[0].payload, Some(payload_bytes));
@@ -856,7 +954,7 @@ fn local_payload_set_and_clear_updates_meta() {
             |row| row.get(0),
         )
         .unwrap();
-    let clear_ops: Vec<JsonOp> = serde_json::from_str(&clear_json).unwrap();
+    let clear_ops: Vec<JsonOp> = decode_ops_or_local_result(&clear_json);
     assert_eq!(clear_ops.len(), 1);
     assert_eq!(clear_ops[0].kind, "payload");
     assert_eq!(clear_ops[0].payload, None);

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -43,6 +43,7 @@ enum JsonMaterializationChange {
     Insert {
         node: String,
         parent_after: String,
+        payload: Option<Vec<u8>>,
     },
     Move {
         node: String,
@@ -56,9 +57,11 @@ enum JsonMaterializationChange {
     Restore {
         node: String,
         parent_after: Option<String>,
+        payload: Option<Vec<u8>>,
     },
     Payload {
         node: String,
+        payload: Option<Vec<u8>>,
     },
 }
 
@@ -88,12 +91,15 @@ fn json_outcome_to_core(outcome: JsonMaterializationOutcome) -> MaterializationO
             .changes
             .into_iter()
             .map(|change| match change {
-                JsonMaterializationChange::Insert { node, parent_after } => {
-                    MaterializationChange::Insert {
-                        node: hex_to_node_id(&node),
-                        parent_after: hex_to_node_id(&parent_after),
-                    }
-                }
+                JsonMaterializationChange::Insert {
+                    node,
+                    parent_after,
+                    payload,
+                } => MaterializationChange::Insert {
+                    node: hex_to_node_id(&node),
+                    parent_after: hex_to_node_id(&parent_after),
+                    payload,
+                },
                 JsonMaterializationChange::Move {
                     node,
                     parent_before,
@@ -110,15 +116,21 @@ fn json_outcome_to_core(outcome: JsonMaterializationOutcome) -> MaterializationO
                     node: hex_to_node_id(&node),
                     parent_before: parent_before.as_deref().map(hex_to_node_id),
                 },
-                JsonMaterializationChange::Restore { node, parent_after } => {
-                    MaterializationChange::Restore {
+                JsonMaterializationChange::Restore {
+                    node,
+                    parent_after,
+                    payload,
+                } => MaterializationChange::Restore {
+                    node: hex_to_node_id(&node),
+                    parent_after: parent_after.as_deref().map(hex_to_node_id),
+                    payload,
+                },
+                JsonMaterializationChange::Payload { node, payload } => {
+                    MaterializationChange::Payload {
                         node: hex_to_node_id(&node),
-                        parent_after: parent_after.as_deref().map(hex_to_node_id),
+                        payload,
                     }
                 }
-                JsonMaterializationChange::Payload { node } => MaterializationChange::Payload {
-                    node: hex_to_node_id(&node),
-                },
             })
             .collect(),
     }

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -19,7 +19,13 @@ import {
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
-import type { TreecrdtEngine } from '@treecrdt/interface/engine';
+import type {
+  MaterializationEvent,
+  MaterializationListener,
+  MaterializationOutcome,
+  TreecrdtEngine,
+  WriteOptions,
+} from '@treecrdt/interface/engine';
 
 export type LoadOptions = {
   extensionPath?: string;
@@ -120,7 +126,19 @@ export function createTreecrdtClient(
   opts: { docId?: string; maxBulkOps?: number } = {},
 ): Promise<TreecrdtEngine & { runner: SqliteRunner }> {
   const runner = createRunner(db);
-  const adapter = createTreecrdtSqliteAdapter(runner, { maxBulkOps: opts.maxBulkOps });
+  const listeners = new Set<MaterializationListener>();
+  const emitMaterialized = (outcome: MaterializationOutcome, writeId?: string) => {
+    if (outcome.changes.length === 0) return;
+    const event: MaterializationEvent = {
+      ...outcome,
+      ...(writeId ? { writeIds: [writeId] } : {}),
+    };
+    for (const listener of listeners) listener(event);
+  };
+  const adapter = createTreecrdtSqliteAdapter(runner, {
+    maxBulkOps: opts.maxBulkOps,
+    onMaterialized: emitMaterialized,
+  });
   const docId = opts.docId ?? 'treecrdt';
 
   const ready = Promise.resolve(adapter.setDocId(docId));
@@ -131,7 +149,10 @@ export function createTreecrdtClient(
     const key = localWriterKey(replica);
     const existing = localWriters.get(key);
     if (existing) return existing;
-    const next = createTreecrdtSqliteWriter(runner, { replica });
+    const next = createTreecrdtSqliteWriter(runner, {
+      replica,
+      onMaterialized: emitMaterialized,
+    });
     localWriters.set(key, next);
     return next;
   };
@@ -187,10 +208,13 @@ export function createTreecrdtClient(
     storage: 'sqlite',
     docId,
     ops: {
-      append: async (op) => adapter.appendOp(op, nodeIdToBytes16, encodeReplica),
-      appendMany: async (ops) => {
-        const affected = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica);
-        return affected.map((node) => nodeIdFromBytes16(node));
+      append: async (op, writeOpts?: WriteOptions) => {
+        const outcome = await adapter.appendOp(op, nodeIdToBytes16, encodeReplica, writeOpts);
+        emitMaterialized(outcome, writeOpts?.writeId);
+      },
+      appendMany: async (ops, writeOpts?: WriteOptions) => {
+        const outcome = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica, writeOpts);
+        emitMaterialized(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),
       since: opsSinceImpl,
@@ -216,6 +240,12 @@ export function createTreecrdtClient(
       move: localMoveImpl,
       delete: localDeleteImpl,
       payload: localPayloadImpl,
+    },
+    onMaterialized: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
     },
     runner,
     close: async () => {

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -19,13 +19,8 @@ import {
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
-import type {
-  MaterializationEvent,
-  MaterializationListener,
-  MaterializationOutcome,
-  TreecrdtEngine,
-  WriteOptions,
-} from '@treecrdt/interface/engine';
+import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 
 export type LoadOptions = {
   extensionPath?: string;
@@ -126,18 +121,10 @@ export function createTreecrdtClient(
   opts: { docId?: string; maxBulkOps?: number } = {},
 ): Promise<TreecrdtEngine & { runner: SqliteRunner }> {
   const runner = createRunner(db);
-  const listeners = new Set<MaterializationListener>();
-  const emitMaterialized = (outcome: MaterializationOutcome, writeId?: string) => {
-    if (outcome.changes.length === 0) return;
-    const event: MaterializationEvent = {
-      ...outcome,
-      ...(writeId ? { writeIds: [writeId] } : {}),
-    };
-    for (const listener of listeners) listener(event);
-  };
+  const materialized = createMaterializationDispatcher();
   const adapter = createTreecrdtSqliteAdapter(runner, {
     maxBulkOps: opts.maxBulkOps,
-    onMaterialized: emitMaterialized,
+    onMaterialized: materialized.emitEvent,
   });
   const docId = opts.docId ?? 'treecrdt';
 
@@ -151,7 +138,7 @@ export function createTreecrdtClient(
     if (existing) return existing;
     const next = createTreecrdtSqliteWriter(runner, {
       replica,
-      onMaterialized: emitMaterialized,
+      onMaterialized: materialized.emitEvent,
     });
     localWriters.set(key, next);
     return next;
@@ -210,11 +197,11 @@ export function createTreecrdtClient(
     ops: {
       append: async (op, writeOpts?: WriteOptions) => {
         const outcome = await adapter.appendOp(op, nodeIdToBytes16, encodeReplica, writeOpts);
-        emitMaterialized(outcome, writeOpts?.writeId);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       appendMany: async (ops, writeOpts?: WriteOptions) => {
         const outcome = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica, writeOpts);
-        emitMaterialized(outcome, writeOpts?.writeId);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),
       since: opsSinceImpl,
@@ -241,12 +228,7 @@ export function createTreecrdtClient(
       delete: localDeleteImpl,
       payload: localPayloadImpl,
     },
-    onMaterialized: (listener) => {
-      listeners.add(listener);
-      return () => {
-        listeners.delete(listener);
-      };
-    },
+    onMaterialized: materialized.onMaterialized,
     runner,
     close: async () => {
       if (typeof db?.close === 'function') db.close();

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -196,11 +196,11 @@ export function createTreecrdtClient(
     docId,
     ops: {
       append: async (op, writeOpts?: WriteOptions) => {
-        const outcome = await adapter.appendOp(op, nodeIdToBytes16, encodeReplica, writeOpts);
+        const outcome = await adapter.appendOp(op, nodeIdToBytes16, encodeReplica);
         materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       appendMany: async (ops, writeOpts?: WriteOptions) => {
-        const outcome = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica, writeOpts);
+        const outcome = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica);
         materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -25,11 +25,11 @@ async function createNodeEngine(opts: { docId: string; path?: string }) {
   return await createTreecrdtClient(db, { docId: opts.docId });
 }
 
-test('conformance registry includes affected-id scenarios', () => {
+test('conformance registry includes materialization-event scenarios', () => {
   const names = treecrdtEngineConformanceScenarios().map((s) => s.name);
-  expect(names).toContain('appendMany: returns affected ids for structural batch');
-  expect(names).toContain('appendMany: returns deduped deterministic affected ids');
-  expect(names).toContain('appendMany: returns indirect affected ids on defensive restore');
+  expect(names).toContain('materialization events: structural batch');
+  expect(names).toContain('materialization events: payload coalescing');
+  expect(names).toContain('materialization events: defensive restore');
 });
 
 for (const scenario of treecrdtEngineConformanceScenarios()) {

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -1,10 +1,13 @@
 use std::slice;
 
-use treecrdt_core::{MaterializationFrontier, NodeId, Operation, ReplicaId};
+use treecrdt_core::{
+    MaterializationChange, MaterializationFrontier, MaterializationOutcome, NodeId, Operation,
+    ReplicaId,
+};
 
 pub trait MaterializationConformanceHarness {
     fn append_ops(&self, ops: &[Operation]);
-    fn append_ops_with_affected_nodes(&self, ops: &[Operation]) -> Vec<NodeId>;
+    fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome;
     fn visible_children(&self, parent: NodeId) -> Vec<NodeId>;
     fn payload(&self, node: NodeId) -> Option<Vec<u8>>;
     fn op_count(&self) -> u64;
@@ -14,6 +17,10 @@ pub trait MaterializationConformanceHarness {
     fn ensure_materialized(&self);
     fn op_ref_counters_for_parent(&self, parent: NodeId) -> Vec<u64>;
     fn op_kinds_for_parent(&self, parent: NodeId) -> Vec<String>;
+}
+
+fn changed_nodes(outcome: &MaterializationOutcome) -> Vec<NodeId> {
+    outcome.affected_nodes()
 }
 
 pub fn order_key_from_position(position: u16) -> Vec<u8> {
@@ -75,8 +82,12 @@ pub fn representative_remote_batch_matches_shape<H: MaterializationConformanceHa
     let replica = ReplicaId::new(b"rep");
     let (p1, p2, child, ops) = representative_remote_batch(&replica);
 
-    let affected = harness.append_ops_with_affected_nodes(&ops);
-    assert_eq!(affected, vec![NodeId::ROOT, p1, p2, child]);
+    let outcome = harness.append_ops_with_materialization_outcome(&ops);
+    assert_eq!(changed_nodes(&outcome), vec![NodeId::ROOT, p1, p2, child]);
+    assert!(outcome
+        .changes
+        .iter()
+        .any(|change| matches!(change, MaterializationChange::Payload { node } if *node == child)));
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![p1, p2]);
     assert_eq!(harness.visible_children(p2), vec![child]);
     assert_eq!(harness.payload(child), Some(vec![8]));
@@ -114,8 +125,11 @@ pub fn out_of_order_append_catches_up_immediately_from_frontier<
     );
 
     harness.append_ops(&[second]);
-    let affected = harness.append_ops_with_affected_nodes(slice::from_ref(&first));
-    assert_eq!(affected, vec![NodeId::ROOT, node(1), node(2)]);
+    let outcome = harness.append_ops_with_materialization_outcome(slice::from_ref(&first));
+    assert_eq!(
+        changed_nodes(&outcome),
+        vec![NodeId::ROOT, node(1), node(2)]
+    );
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 2);
     assert_eq!(
@@ -142,8 +156,8 @@ pub fn out_of_order_losing_payload_skips_replay_frontier<H: MaterializationConfo
     let losing_payload = Operation::set_payload(&replica, 2, 2, payload_node, vec![4]);
 
     harness.append_ops(&[insert, winning_payload]);
-    let affected = harness.append_ops_with_affected_nodes(slice::from_ref(&losing_payload));
-    assert_eq!(affected, vec![payload_node]);
+    let outcome = harness.append_ops_with_materialization_outcome(slice::from_ref(&losing_payload));
+    assert!(outcome.changes.is_empty());
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 3);
     assert_eq!(harness.payload(payload_node), Some(vec![9]));
@@ -167,8 +181,9 @@ pub fn out_of_order_move_with_later_payload_catches_up_immediately<
     let later_payload = Operation::set_payload(&replica, 6, 6, child, vec![9]);
 
     harness.append_ops(&[insert_p1, insert_p2, insert_child, earlier_payload]);
-    let affected = harness.append_ops_with_affected_nodes(&[later_payload, out_of_order_move]);
-    assert_eq!(affected, vec![p1, p2, child]);
+    let outcome =
+        harness.append_ops_with_materialization_outcome(&[later_payload, out_of_order_move]);
+    assert_eq!(changed_nodes(&outcome), vec![p1, p2, child]);
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 6);
     assert_eq!(harness.visible_children(p1), Vec::<NodeId>::new());
@@ -194,9 +209,9 @@ pub fn out_of_order_insert_and_move_before_head_catches_up_immediately<
         Operation::move_node(&replica, 4, 4, child, p2, order_key_from_position(0));
 
     harness.append_ops(&[insert_p1, insert_p2, unrelated_head]);
-    let affected =
-        harness.append_ops_with_affected_nodes(&[out_of_order_move, out_of_order_insert]);
-    assert_eq!(affected, vec![p1, p2, child]);
+    let outcome =
+        harness.append_ops_with_materialization_outcome(&[out_of_order_move, out_of_order_insert]);
+    assert_eq!(changed_nodes(&outcome), vec![p2, child]);
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 5);
     assert_eq!(harness.visible_children(p1), Vec::<NodeId>::new());
@@ -228,8 +243,11 @@ pub fn replay_from_start_frontier_catches_up_immediately<H: MaterializationConfo
     harness.append_ops(&[first]);
     harness.force_replay_from_start();
 
-    let affected = harness.append_ops_with_affected_nodes(&[second]);
-    assert_eq!(affected, vec![NodeId::ROOT, node(1), node(2)]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[second]);
+    assert_eq!(
+        changed_nodes(&outcome),
+        vec![NodeId::ROOT, node(1), node(2)]
+    );
     assert_replay_cleared(harness);
     assert_eq!(
         harness.visible_children(NodeId::ROOT),
@@ -298,7 +316,7 @@ pub fn out_of_order_delete_suffix_falls_back_and_restores_parent<
     let delete_parent = Operation::delete(&replica, 3, 3, parent, Some(vv));
 
     harness.append_ops(&[insert_parent, delete_parent]);
-    let _ = harness.append_ops_with_affected_nodes(&[insert_child]);
+    let _ = harness.append_ops_with_materialization_outcome(&[insert_child]);
 
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 3);

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -87,7 +87,7 @@ pub fn representative_remote_batch_matches_shape<H: MaterializationConformanceHa
     assert!(outcome
         .changes
         .iter()
-        .any(|change| matches!(change, MaterializationChange::Payload { node } if *node == child)));
+        .any(|change| matches!(change, MaterializationChange::Payload { node, payload } if *node == child && payload.as_deref() == Some(&[8]))));
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![p1, p2]);
     assert_eq!(harness.visible_children(p2), vec![child]);
     assert_eq!(harness.payload(child), Some(vec![8]));

--- a/packages/treecrdt-ts/src/adapter.ts
+++ b/packages/treecrdt-ts/src/adapter.ts
@@ -1,5 +1,5 @@
 import type { Operation } from './index.js';
-import type { MaterializationOutcome, WriteOptions } from './engine.js';
+import type { MaterializationOutcome } from './engine.js';
 
 export type SerializeNodeId = (id: string) => Uint8Array;
 export type SerializeReplica = (replica: Operation['meta']['id']['replica']) => Uint8Array;
@@ -92,7 +92,6 @@ export interface TreecrdtAdapter {
     op: Operation,
     serializeNodeId: SerializeNodeId,
     serializeReplica: SerializeReplica,
-    opts?: WriteOptions,
   ): Promise<MaterializationOutcome> | MaterializationOutcome;
   /**
    * Optional batch append hook. When provided, callers can submit many ops
@@ -102,7 +101,6 @@ export interface TreecrdtAdapter {
     ops: Operation[],
     serializeNodeId: SerializeNodeId,
     serializeReplica: SerializeReplica,
-    opts?: WriteOptions,
   ): Promise<MaterializationOutcome> | MaterializationOutcome;
   opsSince(lamport: number, root?: string): Promise<unknown[]>;
   close?(): Promise<void> | void;

--- a/packages/treecrdt-ts/src/adapter.ts
+++ b/packages/treecrdt-ts/src/adapter.ts
@@ -1,4 +1,5 @@
 import type { Operation } from './index.js';
+import type { MaterializationOutcome, WriteOptions } from './engine.js';
 
 export type SerializeNodeId = (id: string) => Uint8Array;
 export type SerializeReplica = (replica: Operation['meta']['id']['replica']) => Uint8Array;
@@ -91,7 +92,8 @@ export interface TreecrdtAdapter {
     op: Operation,
     serializeNodeId: SerializeNodeId,
     serializeReplica: SerializeReplica,
-  ): Promise<void> | void;
+    opts?: WriteOptions,
+  ): Promise<MaterializationOutcome> | MaterializationOutcome;
   /**
    * Optional batch append hook. When provided, callers can submit many ops
    * inside one transaction / prepared statement for better throughput.
@@ -100,7 +102,8 @@ export interface TreecrdtAdapter {
     ops: Operation[],
     serializeNodeId: SerializeNodeId,
     serializeReplica: SerializeReplica,
-  ): Promise<Uint8Array[]> | Uint8Array[];
+    opts?: WriteOptions,
+  ): Promise<MaterializationOutcome> | MaterializationOutcome;
   opsSince(lamport: number, root?: string): Promise<unknown[]>;
   close?(): Promise<void> | void;
 }

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -29,6 +29,38 @@ export type MaterializationEvent = MaterializationOutcome & {
 
 export type MaterializationListener = (event: MaterializationEvent) => void;
 
+export type MaterializationDispatcher = {
+  emitEvent: (event: MaterializationEvent) => void;
+  emitOutcome: (outcome: MaterializationOutcome, writeId?: string) => void;
+  onMaterialized: (listener: MaterializationListener) => () => void;
+};
+
+export function createMaterializationDispatcher(): MaterializationDispatcher {
+  const listeners = new Set<MaterializationListener>();
+
+  const emitEvent = (event: MaterializationEvent) => {
+    if (event.changes.length === 0) return;
+    for (const listener of listeners) listener(event);
+  };
+
+  const emitOutcome = (outcome: MaterializationOutcome, writeId?: string) => {
+    if (outcome.changes.length === 0) return;
+    emitEvent({
+      ...outcome,
+      ...(writeId ? { writeIds: [writeId] } : {}),
+    });
+  };
+
+  const onMaterialized = (listener: MaterializationListener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return { emitEvent, emitOutcome, onMaterialized };
+}
+
 export type WriteOptions = {
   writeId?: string;
 };

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -19,6 +19,10 @@ export type MaterializationOutcome = {
   changes: Change[];
 };
 
+export function emptyMaterializationOutcome(headSeq = 0): MaterializationOutcome {
+  return { headSeq, changes: [] };
+}
+
 /**
  * Event emitted after write-path materialization, or after read-path recovery advances a pending
  * materialization frontier. `writeIds` echoes optional ids supplied to append APIs.

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -1,9 +1,41 @@
 import type { Operation, ReplicaId } from './index.js';
 import type { SqliteTreeChildRow, SqliteTreeRow, TreecrdtSqlitePlacement } from './sqlite.js';
 
+export type Change =
+  | { kind: 'insert'; node: string; parentAfter: string }
+  | { kind: 'move'; node: string; parentBefore: string | null; parentAfter: string }
+  | { kind: 'delete'; node: string; parentBefore: string | null }
+  | { kind: 'restore'; node: string; parentAfter: string | null }
+  | { kind: 'payload'; node: string };
+
+/**
+ * Coalesced result of advancing materialized state to `headSeq`.
+ *
+ * This is intentionally not a raw op list. Replays and batched appends collapse multiple writes for
+ * the same node into final visible changes before adapters emit events.
+ */
+export type MaterializationOutcome = {
+  headSeq: number;
+  changes: Change[];
+};
+
+/**
+ * Event emitted after write-path materialization, or after read-path recovery advances a pending
+ * materialization frontier. `writeIds` echoes optional ids supplied to append APIs.
+ */
+export type MaterializationEvent = MaterializationOutcome & {
+  writeIds?: string[];
+};
+
+export type MaterializationListener = (event: MaterializationEvent) => void;
+
+export type WriteOptions = {
+  writeId?: string;
+};
+
 export type TreecrdtEngineOps = {
-  append: (op: Operation) => Promise<void>;
-  appendMany: (ops: Operation[]) => Promise<string[]>;
+  append: (op: Operation, opts?: WriteOptions) => Promise<void>;
+  appendMany: (ops: Operation[], opts?: WriteOptions) => Promise<void>;
   all: () => Promise<Operation[]>;
   since: (lamport: number, root?: string) => Promise<Operation[]>;
   children: (parent: string) => Promise<Operation[]>;
@@ -67,5 +99,6 @@ export type TreecrdtEngine = {
   tree: TreecrdtEngineTree;
   meta: TreecrdtEngineMeta;
   local: TreecrdtEngineLocal;
+  onMaterialized: (listener: MaterializationListener) => () => void;
   close: () => Promise<void>;
 };

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -2,11 +2,11 @@ import type { Operation, ReplicaId } from './index.js';
 import type { SqliteTreeChildRow, SqliteTreeRow, TreecrdtSqlitePlacement } from './sqlite.js';
 
 export type Change =
-  | { kind: 'insert'; node: string; parentAfter: string }
+  | { kind: 'insert'; node: string; parentAfter: string; payload: Uint8Array | null }
   | { kind: 'move'; node: string; parentBefore: string | null; parentAfter: string }
   | { kind: 'delete'; node: string; parentBefore: string | null }
-  | { kind: 'restore'; node: string; parentAfter: string | null }
-  | { kind: 'payload'; node: string };
+  | { kind: 'restore'; node: string; parentAfter: string | null; payload: Uint8Array | null }
+  | { kind: 'payload'; node: string; payload: Uint8Array | null };
 
 /**
  * Coalesced result of advancing materialized state to `headSeq`.

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -637,6 +637,13 @@ export function decodeSqliteNodeIds(raw: unknown): string[] {
   return raw.map((val) => decodeNodeId(val instanceof Uint8Array ? val : (val as any)));
 }
 
+function decodeSqlitePayload(raw: unknown): Uint8Array | null {
+  if (raw == null) return null;
+  if (raw instanceof Uint8Array) return raw;
+  if (typeof raw === 'string') return hexToBytes(raw);
+  return Uint8Array.from(raw as any);
+}
+
 export function decodeSqliteMaterializationOutcome(raw: unknown): MaterializationOutcome {
   const value = (raw ?? {}) as any;
   const rawChanges = Array.isArray(value.changes) ? value.changes : [];
@@ -647,6 +654,7 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         kind,
         node: decodeNodeId(change.node),
         parentAfter: decodeNodeId(change.parentAfter),
+        payload: decodeSqlitePayload(change.payload),
       };
     }
     if (kind === 'move') {
@@ -669,10 +677,15 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         kind,
         node: decodeNodeId(change.node),
         parentAfter: change.parentAfter == null ? null : decodeNodeId(change.parentAfter),
+        payload: decodeSqlitePayload(change.payload),
       };
     }
     if (kind === 'payload') {
-      return { kind, node: decodeNodeId(change.node) };
+      return {
+        kind,
+        node: decodeNodeId(change.node),
+        payload: decodeSqlitePayload(change.payload),
+      };
     }
     throw new Error(`unknown materialization change kind: ${kind}`);
   });

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,6 +1,9 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
+import type {
+  MaterializationEvent,
+  MaterializationOutcome,
+} from './engine.js';
 import {
-  bytesToHex,
   decodeNodeId,
   decodeReplicaId,
   hexToBytes,
@@ -200,7 +203,7 @@ async function treecrdtAppendOp(
   op: Operation,
   serializeNodeId: SerializeNodeId,
   serializeReplica: SerializeReplica,
-): Promise<void> {
+): Promise<MaterializationOutcome> {
   if (op.kind.type === 'delete' && (!op.meta.knownState || op.meta.knownState.length === 0)) {
     throw new Error('treecrdt: delete operations require meta.knownState');
   }
@@ -216,7 +219,17 @@ async function treecrdtAppendOp(
     knownState: meta.knownState ?? null,
   });
 
-  await runner.getText(sql, params);
+  return decodeSqliteMaterializationOutcome(await sqliteGetJson<unknown>(runner, sql, params));
+}
+
+function mergeMaterializationOutcomes(
+  outcomes: MaterializationOutcome[],
+): MaterializationOutcome {
+  const last = outcomes.length > 0 ? outcomes[outcomes.length - 1] : undefined;
+  return {
+    headSeq: last?.headSeq ?? 0,
+    changes: outcomes.flatMap((outcome) => outcome.changes),
+  };
 }
 
 async function treecrdtAppendOps(
@@ -225,8 +238,8 @@ async function treecrdtAppendOps(
   serializeNodeId: SerializeNodeId,
   serializeReplica: SerializeReplica,
   opts: { maxBulkOps?: number } = {},
-): Promise<Uint8Array[]> {
-  if (ops.length === 0) return [];
+): Promise<MaterializationOutcome> {
+  if (ops.length === 0) return { headSeq: 0, changes: [] };
 
   const maxBulkOps = opts.maxBulkOps ?? 5_000;
   const bulkSql = 'SELECT treecrdt_append_ops(?1)';
@@ -239,43 +252,36 @@ async function treecrdtAppendOps(
     throw new Error('treecrdt: delete operations require meta.knownState');
   }
 
-  const mergeAffected = (into: Map<string, Uint8Array>, values: Uint8Array[]) => {
-    for (const node of values) {
-      const key = bytesToHex(node);
-      if (!into.has(key)) into.set(key, node);
-    }
-  };
-
   // Try bulk entrypoint first, chunked to avoid huge JSON payloads.
   let bulkFailedAt: number | null = null;
-  const affectedByHex = new Map<string, Uint8Array>();
+  const outcomes: MaterializationOutcome[] = [];
   for (let start = 0; start < ops.length; start += maxBulkOps) {
     const chunk = ops.slice(start, start + maxBulkOps);
     const payload = buildAppendOpsPayload(chunk, serializeNodeId, serializeReplica);
     try {
-      const raw = await sqliteGetJsonOrEmpty<unknown[]>(runner, bulkSql, [JSON.stringify(payload)]);
-      mergeAffected(affectedByHex, decodeSqliteOpRefs(raw));
+      const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
+      outcomes.push(decodeSqliteMaterializationOutcome(raw));
     } catch {
       bulkFailedAt = start;
       break;
     }
   }
-  if (bulkFailedAt === null) return Array.from(affectedByHex.values());
+  if (bulkFailedAt === null) return mergeMaterializationOutcomes(outcomes);
 
   const remaining = ops.slice(bulkFailedAt);
   await runner.exec('BEGIN');
   try {
     for (const op of remaining) {
       const payload = buildAppendOpsPayload([op], serializeNodeId, serializeReplica);
-      const raw = await sqliteGetJsonOrEmpty<unknown[]>(runner, bulkSql, [JSON.stringify(payload)]);
-      mergeAffected(affectedByHex, decodeSqliteOpRefs(raw));
+      const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
+      outcomes.push(decodeSqliteMaterializationOutcome(raw));
     }
     await runner.exec('COMMIT');
   } catch (err) {
     await runner.exec('ROLLBACK');
     throw err;
   }
-  return Array.from(affectedByHex.values());
+  return mergeMaterializationOutcomes(outcomes);
 }
 
 async function treecrdtOpsSince(
@@ -293,22 +299,26 @@ async function treecrdtOpsSince(
 
 export function createTreecrdtSqliteAdapter(
   runner: SqliteRunner,
-  opts: { maxBulkOps?: number } = {},
+  opts: { maxBulkOps?: number; onMaterialized?: (event: MaterializationEvent) => void } = {},
 ): TreecrdtAdapter {
+  const emitOutcome = (outcome: MaterializationOutcome) => {
+    if (outcome.changes.length === 0) return;
+    opts.onMaterialized?.({ ...outcome });
+  };
   return {
     setDocId: (docId) => treecrdtSetDocId(runner, docId),
     docId: () => treecrdtDocId(runner),
-    opRefsAll: () => treecrdtOpRefsAll(runner),
-    opRefsChildren: (parent) => treecrdtOpRefsChildren(runner, parent),
+    opRefsAll: () => treecrdtOpRefsAll(runner, emitOutcome),
+    opRefsChildren: (parent) => treecrdtOpRefsChildren(runner, parent, emitOutcome),
     opsByOpRefs: (opRefs) => treecrdtOpsByOpRefs(runner, opRefs),
-    treeChildren: (parent) => treecrdtTreeChildren(runner, parent),
+    treeChildren: (parent) => treecrdtTreeChildren(runner, parent, emitOutcome),
     treeChildrenPage: (parent, cursor, limit) =>
-      treecrdtTreeChildrenPage(runner, parent, cursor, limit),
-    treeDump: () => treecrdtTreeDump(runner),
-    treeNodeCount: () => treecrdtTreeNodeCount(runner),
-    treeParent: (node) => treecrdtTreeParent(runner, node),
-    treeExists: (node) => treecrdtTreeExists(runner, node),
-    treePayload: (node) => treecrdtTreePayload(runner, node),
+      treecrdtTreeChildrenPage(runner, parent, cursor, limit, emitOutcome),
+    treeDump: () => treecrdtTreeDump(runner, emitOutcome),
+    treeNodeCount: () => treecrdtTreeNodeCount(runner, emitOutcome),
+    treeParent: (node) => treecrdtTreeParent(runner, node, emitOutcome),
+    treeExists: (node) => treecrdtTreeExists(runner, node, emitOutcome),
+    treePayload: (node) => treecrdtTreePayload(runner, node, emitOutcome),
     headLamport: () => treecrdtHeadLamport(runner),
     replicaMaxCounter: (replica) => treecrdtReplicaMaxCounter(runner, replica),
     appendOp: (op, serializeNodeId, serializeReplica) =>
@@ -332,16 +342,25 @@ async function treecrdtDocId(runner: SqliteRunner): Promise<string | null> {
   return runner.getText('SELECT treecrdt_doc_id()');
 }
 
-async function treecrdtEnsureMaterialized(runner: SqliteRunner): Promise<void> {
-  await runner.getText('SELECT treecrdt_ensure_materialized()');
+async function treecrdtEnsureMaterialized(
+  runner: SqliteRunner,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<void> {
+  const outcome = decodeSqliteMaterializationOutcome(
+    await sqliteGetJson<unknown>(runner, 'SELECT treecrdt_ensure_materialized()'),
+  );
+  if (outcome.changes.length > 0) emitOutcome?.(outcome);
 }
 
 /**
  * Fetch all stored opRefs (16-byte values) from the extension.
  * Returns raw JSON-decoded values: `number[][]` (bytes) is the expected shape.
  */
-async function treecrdtOpRefsAll(runner: SqliteRunner): Promise<unknown[]> {
-  await treecrdtEnsureMaterialized(runner);
+async function treecrdtOpRefsAll(
+  runner: SqliteRunner,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<unknown[]> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   return sqliteGetJsonOrEmpty(runner, 'SELECT treecrdt_oprefs_all()');
 }
 
@@ -352,8 +371,9 @@ async function treecrdtOpRefsAll(runner: SqliteRunner): Promise<unknown[]> {
 async function treecrdtOpRefsChildren(
   runner: SqliteRunner,
   parent: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
 ): Promise<unknown[]> {
-  await treecrdtEnsureMaterialized(runner);
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   return sqliteGetJsonOrEmpty(runner, 'SELECT treecrdt_oprefs_children(?1)', [parent]);
 }
 
@@ -374,8 +394,12 @@ async function treecrdtOpsByOpRefs(runner: SqliteRunner, opRefs: Uint8Array[]): 
  * Implemented as direct SQL over `tree_nodes` (not a SQLite extension UDF), returning a JSON
  * array of canonical node id hex strings (32 chars).
  */
-async function treecrdtTreeChildren(runner: SqliteRunner, parent: Uint8Array): Promise<unknown[]> {
-  await treecrdtEnsureMaterialized(runner);
+async function treecrdtTreeChildren(
+  runner: SqliteRunner,
+  parent: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<unknown[]> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   return sqliteGetJsonOrEmpty(
     runner,
     "SELECT COALESCE(json_group_array(node_hex), '[]') FROM (\
@@ -398,8 +422,9 @@ async function treecrdtTreeChildrenPage(
   parent: Uint8Array,
   cursor: { orderKey: Uint8Array; node: Uint8Array } | null,
   limit: number,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
 ): Promise<unknown[]> {
-  await treecrdtEnsureMaterialized(runner);
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   const afterOrderKey = cursor?.orderKey ?? null;
   const afterNode = cursor?.node ?? null;
   return sqliteGetJsonOrEmpty(
@@ -425,8 +450,11 @@ async function treecrdtTreeChildrenPage(
  * Dump the full materialized tree state.
  * Returns raw JSON-decoded rows (array of objects with byte fields).
  */
-async function treecrdtTreeDump(runner: SqliteRunner): Promise<unknown[]> {
-  await treecrdtEnsureMaterialized(runner);
+async function treecrdtTreeDump(
+  runner: SqliteRunner,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<unknown[]> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   return sqliteGetJsonOrEmpty(
     runner,
     "SELECT COALESCE(json_group_array(json_object('node', node_hex, 'parent', parent_hex, 'order_key', order_key_hex, 'tombstone', tombstone)), '[]') \
@@ -445,8 +473,11 @@ async function treecrdtTreeDump(runner: SqliteRunner): Promise<unknown[]> {
 /**
  * Count non-tombstoned nodes in the materialized tree (excluding ROOT).
  */
-async function treecrdtTreeNodeCount(runner: SqliteRunner): Promise<number> {
-  await treecrdtEnsureMaterialized(runner);
+async function treecrdtTreeNodeCount(
+  runner: SqliteRunner,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<number> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   return sqliteGetNumber(
     runner,
     'SELECT COUNT(*) FROM tree_nodes WHERE tombstone = 0 AND node <> ?1',
@@ -461,8 +492,9 @@ async function treecrdtTreeNodeCount(runner: SqliteRunner): Promise<number> {
 async function treecrdtTreeParent(
   runner: SqliteRunner,
   node: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
 ): Promise<Uint8Array | null> {
-  await treecrdtEnsureMaterialized(runner);
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   const parentHex = await runner.getText(
     'SELECT CASE WHEN parent IS NULL THEN NULL ELSE lower(hex(parent)) END FROM tree_nodes WHERE node = ?1',
     [node],
@@ -474,8 +506,12 @@ async function treecrdtTreeParent(
 /**
  * Check if a non-tombstoned node exists (16-byte id).
  */
-async function treecrdtTreeExists(runner: SqliteRunner, node: Uint8Array): Promise<boolean> {
-  await treecrdtEnsureMaterialized(runner);
+async function treecrdtTreeExists(
+  runner: SqliteRunner,
+  node: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<boolean> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   const result = await runner.getText(
     'SELECT 1 FROM tree_nodes WHERE node = ?1 AND tombstone = 0 LIMIT 1',
     [node],
@@ -490,8 +526,9 @@ async function treecrdtTreeExists(runner: SqliteRunner, node: Uint8Array): Promi
 async function treecrdtTreePayload(
   runner: SqliteRunner,
   node: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
 ): Promise<Uint8Array | null> {
-  await treecrdtEnsureMaterialized(runner);
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
   const hex = await runner.getText(
     'SELECT hex(payload) FROM tree_payload WHERE node = ?1 LIMIT 1',
     [node],
@@ -538,15 +575,20 @@ export type TreecrdtSqliteWriter = {
 
 export function createTreecrdtSqliteWriter(
   runner: SqliteRunner,
-  opts: { replica: ReplicaId },
+  opts: {
+    replica: ReplicaId;
+    onMaterialized?: (event: MaterializationEvent) => void;
+  },
 ): TreecrdtSqliteWriter {
   const replica = opts.replica;
   const replicaBytes = replicaIdToBytes(replica);
 
   const getLocalOp = async (sql: string, params: SqlCall['params']) => {
-    const raw = await sqliteGetJson<unknown[]>(runner, sql, params);
-    const ops = decodeSqliteOps(raw);
+    const raw = await sqliteGetJson<any>(runner, sql, params);
+    const ops = decodeSqliteOps([raw.op]);
     if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
+    const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
+    if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
     return ops[0]!;
   };
 
@@ -604,6 +646,51 @@ export function decodeSqliteOpRefs(raw: unknown): Uint8Array[] {
 export function decodeSqliteNodeIds(raw: unknown): string[] {
   if (!Array.isArray(raw)) return [];
   return raw.map((val) => decodeNodeId(val instanceof Uint8Array ? val : (val as any)));
+}
+
+export function decodeSqliteMaterializationOutcome(raw: unknown): MaterializationOutcome {
+  const value = (raw ?? {}) as any;
+  const rawChanges = Array.isArray(value.changes) ? value.changes : [];
+  const changes = rawChanges.map((change: any) => {
+    const kind = String(change.kind);
+    if (kind === 'insert') {
+      return {
+        kind,
+        node: decodeNodeId(change.node),
+        parentAfter: decodeNodeId(change.parentAfter),
+      };
+    }
+    if (kind === 'move') {
+      return {
+        kind,
+        node: decodeNodeId(change.node),
+        parentBefore: change.parentBefore == null ? null : decodeNodeId(change.parentBefore),
+        parentAfter: decodeNodeId(change.parentAfter),
+      };
+    }
+    if (kind === 'delete') {
+      return {
+        kind,
+        node: decodeNodeId(change.node),
+        parentBefore: change.parentBefore == null ? null : decodeNodeId(change.parentBefore),
+      };
+    }
+    if (kind === 'restore') {
+      return {
+        kind,
+        node: decodeNodeId(change.node),
+        parentAfter: change.parentAfter == null ? null : decodeNodeId(change.parentAfter),
+      };
+    }
+    if (kind === 'payload') {
+      return { kind, node: decodeNodeId(change.node) };
+    }
+    throw new Error(`unknown materialization change kind: ${kind}`);
+  });
+  return {
+    headSeq: Number(value.headSeq ?? 0),
+    changes,
+  };
 }
 
 export type SqliteTreeChildRow = {

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -265,17 +265,10 @@ async function treecrdtAppendOps(
   if (bulkFailedAt === null) return mergeMaterializationOutcomes(outcomes);
 
   const remaining = ops.slice(bulkFailedAt);
-  await runner.exec('BEGIN');
-  try {
-    for (const op of remaining) {
-      const payload = buildAppendOpsPayload([op], serializeNodeId, serializeReplica);
-      const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
-      outcomes.push(decodeSqliteMaterializationOutcome(raw));
-    }
-    await runner.exec('COMMIT');
-  } catch (err) {
-    await runner.exec('ROLLBACK');
-    throw err;
+  for (const op of remaining) {
+    const payload = buildAppendOpsPayload([op], serializeNodeId, serializeReplica);
+    const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
+    outcomes.push(decodeSqliteMaterializationOutcome(raw));
   }
   return mergeMaterializationOutcomes(outcomes);
 }

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,4 +1,5 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
+import { emptyMaterializationOutcome } from './engine.js';
 import type {
   MaterializationEvent,
   MaterializationOutcome,
@@ -239,7 +240,7 @@ async function treecrdtAppendOps(
   serializeReplica: SerializeReplica,
   opts: { maxBulkOps?: number } = {},
 ): Promise<MaterializationOutcome> {
-  if (ops.length === 0) return { headSeq: 0, changes: [] };
+  if (ops.length === 0) return emptyMaterializationOutcome();
 
   const maxBulkOps = opts.maxBulkOps ?? 5_000;
   const bulkSql = 'SELECT treecrdt_append_ops(?1)';

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,9 +1,6 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
 import { emptyMaterializationOutcome } from './engine.js';
-import type {
-  MaterializationEvent,
-  MaterializationOutcome,
-} from './engine.js';
+import type { MaterializationEvent, MaterializationOutcome } from './engine.js';
 import {
   decodeNodeId,
   decodeReplicaId,
@@ -223,9 +220,7 @@ async function treecrdtAppendOp(
   return decodeSqliteMaterializationOutcome(await sqliteGetJson<unknown>(runner, sql, params));
 }
 
-function mergeMaterializationOutcomes(
-  outcomes: MaterializationOutcome[],
-): MaterializationOutcome {
+function mergeMaterializationOutcomes(outcomes: MaterializationOutcome[]): MaterializationOutcome {
   const last = outcomes.length > 0 ? outcomes[outcomes.length - 1] : undefined;
   return {
     headSeq: last?.headSeq ?? 0,

--- a/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
@@ -8,6 +8,7 @@ import {
 } from '@treecrdt/benchmark';
 import { createTreecrdtClient, type TreecrdtClient } from '@treecrdt/wa-sqlite/client';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
+import { emptyMaterializationOutcome } from '@treecrdt/interface/engine';
 import { bytesToHex } from '@treecrdt/interface/ids';
 
 type StorageKind = 'browser-opfs-coop-sync' | 'browser-memory';
@@ -98,7 +99,7 @@ async function createAdapter(
           },
         },
       });
-      return { headSeq: 0, changes: [] };
+      return emptyMaterializationOutcome();
     },
     appendOps: async (ops, serializeNodeId, serializeReplica) => {
       await client.ops.appendMany(
@@ -110,7 +111,7 @@ async function createAdapter(
           },
         })),
       );
-      return { headSeq: 0, changes: [] };
+      return emptyMaterializationOutcome();
     },
     opsSince: async (lamport, root) => client.ops.since(lamport, root),
     close: async () => client.close(),

--- a/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
@@ -87,8 +87,8 @@ async function createAdapter(
     treeNodeCount: async () => client.tree.nodeCount(),
     headLamport: async () => client.meta.headLamport(),
     replicaMaxCounter: async (replica) => client.meta.replicaMaxCounter(replica),
-    appendOp: (op, serializeNodeId, serializeReplica) =>
-      client.ops.append({
+    appendOp: async (op, serializeNodeId, serializeReplica) => {
+      await client.ops.append({
         ...op,
         meta: {
           ...op.meta,
@@ -97,9 +97,11 @@ async function createAdapter(
             counter: op.meta.id.counter,
           },
         },
-      }),
+      });
+      return { headSeq: 0, changes: [] };
+    },
     appendOps: async (ops, serializeNodeId, serializeReplica) => {
-      const affected = await client.ops.appendMany(
+      await client.ops.appendMany(
         ops.map((op) => ({
           ...op,
           meta: {
@@ -108,7 +110,7 @@ async function createAdapter(
           },
         })),
       );
-      return affected.map((id) => serializeNodeId(id));
+      return { headSeq: 0, changes: [] };
     },
     opsSince: async (lamport, root) => client.ops.since(lamport, root),
     close: async () => client.close(),

--- a/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
@@ -264,12 +264,12 @@ export async function runTreecrdtSyncE2E(): Promise<{ ok: true }> {
   return { ok: true };
 }
 
-export async function runTreecrdtAppendManyAffectedIdsE2E(): Promise<{
+export async function runTreecrdtMaterializationEventE2E(): Promise<{
   ok: true;
-  affectedIds: string[];
+  eventIds: string[];
   children: string[];
 }> {
-  const docId = `e2e-affected-ids-${crypto.randomUUID()}`;
+  const docId = `e2e-materialization-event-${crypto.randomUUID()}`;
   const client = await createTreecrdtClient({ storage: 'memory', docId });
   try {
     const root = '0'.repeat(32);
@@ -290,9 +290,20 @@ export async function runTreecrdtAppendManyAffectedIdsE2E(): Promise<{
       }),
     ];
 
-    const affectedIds = await client.ops.appendMany(ops);
+    const events: string[][] = [];
+    const unsubscribe = client.onMaterialized((event) => {
+      const ids = new Set<string>();
+      for (const change of event.changes) {
+        ids.add(change.node);
+        if ('parentAfter' in change && change.parentAfter) ids.add(change.parentAfter);
+        if ('parentBefore' in change && change.parentBefore) ids.add(change.parentBefore);
+      }
+      events.push([...ids].sort());
+    });
+    await client.ops.appendMany(ops);
+    unsubscribe();
     const children = await client.tree.children(root);
-    return { ok: true, affectedIds, children };
+    return { ok: true, eventIds: events.length ? events[events.length - 1]! : [], children };
   } finally {
     await client.close();
   }
@@ -610,7 +621,7 @@ export async function runTreecrdtSyncBench(
 declare global {
   interface Window {
     runTreecrdtSyncE2E?: typeof runTreecrdtSyncE2E;
-    runTreecrdtAppendManyAffectedIdsE2E?: typeof runTreecrdtAppendManyAffectedIdsE2E;
+    runTreecrdtMaterializationEventE2E?: typeof runTreecrdtMaterializationEventE2E;
     runTreecrdtSyncLargeFanoutE2E?: typeof runTreecrdtSyncLargeFanoutE2E;
     runTreecrdtSyncSubscribeE2E?: typeof runTreecrdtSyncSubscribeE2E;
     runTreecrdtSyncBench?: typeof runTreecrdtSyncBench;
@@ -619,7 +630,7 @@ declare global {
 
 if (typeof window !== 'undefined') {
   window.runTreecrdtSyncE2E = runTreecrdtSyncE2E;
-  window.runTreecrdtAppendManyAffectedIdsE2E = runTreecrdtAppendManyAffectedIdsE2E;
+  window.runTreecrdtMaterializationEventE2E = runTreecrdtMaterializationEventE2E;
   window.runTreecrdtSyncLargeFanoutE2E = runTreecrdtSyncLargeFanoutE2E;
   window.runTreecrdtSyncSubscribeE2E = runTreecrdtSyncSubscribeE2E;
   window.runTreecrdtSyncBench = runTreecrdtSyncBench;

--- a/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
@@ -15,22 +15,22 @@ test('sync v0 e2e', async ({ page }) => {
   expect(result).toEqual({ ok: true });
 });
 
-test('appendMany returns affected ids e2e', async ({ page }) => {
+test('appendMany emits materialization event e2e', async ({ page }) => {
   test.setTimeout(90_000);
   await page.goto('/');
   await page.waitForFunction(
-    () => typeof window.runTreecrdtAppendManyAffectedIdsE2E === 'function',
+    () => typeof window.runTreecrdtMaterializationEventE2E === 'function',
   );
 
   const result = await page.evaluate(async () => {
-    const runner = window.runTreecrdtAppendManyAffectedIdsE2E;
-    if (!runner) throw new Error('runTreecrdtAppendManyAffectedIdsE2E not available');
+    const runner = window.runTreecrdtMaterializationEventE2E;
+    if (!runner) throw new Error('runTreecrdtMaterializationEventE2E not available');
     return await runner();
   });
 
   expect(result.ok).toBe(true);
-  expect(result.affectedIds.length).toBeGreaterThanOrEqual(3);
-  expect(new Set(result.affectedIds).size).toBe(result.affectedIds.length);
-  expect(result.affectedIds).toEqual([...result.affectedIds].sort());
+  expect(result.eventIds.length).toBeGreaterThanOrEqual(3);
+  expect(new Set(result.eventIds).size).toBe(result.eventIds.length);
+  expect(result.eventIds).toEqual([...result.eventIds].sort());
   expect(result.children.length).toBe(1);
 });

--- a/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
@@ -18,9 +18,7 @@ test('sync v0 e2e', async ({ page }) => {
 test('appendMany emits materialization event e2e', async ({ page }) => {
   test.setTimeout(90_000);
   await page.goto('/');
-  await page.waitForFunction(
-    () => typeof window.runTreecrdtMaterializationEventE2E === 'function',
-  );
+  await page.waitForFunction(() => typeof window.runTreecrdtMaterializationEventE2E === 'function');
 
   const result = await page.evaluate(async () => {
     const runner = window.runTreecrdtMaterializationEventE2E;

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -18,10 +18,7 @@ import {
   nodeIdToBytes16,
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
-import type {
-  TreecrdtEngine,
-  WriteOptions,
-} from '@treecrdt/interface/engine';
+import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -272,8 +272,9 @@ async function createDirectClient(opts: {
     );
   let closed = false;
   const closedError = new Error(CLIENT_CLOSED_ERROR);
+  let callQueue: Promise<void> = Promise.resolve();
 
-  const call: RpcCall = async (method, params) => {
+  const runDirectCall: RpcCall = async (method, params) => {
     if (closed) throw closedError;
     try {
       switch (method) {
@@ -392,6 +393,17 @@ async function createDirectClient(opts: {
     } catch (err) {
       throw wrapError(method, err);
     }
+  };
+  const call: RpcCall = (method, params) => {
+    const run = callQueue.then(
+      () => runDirectCall(method, params),
+      () => runDirectCall(method, params),
+    );
+    callQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
   };
 
   return makeTreecrdtClientFromCall({

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -8,7 +8,6 @@ import {
   decodeSqliteTreeChildRows,
   decodeSqliteTreeRows,
   type SqliteTreeChildRow,
-  type SqliteTreeRow,
   type SqliteRunner,
   type TreecrdtSqlitePlacement,
   type TreecrdtSqliteWriter,
@@ -21,11 +20,6 @@ import {
 } from '@treecrdt/interface/ids';
 import type {
   TreecrdtEngine,
-  TreecrdtEngineLocal,
-  TreecrdtEngineMeta,
-  TreecrdtEngineOpRefs,
-  TreecrdtEngineOps,
-  TreecrdtEngineTree,
   WriteOptions,
 } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
@@ -46,29 +40,10 @@ export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
 export type StorageMode = 'memory' | 'opfs';
 export type ClientMode = 'direct' | 'worker';
 
-export type TreecrdtOpsApi = TreecrdtEngineOps;
-
-export type TreecrdtOpRefsApi = TreecrdtEngineOpRefs;
-
-export type TreeNodeRow = SqliteTreeRow;
-
-export type TreecrdtTreeApi = TreecrdtEngineTree;
-
-export type TreecrdtMetaApi = TreecrdtEngineMeta;
-
-export type TreecrdtLocalApi = TreecrdtEngineLocal;
-
 export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
   storage: StorageMode;
-  docId: string;
   runner: SqliteRunner;
-  ops: TreecrdtOpsApi;
-  opRefs: TreecrdtOpRefsApi;
-  tree: TreecrdtTreeApi;
-  meta: TreecrdtMetaApi;
-  local: TreecrdtLocalApi;
-  close: () => Promise<void>;
   drop: () => Promise<void>;
 };
 

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -273,6 +273,11 @@ async function createDirectClient(opts: {
   let closed = false;
   const closedError = new Error(CLIENT_CLOSED_ERROR);
   let callQueue: Promise<void> = Promise.resolve();
+  const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
+    promise.then(
+      () => undefined,
+      () => undefined,
+    );
 
   const runDirectCall: RpcCall = async (method, params) => {
     if (closed) throw closedError;
@@ -395,14 +400,8 @@ async function createDirectClient(opts: {
     }
   };
   const call: RpcCall = (method, params) => {
-    const run = callQueue.then(
-      () => runDirectCall(method, params),
-      () => runDirectCall(method, params),
-    );
-    callQueue = run.then(
-      () => undefined,
-      () => undefined,
-    );
+    const run = callQueue.then(() => runDirectCall(method, params));
+    callQueue = settleQueue(run);
     return run;
   };
 

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -26,11 +26,9 @@ import type {
   TreecrdtEngineOpRefs,
   TreecrdtEngineOps,
   TreecrdtEngineTree,
-  MaterializationEvent,
-  MaterializationListener,
-  MaterializationOutcome,
   WriteOptions,
 } from '@treecrdt/interface/engine';
+import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
 import type {
@@ -73,28 +71,6 @@ export type TreecrdtClient = TreecrdtEngine & {
   close: () => Promise<void>;
   drop: () => Promise<void>;
 };
-
-function createMaterializationDispatch() {
-  const listeners = new Set<MaterializationListener>();
-  const emitEvent = (event: MaterializationEvent) => {
-    if (event.changes.length === 0) return;
-    for (const listener of listeners) listener(event);
-  };
-  const emitOutcome = (outcome: MaterializationOutcome, writeId?: string) => {
-    if (outcome.changes.length === 0) return;
-    emitEvent({
-      ...outcome,
-      ...(writeId ? { writeIds: [writeId] } : {}),
-    });
-  };
-  const onMaterialized = (listener: MaterializationListener) => {
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
-  };
-  return { emitEvent, emitOutcome, onMaterialized };
-}
 
 export type ClientOptions = {
   storage?: StorageMode | 'auto';
@@ -165,7 +141,7 @@ async function createWorkerClient(opts: {
   docId: string;
   requireOpfs?: boolean;
 }): Promise<TreecrdtClient> {
-  const materialized = createMaterializationDispatch();
+  const materialized = createMaterializationDispatcher();
   // Keep the URL inline so Vite detects and bundles the worker properly.
   const worker = new Worker(new URL('./worker.js', import.meta.url), {
     type: 'module',
@@ -281,7 +257,7 @@ async function createDirectClient(opts: {
   docId: string;
   requireOpfs?: boolean;
 }): Promise<TreecrdtClient> {
-  const materialized = createMaterializationDispatch();
+  const materialized = createMaterializationDispatcher();
   const { baseUrl, storage, requireOpfs } = opts;
   const opened = await openTreecrdtDb({
     baseUrl,
@@ -475,7 +451,7 @@ function makeTreecrdtClientFromCall(opts: {
   storage: StorageMode;
   docId: string;
   call: RpcCall;
-  materialized: ReturnType<typeof createMaterializationDispatch>;
+  materialized: ReturnType<typeof createMaterializationDispatcher>;
   close: () => Promise<void>;
   drop: () => Promise<void>;
 }): TreecrdtClient {

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -537,11 +537,11 @@ function makeTreecrdtClientFromCall(opts: {
     runner,
     ops: {
       append: async (op, writeOpts?: WriteOptions) => {
-        const outcome = await call('append', [op, writeOpts]);
+        const outcome = await call('append', [op]);
         materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       appendMany: async (ops, writeOpts?: WriteOptions) => {
-        const outcome = await call('appendMany', [ops, writeOpts]);
+        const outcome = await call('appendMany', [ops]);
         materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -26,10 +26,21 @@ import type {
   TreecrdtEngineOpRefs,
   TreecrdtEngineOps,
   TreecrdtEngineTree,
+  MaterializationEvent,
+  MaterializationListener,
+  MaterializationOutcome,
+  WriteOptions,
 } from '@treecrdt/interface/engine';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
-import type { RpcMethod, RpcParams, RpcRequest, RpcResponse, RpcResult } from './rpc.js';
+import type {
+  RpcMethod,
+  RpcParams,
+  RpcPushMessage,
+  RpcRequest,
+  RpcResponse,
+  RpcResult,
+} from './rpc.js';
 import { openTreecrdtDb } from './open.js';
 
 export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
@@ -62,6 +73,28 @@ export type TreecrdtClient = TreecrdtEngine & {
   close: () => Promise<void>;
   drop: () => Promise<void>;
 };
+
+function createMaterializationDispatch() {
+  const listeners = new Set<MaterializationListener>();
+  const emitEvent = (event: MaterializationEvent) => {
+    if (event.changes.length === 0) return;
+    for (const listener of listeners) listener(event);
+  };
+  const emitOutcome = (outcome: MaterializationOutcome, writeId?: string) => {
+    if (outcome.changes.length === 0) return;
+    emitEvent({
+      ...outcome,
+      ...(writeId ? { writeIds: [writeId] } : {}),
+    });
+  };
+  const onMaterialized = (listener: MaterializationListener) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+  return { emitEvent, emitOutcome, onMaterialized };
+}
 
 export type ClientOptions = {
   storage?: StorageMode | 'auto';
@@ -132,6 +165,7 @@ async function createWorkerClient(opts: {
   docId: string;
   requireOpfs?: boolean;
 }): Promise<TreecrdtClient> {
+  const materialized = createMaterializationDispatch();
   // Keep the URL inline so Vite detects and bundles the worker properly.
   const worker = new Worker(new URL('./worker.js', import.meta.url), {
     type: 'module',
@@ -156,12 +190,18 @@ async function createWorkerClient(opts: {
     });
   };
 
-  const onMessage = (ev: MessageEvent<RpcResponse>) => {
-    const handler = pending.get(ev.data.id as number);
+  const onMessage = (ev: MessageEvent<RpcResponse | RpcPushMessage>) => {
+    const data = ev.data;
+    if ('type' in data && data.type === 'materialized') {
+      materialized.emitEvent(data.event);
+      return;
+    }
+    const response = data as RpcResponse;
+    const handler = pending.get(response.id as number);
     if (!handler) return;
-    pending.delete(ev.data.id as number);
-    if (ev.data.ok) handler.resolve(ev.data.result);
-    else handler.reject(new Error(ev.data.error || 'worker error'));
+    pending.delete(response.id as number);
+    if (response.ok) handler.resolve(response.result);
+    else handler.reject(new Error(response.error || 'worker error'));
   };
   const onError = (ev: ErrorEvent) => {
     const err = new Error(ev.message || 'worker error');
@@ -226,6 +266,7 @@ async function createWorkerClient(opts: {
     storage: effectiveStorage,
     docId: opts.docId,
     call,
+    materialized,
     close: closeImpl,
     drop: dropImpl,
   });
@@ -240,6 +281,7 @@ async function createDirectClient(opts: {
   docId: string;
   requireOpfs?: boolean;
 }): Promise<TreecrdtClient> {
+  const materialized = createMaterializationDispatch();
   const { baseUrl, storage, requireOpfs } = opts;
   const opened = await openTreecrdtDb({
     baseUrl,
@@ -247,6 +289,7 @@ async function createDirectClient(opts: {
     storage,
     docId: opts.docId,
     requireOpfs,
+    onMaterialized: materialized.emitEvent,
   });
   const db = opened.db;
   const finalStorage: StorageMode = opened.storage;
@@ -262,7 +305,10 @@ async function createDirectClient(opts: {
     const key = localWriterKey(replica);
     const existing = localWriters.get(key);
     if (existing) return existing;
-    const next = createTreecrdtSqliteWriter(runner, { replica });
+    const next = createTreecrdtSqliteWriter(runner, {
+      replica,
+      onMaterialized: materialized.emitEvent,
+    });
     localWriters.set(key, next);
     return next;
   };
@@ -294,13 +340,11 @@ async function createDirectClient(opts: {
         }
         case 'append': {
           const [op] = params as RpcParams<'append'>;
-          await adapter.appendOp(op, nodeIdToBytes16, encodeReplica);
-          return undefined as any;
+          return (await adapter.appendOp(op, nodeIdToBytes16, encodeReplica)) as any;
         }
         case 'appendMany': {
           const [ops] = params as RpcParams<'appendMany'>;
-          const affected = await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica);
-          return affected.map((node) => Array.from(node)) as any;
+          return (await adapter.appendOps!(ops, nodeIdToBytes16, encodeReplica)) as any;
         }
         case 'opsSince': {
           const [lamport, root] = params as RpcParams<'opsSince'>;
@@ -407,6 +451,7 @@ async function createDirectClient(opts: {
     storage: finalStorage,
     docId: opts.docId,
     call,
+    materialized,
     close: async () => {
       if (closed) return;
       if (db.close) await db.close();
@@ -430,10 +475,12 @@ function makeTreecrdtClientFromCall(opts: {
   storage: StorageMode;
   docId: string;
   call: RpcCall;
+  materialized: ReturnType<typeof createMaterializationDispatch>;
   close: () => Promise<void>;
   drop: () => Promise<void>;
 }): TreecrdtClient {
   const call = opts.call;
+  const materialized = opts.materialized;
   let closePromise: Promise<void> | null = null;
 
   const runner: SqliteRunner = {
@@ -530,11 +577,13 @@ function makeTreecrdtClientFromCall(opts: {
     docId: opts.docId,
     runner,
     ops: {
-      append: (op) => call('append', [op]).then(() => undefined),
-      appendMany: async (ops) => {
-        const affected = await call('appendMany', [ops]);
-        if (!Array.isArray(affected)) return [];
-        return affected.map((node) => nodeIdFromBytes16(Uint8Array.from(node)));
+      append: async (op, writeOpts?: WriteOptions) => {
+        const outcome = await call('append', [op, writeOpts]);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
+      },
+      appendMany: async (ops, writeOpts?: WriteOptions) => {
+        const outcome = await call('appendMany', [ops, writeOpts]);
+        materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       all: () => opsSinceImpl(0),
       since: opsSinceImpl,
@@ -558,6 +607,7 @@ function makeTreecrdtClientFromCall(opts: {
       delete: localDeleteImpl,
       payload: localPayloadImpl,
     },
+    onMaterialized: materialized.onMaterialized,
     close: closeImpl,
     drop: opts.drop,
   };

--- a/packages/treecrdt-wa-sqlite/src/index.ts
+++ b/packages/treecrdt-wa-sqlite/src/index.ts
@@ -1,5 +1,6 @@
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import { createTreecrdtSqliteAdapter, type SqliteRunner } from '@treecrdt/interface/sqlite';
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
 import { dbGetText } from './sql.js';
 import type { Database } from './types.js';
 
@@ -14,7 +15,7 @@ function createRunner(db: Database): SqliteRunner {
 
 export function createWaSqliteApi(
   db: Database,
-  opts: { maxBulkOps?: number } = {},
+  opts: { maxBulkOps?: number; onMaterialized?: (event: MaterializationEvent) => void } = {},
 ): TreecrdtAdapter {
   return createTreecrdtSqliteAdapter(createRunner(db), opts);
 }

--- a/packages/treecrdt-wa-sqlite/src/open.ts
+++ b/packages/treecrdt-wa-sqlite/src/open.ts
@@ -3,6 +3,7 @@ import { createWaSqliteApi } from './index.js';
 import type { Database } from './index.js';
 import { makeDbAdapter } from './db.js';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
 
 export type OpenTreecrdtDbOptions = {
   baseUrl: string;
@@ -10,6 +11,7 @@ export type OpenTreecrdtDbOptions = {
   storage: 'memory' | 'opfs';
   docId: string;
   requireOpfs?: boolean;
+  onMaterialized?: (event: MaterializationEvent) => void;
 };
 
 export type OpenTreecrdtDbResult = {
@@ -48,7 +50,7 @@ export async function openTreecrdtDb(opts: OpenTreecrdtDbOptions): Promise<OpenT
   const filename = storage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:';
   const handle = await sqlite3.open_v2(filename);
   const db = makeDbAdapter(sqlite3, handle);
-  const api = createWaSqliteApi(db);
+  const api = createWaSqliteApi(db, { onMaterialized: opts.onMaterialized });
   await api.setDocId(opts.docId);
 
   return opfsError ? { db, api, storage, filename, opfsError } : { db, api, storage, filename };

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -2,7 +2,6 @@ import type { Operation } from '@treecrdt/interface';
 import type {
   MaterializationEvent,
   MaterializationOutcome,
-  WriteOptions,
 } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
@@ -27,9 +26,9 @@ export type RpcSchema = {
   };
   sqlExec: { params: [sql: string]; result: void };
   sqlGetText: { params: [sql: string, params?: RpcSqlParams]; result: string | null };
-  append: { params: [op: Operation, opts?: WriteOptions]; result: MaterializationOutcome };
+  append: { params: [op: Operation]; result: MaterializationOutcome };
   appendMany: {
-    params: [ops: Operation[], opts?: WriteOptions];
+    params: [ops: Operation[]];
     result: MaterializationOutcome;
   };
   opsSince: { params: [lamport: number, root?: string]; result: unknown[] };

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -1,5 +1,9 @@
 import type { Operation } from '@treecrdt/interface';
-import type { MaterializationEvent, MaterializationOutcome, WriteOptions } from '@treecrdt/interface/engine';
+import type {
+  MaterializationEvent,
+  MaterializationOutcome,
+  WriteOptions,
+} from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 export type RpcStorageMode = 'memory' | 'opfs';

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -1,8 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
-import type {
-  MaterializationEvent,
-  MaterializationOutcome,
-} from '@treecrdt/interface/engine';
+import type { MaterializationEvent, MaterializationOutcome } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 export type RpcStorageMode = 'memory' | 'opfs';

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -1,4 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
+import type { MaterializationEvent, MaterializationOutcome, WriteOptions } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 export type RpcStorageMode = 'memory' | 'opfs';
@@ -22,8 +23,11 @@ export type RpcSchema = {
   };
   sqlExec: { params: [sql: string]; result: void };
   sqlGetText: { params: [sql: string, params?: RpcSqlParams]; result: string | null };
-  append: { params: [op: Operation]; result: void };
-  appendMany: { params: [ops: Operation[]]; result: number[][] };
+  append: { params: [op: Operation, opts?: WriteOptions]; result: MaterializationOutcome };
+  appendMany: {
+    params: [ops: Operation[], opts?: WriteOptions];
+    result: MaterializationOutcome;
+  };
   opsSince: { params: [lamport: number, root?: string]; result: unknown[] };
   opRefsAll: { params: []; result: unknown[] };
   opRefsChildren: { params: [parent: string]; result: unknown[] };
@@ -81,3 +85,8 @@ export type RpcRequest<M extends RpcMethod = RpcMethod> = {
 export type RpcResponse<M extends RpcMethod = RpcMethod> =
   | { id: number; ok: true; result: RpcResult<M> }
   | { id: number; ok: false; error: string };
+
+export type RpcPushMessage = {
+  type: 'materialized';
+  event: MaterializationEvent;
+};

--- a/packages/treecrdt-wa-sqlite/src/worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/worker.ts
@@ -10,7 +10,7 @@ import {
   type TreecrdtSqlitePlacement,
   type TreecrdtSqliteWriter,
 } from '@treecrdt/interface/sqlite';
-import type { MaterializationEvent, WriteOptions } from '@treecrdt/interface/engine';
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
 import type { RpcMethod, RpcRequest, RpcSqlParams } from './rpc.js';
 import { openTreecrdtDb } from './open.js';
 import { clearOpfsStorage } from './opfs.js';
@@ -113,12 +113,12 @@ async function sqlGetText(sql: string, params?: RpcSqlParams): Promise<string | 
   return dbGetText(ensureDb(), sql, params ?? []);
 }
 
-async function append(op: Operation, _opts?: WriteOptions) {
+async function append(op: Operation) {
   const api = ensureApi();
   return await api.appendOp(op, nodeIdToBytes16, replicaIdToBytes);
 }
 
-async function appendMany(ops: Operation[], _opts?: WriteOptions) {
+async function appendMany(ops: Operation[]) {
   const api = ensureApi();
   return await api.appendOps!(ops, nodeIdToBytes16, replicaIdToBytes);
 }

--- a/packages/treecrdt-wa-sqlite/src/worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/worker.ts
@@ -10,6 +10,7 @@ import {
   type TreecrdtSqlitePlacement,
   type TreecrdtSqliteWriter,
 } from '@treecrdt/interface/sqlite';
+import type { MaterializationEvent, WriteOptions } from '@treecrdt/interface/engine';
 import type { RpcMethod, RpcRequest, RpcSqlParams } from './rpc.js';
 import { openTreecrdtDb } from './open.js';
 import { clearOpfsStorage } from './opfs.js';
@@ -20,6 +21,10 @@ let storedStorage: 'memory' | 'opfs' = 'memory';
 let api: TreecrdtAdapter | null = null;
 let runner: SqliteRunner | null = null;
 const localWriters = new Map<string, TreecrdtSqliteWriter>();
+
+function postMaterialized(event: MaterializationEvent) {
+  (self as unknown as Worker).postMessage({ type: 'materialized', event });
+}
 
 const methods = {
   init,
@@ -85,6 +90,7 @@ async function init(
     storage: storageParam,
     docId,
     requireOpfs: false,
+    onMaterialized: postMaterialized,
   });
   db = opened.db;
   api = opened.api;
@@ -107,16 +113,14 @@ async function sqlGetText(sql: string, params?: RpcSqlParams): Promise<string | 
   return dbGetText(ensureDb(), sql, params ?? []);
 }
 
-async function append(op: Operation) {
+async function append(op: Operation, _opts?: WriteOptions) {
   const api = ensureApi();
-  await api.appendOp(op, nodeIdToBytes16, replicaIdToBytes);
-  return null;
+  return await api.appendOp(op, nodeIdToBytes16, replicaIdToBytes);
 }
 
-async function appendMany(ops: Operation[]) {
+async function appendMany(ops: Operation[], _opts?: WriteOptions) {
   const api = ensureApi();
-  const affected = await api.appendOps!(ops, nodeIdToBytes16, replicaIdToBytes);
-  return affected.map((node) => Array.from(node));
+  return await api.appendOps!(ops, nodeIdToBytes16, replicaIdToBytes);
 }
 
 async function opsSince(lamport: number, root: string | undefined) {
@@ -283,7 +287,10 @@ function ensureLocalWriter(replica: ReplicaId): TreecrdtSqliteWriter {
   const key = replicaKey(replica);
   const existing = localWriters.get(key);
   if (existing) return existing;
-  const writer = createTreecrdtSqliteWriter(ensureRunner(), { replica });
+  const writer = createTreecrdtSqliteWriter(ensureRunner(), {
+    replica,
+    onMaterialized: postMaterialized,
+  });
   localWriters.set(key, writer);
   return writer;
 }

--- a/packages/treecrdt-wasm-js/src/index.ts
+++ b/packages/treecrdt-wasm-js/src/index.ts
@@ -94,9 +94,9 @@ export async function createWasmAdapter(opts: LoadOptions = {}): Promise<Treecrd
         jsOp.known_state = Array.from(op.meta.knownState);
       }
       tree.appendOp(JSON.stringify(jsOp));
+      return { headSeq: 0, changes: [] };
     },
     appendOps: async (ops, serializeNodeId, serializeReplica) => {
-      const affected: Uint8Array[] = [];
       for (const op of ops) {
         const jsOp = toJsOp(op, serializeNodeId, serializeReplica);
         if (op.kind.type === 'delete') {
@@ -105,12 +105,9 @@ export async function createWasmAdapter(opts: LoadOptions = {}): Promise<Treecrd
           }
           jsOp.known_state = Array.from(op.meta.knownState);
         }
-        const nodes: string[] = tree.appendOpWithDelta(JSON.stringify(jsOp));
-        for (const hex of nodes) {
-          affected.push(hexToBytes(hex));
-        }
+        tree.appendOp(JSON.stringify(jsOp));
       }
-      return affected;
+      return { headSeq: 0, changes: [] };
     },
     opsSince: async (lamport: number) => {
       const ops = tree.opsSince(BigInt(lamport));

--- a/packages/treecrdt-wasm-js/src/index.ts
+++ b/packages/treecrdt-wasm-js/src/index.ts
@@ -1,4 +1,5 @@
 import type { Operation, TreecrdtAdapter } from '@treecrdt/interface';
+import { emptyMaterializationOutcome } from '@treecrdt/interface/engine';
 import { bytesToHex, hexToBytes, normalizeNodeId } from '@treecrdt/interface/ids';
 import { WasmTree } from '../pkg/treecrdt_wasm.js';
 import { createHash } from 'node:crypto';
@@ -94,7 +95,7 @@ export async function createWasmAdapter(opts: LoadOptions = {}): Promise<Treecrd
         jsOp.known_state = Array.from(op.meta.knownState);
       }
       tree.appendOp(JSON.stringify(jsOp));
-      return { headSeq: 0, changes: [] };
+      return emptyMaterializationOutcome();
     },
     appendOps: async (ops, serializeNodeId, serializeReplica) => {
       for (const op of ops) {
@@ -107,7 +108,7 @@ export async function createWasmAdapter(opts: LoadOptions = {}): Promise<Treecrd
         }
         tree.appendOp(JSON.stringify(jsOp));
       }
-      return { headSeq: 0, changes: [] };
+      return emptyMaterializationOutcome();
     },
     opsSince: async (lamport: number) => {
       const ops = tree.opsSince(BigInt(lamport));

--- a/packages/treecrdt-wasm/src/lib.rs
+++ b/packages/treecrdt-wasm/src/lib.rs
@@ -5,7 +5,8 @@
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::to_value;
 use treecrdt_core::{
-    Lamport, LamportClock, MemoryStorage, NodeId, Operation, OperationKind, ReplicaId, TreeCrdt,
+    Lamport, LamportClock, MaterializationOutcome, MemoryStorage, NodeId, Operation, OperationKind,
+    ReplicaId, TreeCrdt,
 };
 use wasm_bindgen::prelude::*;
 
@@ -198,7 +199,16 @@ impl WasmTree {
             .apply_remote_with_delta(op)
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))?;
         let affected: Vec<String> = delta
-            .map(|d| d.affected_nodes.into_iter().map(node_to_hex).collect())
+            .map(|d| {
+                MaterializationOutcome {
+                    head_seq: 0,
+                    changes: d.changes,
+                }
+                .affected_nodes()
+                .into_iter()
+                .map(node_to_hex)
+                .collect()
+            })
             .unwrap_or_default();
         to_value(&affected).map_err(|e| JsValue::from_str(&e.to_string()))
     }


### PR DESCRIPTION
## Summary
- add core `MaterializationChange` / `MaterializationOutcome` with coalesced visible changes plus `headSeq`
- wire append/local/catch-up materialization outcomes through SQLite, sqlite-node, wa-sqlite, Postgres Rust/N-API, and wasm adapters
- add `engine.onMaterialized(...)`, optional `writeId` / emitted `writeIds`, and change `appendMany` to return `Promise<void>` at the engine API
- move playground remote tree refreshes to materialization events and remove raw-op affected-parent derivation from UI refreshes

## JS API Example
```ts
import type { MaterializationEvent } from '@treecrdt/interface/engine';

const unsubscribe = client.onMaterialized((event: MaterializationEvent) => {
  console.log(event.headSeq, event.writeIds, event.changes);

  for (const change of event.changes) {
    if (change.kind === 'payload') {
      // Refresh only this node's payload.
      void refreshPayload(change.node);
    } else if (change.kind === 'insert' || change.kind === 'restore') {
      // Refresh the parent list that now contains this node.
      void refreshChildren(change.parentAfter);
    } else if (change.kind === 'move') {
      // Refresh both old and new parent lists.
      if (change.parentBefore) void refreshChildren(change.parentBefore);
      void refreshChildren(change.parentAfter);
    } else if (change.kind === 'delete') {
      // Refresh the parent list that lost this node.
      if (change.parentBefore) void refreshChildren(change.parentBefore);
    }
  }
});

await client.ops.appendMany(ops, { writeId: 'editor-save-42' });

// Later, when the view/component is disposed.
unsubscribe();
```

## Notes
- `ensure_materialized` remains a recovery path and emits only when it advances a pending materialization frontier with non-empty changes
- subscriptions are doc-level for this draft; query/subtree filtering is still future API work
- events are coalesced materialization changes, not raw operations, so batched/replayed payload updates collapse to the final visible outcome
- Postgres tests that require `TREECRDT_POSTGRES_URL` are skipped locally when that env var is absent
