### PR TITLE
Refactor materialization replay invariants

### DIFF
--- a/packages/sync/material/sqlite/src/proof-material/sqlite.ts
+++ b/packages/sync/material/sqlite/src/proof-material/sqlite.ts
@@ -288,7 +288,7 @@ FROM (
   SELECT json_object('name', name, 'value', value) AS obj
   FROM treecrdt_sync_capability
   WHERE doc_id = ?1
-  ORDER BY created_at_ms ASC, name ASC, value ASC
+  ORDER BY name ASC, value ASC
 )
 `;
 

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -304,12 +304,6 @@ impl ReplayChangeScope<'_> {
     }
 }
 
-#[derive(Clone, Copy)]
-enum RejectedReplayOp {
-    Ignore,
-    Error(&'static str),
-}
-
 struct ReplayRun {
     head: Option<Operation>,
     seq: u64,
@@ -354,6 +348,38 @@ impl<'a> ReplayAccumulator<'a> {
         if collect {
             self.changes.extend(changes);
         }
+    }
+
+    fn apply_remote(
+        &mut self,
+        crdt: &mut TreeCrdt<impl Storage, impl Clock, impl NodeStore, impl PayloadStore>,
+        index: &mut impl ParentOpIndex,
+        op: Operation,
+        rejected_op_error: Option<&'static str>,
+    ) -> Result<()> {
+        let collect = self.before_op(&op);
+        match crdt.apply_remote_with_materialization_seq(op.clone(), index, &mut self.seq)? {
+            Some(delta) => self.record_applied(op, collect, delta.changes),
+            None => {
+                if let Some(message) = rejected_op_error {
+                    return Err(Error::Storage(message.into()));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn apply_sorted(
+        &mut self,
+        crdt: &mut TreeCrdt<impl Storage, impl Clock, impl NodeStore, impl PayloadStore>,
+        index: &mut impl ParentOpIndex,
+        op: Operation,
+    ) -> Result<()> {
+        let collect = self.before_op(&op);
+        self.seq = self.seq.saturating_add(1);
+        let delta = crdt.apply_sorted_remote_with_materialization(op.clone(), index, self.seq)?;
+        self.record_applied(op, collect, delta.changes);
+        Ok(())
     }
 
     fn finish(self) -> ReplayRun {
@@ -680,81 +706,6 @@ impl MaterializationOutcome {
     }
 }
 
-fn replay_remote_op_with_materialization_seq<S, C, N, P, I>(
-    crdt: &mut TreeCrdt<S, C, N, P>,
-    index: &mut I,
-    replay: &mut ReplayAccumulator<'_>,
-    op: Operation,
-    rejected_op: RejectedReplayOp,
-) -> Result<()>
-where
-    S: Storage,
-    C: Clock,
-    N: NodeStore,
-    P: PayloadStore,
-    I: ParentOpIndex,
-{
-    let collect = replay.before_op(&op);
-    match crdt.apply_remote_with_materialization_seq(op.clone(), index, &mut replay.seq)? {
-        Some(delta) => replay.record_applied(op, collect, delta.changes),
-        None => match rejected_op {
-            RejectedReplayOp::Ignore => {}
-            RejectedReplayOp::Error(message) => return Err(Error::Storage(message.into())),
-        },
-    }
-    Ok(())
-}
-
-fn replay_remote_ops_with_materialization_seq<S, C, N, P, I>(
-    crdt: &mut TreeCrdt<S, C, N, P>,
-    index: &mut I,
-    start_seq: u64,
-    ops: impl IntoIterator<Item = Operation>,
-    change_scope: ReplayChangeScope<'_>,
-    rejected_op: RejectedReplayOp,
-) -> Result<ReplayRun>
-where
-    S: Storage,
-    C: Clock,
-    N: NodeStore,
-    P: PayloadStore,
-    I: ParentOpIndex,
-{
-    let mut replay = ReplayAccumulator::new(start_seq, change_scope);
-
-    for op in ops {
-        replay_remote_op_with_materialization_seq(crdt, index, &mut replay, op, rejected_op)?;
-    }
-
-    Ok(replay.finish())
-}
-
-fn replay_sorted_ops_with_materialization<S, C, N, P, I>(
-    crdt: &mut TreeCrdt<S, C, N, P>,
-    index: &mut I,
-    start_seq: u64,
-    ops: impl IntoIterator<Item = Operation>,
-    change_scope: ReplayChangeScope<'_>,
-) -> Result<ReplayRun>
-where
-    S: Storage,
-    C: Clock,
-    N: NodeStore,
-    P: PayloadStore,
-    I: ParentOpIndex,
-{
-    let mut replay = ReplayAccumulator::new(start_seq, change_scope);
-
-    for op in ops {
-        let collect = replay.before_op(&op);
-        replay.seq = replay.seq.saturating_add(1);
-        let delta = crdt.apply_sorted_remote_with_materialization(op.clone(), index, replay.seq)?;
-        replay.record_applied(op, collect, delta.changes);
-    }
-
-    Ok(replay.finish())
-}
-
 /// Apply an incremental batch and return both head metadata and the structured materialization delta.
 pub fn apply_incremental_ops_with_delta<S, C, N, P, I, M>(
     crdt: &mut TreeCrdt<S, C, N, P>,
@@ -804,14 +755,11 @@ where
         }
     }
 
-    let replay = replay_remote_ops_with_materialization_seq(
-        crdt,
-        index,
-        state.head_seq(),
-        ops,
-        ReplayChangeScope::All,
-        RejectedReplayOp::Ignore,
-    )?;
+    let mut replay = ReplayAccumulator::new(state.head_seq(), ReplayChangeScope::All);
+    for op in ops {
+        replay.apply_remote(crdt, index, op, None)?;
+    }
+    let replay = replay.finish();
 
     let last = replay
         .head
@@ -889,12 +837,11 @@ fn replay_frontier_in_memory<S: Storage>(
     let mut replay = ReplayAccumulator::new(0, ReplayChangeScope::FromFrontier(frontier));
 
     storage.scan_since(0, &mut |op| {
-        replay_remote_op_with_materialization_seq(
+        replay.apply_remote(
             &mut crdt,
             &mut index,
-            &mut replay,
             op,
-            RejectedReplayOp::Error("frontier replay unexpectedly required nested catch-up"),
+            Some("frontier replay unexpectedly required nested catch-up"),
         )
     })?;
 
@@ -994,13 +941,11 @@ where
     // invalidated suffix. Replaying `full_suffix_ops` forward rebuilds only the corrected suffix.
     let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
 
-    let replay = replay_sorted_ops_with_materialization(
-        &mut crdt,
-        &mut index,
-        prefix_seq,
-        full_suffix_ops,
-        ReplayChangeScope::All,
-    )?;
+    let mut replay = ReplayAccumulator::new(prefix_seq, ReplayChangeScope::All);
+    for op in full_suffix_ops {
+        replay.apply_sorted(&mut crdt, &mut index, op)?;
+    }
+    let replay = replay.finish();
 
     flush_nodes(crdt.node_store_mut())?;
     flush_index(&mut index)?;

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -281,11 +281,89 @@ impl TruncatingParentOpIndex for RecordingIndex {
     }
 }
 
-struct ReplaySnapshot {
+struct RebuiltMaterialization {
     crdt: TreeCrdt<NoopStorage, LamportClock, MemoryNodeStore, MemoryPayloadStore>,
     index: RecordingIndex,
     head: Option<Operation>,
     seq: u64,
+}
+
+enum ReplayChangeScope<'a> {
+    All,
+    FromFrontier(&'a MaterializationFrontier),
+}
+
+impl ReplayChangeScope<'_> {
+    fn includes(&self, op: &Operation) -> bool {
+        match self {
+            Self::All => true,
+            Self::FromFrontier(frontier) => {
+                cmp_frontiers(&frontier_from_op(op), frontier) != Ordering::Less
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum RejectedReplayOp {
+    Ignore,
+    Error(&'static str),
+}
+
+struct ReplayRun {
+    head: Option<Operation>,
+    seq: u64,
+    prefix_seq: u64,
+    outcome: MaterializationOutcome,
+}
+
+struct ReplayAccumulator<'a> {
+    seq: u64,
+    head: Option<Operation>,
+    changes: Vec<MaterializationChange>,
+    prefix_seq: Option<u64>,
+    change_scope: ReplayChangeScope<'a>,
+}
+
+impl<'a> ReplayAccumulator<'a> {
+    fn new(seq: u64, change_scope: ReplayChangeScope<'a>) -> Self {
+        Self {
+            seq,
+            head: None,
+            changes: Vec::new(),
+            prefix_seq: None,
+            change_scope,
+        }
+    }
+
+    fn before_op(&mut self, op: &Operation) -> bool {
+        let collect = self.change_scope.includes(op);
+        if collect && self.prefix_seq.is_none() {
+            self.prefix_seq = Some(self.seq);
+        }
+        collect
+    }
+
+    fn record_applied(
+        &mut self,
+        op: Operation,
+        collect: bool,
+        changes: Vec<MaterializationChange>,
+    ) {
+        self.head = Some(op);
+        if collect {
+            self.changes.extend(changes);
+        }
+    }
+
+    fn finish(self) -> ReplayRun {
+        ReplayRun {
+            head: self.head,
+            seq: self.seq,
+            prefix_seq: self.prefix_seq.unwrap_or(self.seq),
+            outcome: MaterializationOutcome::from_changes(self.seq, self.changes),
+        }
+    }
 }
 
 fn frontier_from_op(op: &Operation) -> MaterializationFrontier {
@@ -602,6 +680,81 @@ impl MaterializationOutcome {
     }
 }
 
+fn replay_remote_op_with_materialization_seq<S, C, N, P, I>(
+    crdt: &mut TreeCrdt<S, C, N, P>,
+    index: &mut I,
+    replay: &mut ReplayAccumulator<'_>,
+    op: Operation,
+    rejected_op: RejectedReplayOp,
+) -> Result<()>
+where
+    S: Storage,
+    C: Clock,
+    N: NodeStore,
+    P: PayloadStore,
+    I: ParentOpIndex,
+{
+    let collect = replay.before_op(&op);
+    match crdt.apply_remote_with_materialization_seq(op.clone(), index, &mut replay.seq)? {
+        Some(delta) => replay.record_applied(op, collect, delta.changes),
+        None => match rejected_op {
+            RejectedReplayOp::Ignore => {}
+            RejectedReplayOp::Error(message) => return Err(Error::Storage(message.into())),
+        },
+    }
+    Ok(())
+}
+
+fn replay_remote_ops_with_materialization_seq<S, C, N, P, I>(
+    crdt: &mut TreeCrdt<S, C, N, P>,
+    index: &mut I,
+    start_seq: u64,
+    ops: impl IntoIterator<Item = Operation>,
+    change_scope: ReplayChangeScope<'_>,
+    rejected_op: RejectedReplayOp,
+) -> Result<ReplayRun>
+where
+    S: Storage,
+    C: Clock,
+    N: NodeStore,
+    P: PayloadStore,
+    I: ParentOpIndex,
+{
+    let mut replay = ReplayAccumulator::new(start_seq, change_scope);
+
+    for op in ops {
+        replay_remote_op_with_materialization_seq(crdt, index, &mut replay, op, rejected_op)?;
+    }
+
+    Ok(replay.finish())
+}
+
+fn replay_sorted_ops_with_materialization<S, C, N, P, I>(
+    crdt: &mut TreeCrdt<S, C, N, P>,
+    index: &mut I,
+    start_seq: u64,
+    ops: impl IntoIterator<Item = Operation>,
+    change_scope: ReplayChangeScope<'_>,
+) -> Result<ReplayRun>
+where
+    S: Storage,
+    C: Clock,
+    N: NodeStore,
+    P: PayloadStore,
+    I: ParentOpIndex,
+{
+    let mut replay = ReplayAccumulator::new(start_seq, change_scope);
+
+    for op in ops {
+        let collect = replay.before_op(&op);
+        replay.seq = replay.seq.saturating_add(1);
+        let delta = crdt.apply_sorted_remote_with_materialization(op.clone(), index, replay.seq)?;
+        replay.record_applied(op, collect, delta.changes);
+    }
+
+    Ok(replay.finish())
+}
+
 /// Apply an incremental batch and return both head metadata and the structured materialization delta.
 pub fn apply_incremental_ops_with_delta<S, C, N, P, I, M>(
     crdt: &mut TreeCrdt<S, C, N, P>,
@@ -651,21 +804,24 @@ where
         }
     }
 
-    let mut seq = state.head_seq();
-    let mut changes = Vec::new();
-    for op in ops {
-        if let Some(delta) = crdt.apply_remote_with_materialization_seq(op, index, &mut seq)? {
-            changes.extend(delta.changes);
-        }
-    }
+    let replay = replay_remote_ops_with_materialization_seq(
+        crdt,
+        index,
+        state.head_seq(),
+        ops,
+        ReplayChangeScope::All,
+        RejectedReplayOp::Ignore,
+    )?;
 
-    let last = crdt
-        .head_op()
+    let last = replay
+        .head
+        .as_ref()
+        .or_else(|| crdt.head_op())
         .ok_or_else(|| Error::Storage("expected head op after materialization".into()))?;
 
     Ok(IncrementalApplyResult {
-        head: Some(MaterializationHead::from_op(last, seq)),
-        outcome: MaterializationOutcome::from_changes(seq, changes),
+        head: Some(MaterializationHead::from_op(last, replay.seq)),
+        outcome: replay.outcome,
     })
 }
 
@@ -721,7 +877,7 @@ fn replay_frontier_in_memory<S: Storage>(
     storage: &S,
     frontier: &MaterializationFrontier,
     replica_id: &ReplicaId,
-) -> Result<(ReplaySnapshot, u64, MaterializationOutcome)> {
+) -> Result<(RebuiltMaterialization, u64, MaterializationOutcome)> {
     let mut crdt = TreeCrdt::with_stores(
         replica_id.clone(),
         NoopStorage,
@@ -730,40 +886,29 @@ fn replay_frontier_in_memory<S: Storage>(
         MemoryPayloadStore::default(),
     )?;
     let mut index = RecordingIndex::default();
-    let mut seq = 0u64;
-    let mut head: Option<Operation> = None;
-    let mut changes = Vec::new();
-    let mut prefix_seq = None;
+    let mut replay = ReplayAccumulator::new(0, ReplayChangeScope::FromFrontier(frontier));
 
     storage.scan_since(0, &mut |op| {
-        let in_suffix = cmp_frontiers(&frontier_from_op(&op), frontier) != Ordering::Less;
-        if in_suffix && prefix_seq.is_none() {
-            prefix_seq = Some(seq);
-        }
-
-        match crdt.apply_remote_with_materialization_seq(op.clone(), &mut index, &mut seq)? {
-            Some(delta) => {
-                head = Some(op);
-                if in_suffix {
-                    changes.extend(delta.changes);
-                }
-                Ok(())
-            }
-            None => Err(Error::Storage(
-                "frontier replay unexpectedly required nested catch-up".into(),
-            )),
-        }
+        replay_remote_op_with_materialization_seq(
+            &mut crdt,
+            &mut index,
+            &mut replay,
+            op,
+            RejectedReplayOp::Error("frontier replay unexpectedly required nested catch-up"),
+        )
     })?;
 
-    let outcome = MaterializationOutcome::from_changes(seq, changes);
+    let replay = replay.finish();
+    let prefix_seq = replay.prefix_seq;
+    let outcome = replay.outcome;
     Ok((
-        ReplaySnapshot {
+        RebuiltMaterialization {
             crdt,
             index,
-            head,
-            seq,
+            head: replay.head,
+            seq: replay.seq,
         },
-        prefix_seq.unwrap_or(seq),
+        prefix_seq,
         outcome,
     ))
 }
@@ -849,27 +994,25 @@ where
     // invalidated suffix. Replaying `full_suffix_ops` forward rebuilds only the corrected suffix.
     let mut crdt = TreeCrdt::with_stores(replica_id, NoopStorage, clock, nodes, payloads)?;
 
-    let mut changes = Vec::new();
-    let mut seq = prefix_seq;
-    let mut replay_head: Option<Operation> = None;
-    for op in full_suffix_ops {
-        seq = seq.saturating_add(1);
-        let delta = crdt.apply_sorted_remote_with_materialization(op.clone(), &mut index, seq)?;
-        changes.extend(delta.changes);
-        replay_head = Some(op);
-    }
+    let replay = replay_sorted_ops_with_materialization(
+        &mut crdt,
+        &mut index,
+        prefix_seq,
+        full_suffix_ops,
+        ReplayChangeScope::All,
+    )?;
 
     flush_nodes(crdt.node_store_mut())?;
     flush_index(&mut index)?;
 
     Ok(Some(CatchUpResult {
-        head: replay_head.as_ref().map(|head| MaterializationHead::from_op(head, seq)),
-        outcome: MaterializationOutcome::from_changes(seq, changes),
+        head: replay.head.as_ref().map(|head| MaterializationHead::from_op(head, replay.seq)),
+        outcome: replay.outcome,
     }))
 }
 
 fn patch_final_state_in_place<N, P, I>(
-    replay: &mut ReplaySnapshot,
+    replay: &mut RebuiltMaterialization,
     prefix_seq: u64,
     affected_nodes: &[NodeId],
     nodes: &mut N,

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -759,17 +759,17 @@ where
     for op in ops {
         replay.apply_remote(crdt, index, op, None)?;
     }
-    let replay = replay.finish();
+    let run = replay.finish();
 
-    let last = replay
+    let last = run
         .head
         .as_ref()
         .or_else(|| crdt.head_op())
         .ok_or_else(|| Error::Storage("expected head op after materialization".into()))?;
 
     Ok(IncrementalApplyResult {
-        head: Some(MaterializationHead::from_op(last, replay.seq)),
-        outcome: replay.outcome,
+        head: Some(MaterializationHead::from_op(last, run.seq)),
+        outcome: run.outcome,
     })
 }
 
@@ -845,15 +845,15 @@ fn replay_frontier_in_memory<S: Storage>(
         )
     })?;
 
-    let replay = replay.finish();
-    let prefix_seq = replay.prefix_seq;
-    let outcome = replay.outcome;
+    let run = replay.finish();
+    let prefix_seq = run.prefix_seq;
+    let outcome = run.outcome;
     Ok((
         RebuiltMaterialization {
             crdt,
             index,
-            head: replay.head,
-            seq: replay.seq,
+            head: run.head,
+            seq: run.seq,
         },
         prefix_seq,
         outcome,
@@ -945,19 +945,19 @@ where
     for op in full_suffix_ops {
         replay.apply_sorted(&mut crdt, &mut index, op)?;
     }
-    let replay = replay.finish();
+    let run = replay.finish();
 
     flush_nodes(crdt.node_store_mut())?;
     flush_index(&mut index)?;
 
     Ok(Some(CatchUpResult {
-        head: replay.head.as_ref().map(|head| MaterializationHead::from_op(head, replay.seq)),
-        outcome: replay.outcome,
+        head: run.head.as_ref().map(|head| MaterializationHead::from_op(head, run.seq)),
+        outcome: run.outcome,
     }))
 }
 
 fn patch_final_state_in_place<N, P, I>(
-    replay: &mut RebuiltMaterialization,
+    rebuilt: &mut RebuiltMaterialization,
     prefix_seq: u64,
     affected_nodes: &[NodeId],
     nodes: &mut N,
@@ -988,14 +988,14 @@ where
         } else {
             None
         };
-        let final_parent = replay.crdt.node_store_mut().parent(*node)?;
-        let final_tombstone = replay.crdt.node_store_mut().tombstone(*node)?;
+        let final_parent = rebuilt.crdt.node_store_mut().parent(*node)?;
+        let final_tombstone = rebuilt.crdt.node_store_mut().tombstone(*node)?;
 
         nodes.ensure_node(*node)?;
         nodes.detach(*node)?;
 
         if let Some(parent) = final_parent {
-            let order_key = replay.crdt.node_store_mut().order_key(*node)?.unwrap_or_default();
+            let order_key = rebuilt.crdt.node_store_mut().order_key(*node)?.unwrap_or_default();
             nodes.attach(*node, parent, order_key)?;
         }
 
@@ -1006,7 +1006,7 @@ where
                 (true, false) => patch_changes.push(MaterializationChange::Restore {
                     node: *node,
                     parent_after: final_parent.filter(|parent| *parent != NodeId::TRASH),
-                    payload: replay.crdt.payload(*node)?,
+                    payload: rebuilt.crdt.payload(*node)?,
                 }),
                 (false, true) => patch_changes.push(MaterializationChange::Delete {
                     node: *node,
@@ -1019,20 +1019,20 @@ where
         // These are exact setters on purpose: the backend may already contain newer-looking merged
         // values from the stale suffix, so fallback catch-up must overwrite them with the rebuilt
         // post-replay state rather than merge again.
-        let last_change = replay.crdt.node_store_mut().last_change(*node)?;
+        let last_change = rebuilt.crdt.node_store_mut().last_change(*node)?;
         nodes.set_last_change_exact(*node, &last_change)?;
 
-        let deleted_at = replay.crdt.node_store_mut().deleted_at(*node)?;
+        let deleted_at = rebuilt.crdt.node_store_mut().deleted_at(*node)?;
         nodes.set_deleted_at_exact(*node, deleted_at.as_ref())?;
 
-        if let Some(writer) = replay.crdt.payload_last_writer(*node)? {
-            payloads.set_payload(*node, replay.crdt.payload(*node)?, writer)?;
+        if let Some(writer) = rebuilt.crdt.payload_last_writer(*node)? {
+            payloads.set_payload(*node, rebuilt.crdt.payload(*node)?, writer)?;
         } else {
             payloads.clear_payload(*node)?;
         }
     }
 
-    let mut records: Vec<_> = replay
+    let mut records: Vec<_> = rebuilt
         .index
         .records
         .iter()
@@ -1044,7 +1044,7 @@ where
         index.record(parent, &op_id, seq)?;
     }
 
-    Ok(MaterializationOutcome::from_changes(replay.seq, patch_changes).changes)
+    Ok(MaterializationOutcome::from_changes(rebuilt.seq, patch_changes).changes)
 }
 
 /// Catch backend materialized state up from a replay frontier by patching affected backend rows
@@ -1087,13 +1087,13 @@ where
         mut index,
     } = stores;
 
-    let (mut replay, prefix_seq, replay_outcome) =
+    let (mut rebuilt, prefix_seq, replay_outcome) =
         replay_frontier_in_memory(&storage, frontier, &replica_id)?;
     let mut affected_nodes = replay_outcome.affected_nodes();
     let mut seen_nodes: HashSet<NodeId> = affected_nodes.iter().copied().collect();
     let mut idx = 0usize;
     while idx < affected_nodes.len() {
-        if let Some(parent) = replay.crdt.node_store_mut().parent(affected_nodes[idx])? {
+        if let Some(parent) = rebuilt.crdt.node_store_mut().parent(affected_nodes[idx])? {
             if parent != NodeId::ROOT && parent != NodeId::TRASH && seen_nodes.insert(parent) {
                 affected_nodes.push(parent);
             }
@@ -1103,7 +1103,7 @@ where
     affected_nodes.sort();
     affected_nodes.dedup();
     let patch_changes = patch_final_state_in_place(
-        &mut replay,
+        &mut rebuilt,
         prefix_seq,
         &affected_nodes,
         &mut nodes,
@@ -1115,12 +1115,15 @@ where
     flush_index(&mut index)?;
 
     Ok(CatchUpResult {
-        head: replay.head.as_ref().map(|head| MaterializationHead::from_op(head, replay.seq)),
+        head: rebuilt
+            .head
+            .as_ref()
+            .map(|head| MaterializationHead::from_op(head, rebuilt.seq)),
         outcome: MaterializationOutcome::merge(
-            replay.seq,
+            rebuilt.seq,
             [
                 replay_outcome,
-                MaterializationOutcome::from_changes(replay.seq, patch_changes),
+                MaterializationOutcome::from_changes(rebuilt.seq, patch_changes),
             ],
         ),
     })

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -8,7 +8,8 @@ use treecrdt_core::{
     LocalPlacement, MaterializationChange, MaterializationCursor, MaterializationHead,
     MaterializationKey, MaterializationOutcome, MaterializationState, MemoryNodeStore,
     MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation, OperationId,
-    ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt, VersionVector,
+    ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt, TruncatingParentOpIndex,
+    VersionVector,
 };
 
 #[derive(Default)]
@@ -75,6 +76,13 @@ impl ParentOpIndex for RecordingIndex {
         seq: u64,
     ) -> treecrdt_core::Result<()> {
         self.records.push((parent, op_id.clone(), seq));
+        Ok(())
+    }
+}
+
+impl TruncatingParentOpIndex for RecordingIndex {
+    fn truncate_from(&mut self, seq: u64) -> treecrdt_core::Result<()> {
+        self.records.retain(|(_, _, existing_seq)| *existing_seq < seq);
         Ok(())
     }
 }
@@ -759,6 +767,8 @@ fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
     let mut nodes = MemoryNodeStore::default();
     nodes.ensure_node(prefix).unwrap();
     nodes.attach(prefix, NodeId::ROOT, vec![0x10]).unwrap();
+    let mut index = RecordingIndex::default();
+    index.record(NodeId::ROOT, &prefix_op.meta.id, 1).unwrap();
 
     let meta = Cursor {
         head_lamport: suffix_op.meta.lamport,
@@ -778,7 +788,7 @@ fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
             clock: LamportClock::default(),
             nodes,
             payloads: MemoryPayloadStore::default(),
-            index: NoopParentOpIndex,
+            index,
         },
         &meta,
         |nodes| {
@@ -787,7 +797,16 @@ fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
             assert!(nodes.exists(suffix)?);
             Ok(())
         },
-        |_| Ok(()),
+        |index| {
+            assert_eq!(
+                index.records,
+                vec![
+                    (NodeId::ROOT, prefix_op.meta.id.clone(), 1),
+                    (NodeId::ROOT, suffix_op.meta.id.clone(), 2)
+                ]
+            );
+            Ok(())
+        },
     )
     .unwrap();
 

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -179,6 +179,46 @@ fn apply_incremental_ops_with_delta_sorts_and_returns_head() {
 }
 
 #[test]
+fn apply_incremental_ops_with_delta_keeps_head_for_duplicate_ops() {
+    let mut crdt = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut index = RecordingIndex::default();
+    let replica = ReplicaId::new(b"remote");
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+
+    let first_result = apply_incremental_ops_with_delta(
+        &mut crdt,
+        &mut index,
+        &Cursor::default(),
+        vec![op.clone()],
+    )
+    .unwrap();
+    let first_head = first_result.head.expect("expected first head");
+
+    let duplicate_cursor = Cursor {
+        head_lamport: first_head.at.lamport,
+        head_replica: first_head.at.replica.to_vec(),
+        head_counter: first_head.at.counter,
+        head_seq: first_head.seq,
+        ..Cursor::default()
+    };
+    let duplicate_result =
+        apply_incremental_ops_with_delta(&mut crdt, &mut index, &duplicate_cursor, vec![op])
+            .unwrap();
+
+    assert_eq!(
+        duplicate_result.head.expect("expected duplicate head").seq,
+        1
+    );
+    assert_eq!(duplicate_result.outcome.head_seq, 1);
+    assert!(duplicate_result.outcome.changes.is_empty());
+}
+
+#[test]
 fn apply_incremental_ops_with_delta_rejects_before_materialized_head() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"local"),
@@ -700,6 +740,60 @@ fn catch_up_materialized_state_scans_storage_once() {
         result.outcome.affected_nodes(),
         vec![NodeId::ROOT, NodeId(1), NodeId(2)]
     );
+}
+
+#[test]
+fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
+    let replica = ReplicaId::new(b"suffix-only");
+    let prefix = NodeId(1);
+    let suffix = NodeId(2);
+    let prefix_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, prefix, vec![0x10]);
+    let suffix_op = Operation::insert(&replica, 2, 2, NodeId::ROOT, suffix, vec![0x20]);
+
+    let mut storage = MemoryStorage::default();
+    storage.apply(prefix_op.clone()).unwrap();
+    storage.apply(suffix_op.clone()).unwrap();
+
+    // Simulate the backend state at the replay boundary: prefix rows are already materialized,
+    // so conservative catch-up should not re-emit them as materialization changes.
+    let mut nodes = MemoryNodeStore::default();
+    nodes.ensure_node(prefix).unwrap();
+    nodes.attach(prefix, NodeId::ROOT, vec![0x10]).unwrap();
+
+    let meta = Cursor {
+        head_lamport: suffix_op.meta.lamport,
+        head_replica: suffix_op.meta.id.replica.as_bytes().to_vec(),
+        head_counter: suffix_op.meta.id.counter,
+        head_seq: 2,
+        replay_lamport: Some(suffix_op.meta.lamport),
+        replay_replica: Some(suffix_op.meta.id.replica.as_bytes().to_vec()),
+        replay_counter: Some(suffix_op.meta.id.counter),
+    };
+
+    let mut flushed_nodes = false;
+    let result = catch_up_materialized_state(
+        storage,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"adapter"),
+            clock: LamportClock::default(),
+            nodes,
+            payloads: MemoryPayloadStore::default(),
+            index: NoopParentOpIndex,
+        },
+        &meta,
+        |nodes| {
+            flushed_nodes = true;
+            assert!(nodes.exists(prefix)?);
+            assert!(nodes.exists(suffix)?);
+            Ok(())
+        },
+        |_| Ok(()),
+    )
+    .unwrap();
+
+    assert!(flushed_nodes);
+    assert_eq!(result.head.expect("expected head").seq, 2);
+    assert_eq!(result.outcome.affected_nodes(), vec![NodeId::ROOT, suffix]);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR refactors core materialization replay bookkeeping so the same rules are used across incremental append, conservative catch-up from a replay frontier, and direct rewind/replay of an out-of-order suffix.

It introduces a shared `ReplayAccumulator` that tracks materialization seq, final head, trusted prefix boundary, and emitted `MaterializationOutcome` changes. This makes the subtle replay rules explicit and avoids each path manually deciding which changes to report.

The key behavior preserved is that a full internal replay can rebuild state without telling subscribers that the whole tree changed. When replay starts from an invalidated frontier, only suffix changes are emitted.

It also renames `ReplaySnapshot` to `RebuiltMaterialization`, since that value contains a rebuilt in-memory CRDT/index/head/seq rather than just a passive snapshot, and adds regression tests for duplicate-op head preservation and suffix-only catch-up reporting.

Closes #126