### PR TITLE
Extract reusable auth session preparation

### DIFF
--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -4,8 +4,7 @@ import type { Operation } from "@treecrdt/interface";
 import {
   base64urlDecode,
   base64urlEncode,
-  createTreecrdtCoseCwtAuth,
-  createTreecrdtIdentityChainCapabilityV1,
+  createTreecrdtAuthSession,
   createTreecrdtSqliteSubtreeScopeEvaluator,
   describeTreecrdtCapabilityTokenV1,
   deriveKeyIdV1,
@@ -546,7 +545,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       const opAuthStore = createOpAuthStore({ runner: client.runner, docId });
       const capabilityStore = createCapabilityMaterialStore({ runner: client.runner, docId });
 
-      const baseAuth = createTreecrdtCoseCwtAuth({
+      const authSession = createTreecrdtAuthSession({
+        docId,
         issuerPublicKeys: [issuerPk],
         localPrivateKey: localSk,
         localPublicKey: localPk,
@@ -557,37 +557,15 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         scopeEvaluator,
         opAuthStore,
         onPeerIdentityChain,
+        localIdentityChain: getLocalIdentityChain,
       });
 
-      const preparedAuth: SyncAuth<Operation> = {
-        ...baseAuth,
-        helloCapabilities: async (ctx) => {
-          const caps = (await baseAuth.helloCapabilities?.(ctx)) ?? [];
-          try {
-            const chain = await getLocalIdentityChain();
-            if (chain) caps.push(createTreecrdtIdentityChainCapabilityV1(chain));
-          } catch {
-            // Identity chains are optional and best-effort.
-          }
-          return caps;
-        },
-        onHello: async (hello, ctx) => {
-          const ackCaps = (await baseAuth.onHello?.(hello, ctx)) ?? [];
-          try {
-            const chain = await getLocalIdentityChain();
-            if (chain) ackCaps.push(createTreecrdtIdentityChainCapabilityV1(chain));
-          } catch {
-            // Identity chains are optional and best-effort.
-          }
-          return ackCaps;
-        },
-      };
-
+      const preparedAuth = authSession.syncAuth;
       localAuthRef.current = preparedAuth;
 
       void (async () => {
         try {
-          await preparedAuth.helloCapabilities?.({ docId });
+          await authSession.ready;
           if (cancelled) return;
           setSyncAuth(preparedAuth);
         } catch (err) {

--- a/packages/treecrdt-auth/src/index.ts
+++ b/packages/treecrdt-auth/src/index.ts
@@ -3,5 +3,6 @@ export * from './cose.js';
 export * from './ed25519.js';
 export * from './identity.js';
 export * from './revocation.js';
+export * from './session.js';
 export * from './treecrdt-auth.js';
 export * from './sqlite.js';

--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -1,0 +1,103 @@
+import type { Operation } from '@treecrdt/interface';
+import type { Capability, SyncAuth } from '@treecrdt/sync';
+
+import {
+  createTreecrdtIdentityChainCapabilityV1,
+  type TreecrdtIdentityChainV1,
+} from './identity.js';
+import {
+  createTreecrdtCoseCwtAuth,
+  type TreecrdtCoseCwtAuthOptions,
+} from './internal/cose-cwt-auth.js';
+
+type MaybePromise<T> = T | Promise<T>;
+
+export type TreecrdtAuthSessionState =
+  | { status: 'loading' }
+  | { status: 'ready' }
+  | { status: 'error'; error: unknown };
+
+export type TreecrdtAuthSessionOptions = Omit<TreecrdtCoseCwtAuthOptions, 'localIdentityChain'> & {
+  /** Doc used to warm local auth material before the session is handed to sync. */
+  docId: string;
+  /**
+   * Optional local identity chain, or provider for apps that create it lazily.
+   *
+   * Provider failures are intentionally best-effort: identity disclosure should not prevent
+   * signed capability auth from becoming ready.
+   */
+  localIdentityChain?:
+    | TreecrdtIdentityChainV1
+    | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
+  onIdentityChainError?: (error: unknown) => void;
+};
+
+export type TreecrdtAuthSession = {
+  syncAuth: SyncAuth<Operation>;
+  readonly ready: Promise<SyncAuth<Operation>>;
+  getState: () => TreecrdtAuthSessionState;
+  refresh: () => Promise<SyncAuth<Operation>>;
+};
+
+/**
+ * Creates one long-lived sync auth object and warms its local material before exposing readiness.
+ *
+ * This is intentionally framework-agnostic. Apps can keep the returned `syncAuth` stable while
+ * awaiting `ready` before passing it into sync startup, avoiding per-app warmup wrappers.
+ */
+export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): TreecrdtAuthSession {
+  const { docId, localIdentityChain, onIdentityChainError, ...authOpts } = opts;
+  const baseAuth = createTreecrdtCoseCwtAuth(authOpts);
+  let state: TreecrdtAuthSessionState = { status: 'loading' };
+
+  const localIdentityCapability = async () => {
+    if (!localIdentityChain) return null;
+    try {
+      const chain =
+        typeof localIdentityChain === 'function' ? await localIdentityChain() : localIdentityChain;
+      return chain ? createTreecrdtIdentityChainCapabilityV1(chain) : null;
+    } catch (err) {
+      onIdentityChainError?.(err);
+      return null;
+    }
+  };
+
+  const addLocalIdentity = async (baseCaps: MaybePromise<Capability[] | undefined>) => {
+    const caps = [...((await baseCaps) ?? [])];
+    const identityCap = await localIdentityCapability();
+    if (identityCap) caps.push(identityCap);
+    return caps;
+  };
+
+  const syncAuth: SyncAuth<Operation> = {
+    ...baseAuth,
+    helloCapabilities: (ctx) => addLocalIdentity(baseAuth.helloCapabilities?.(ctx)),
+    onHello: (hello, ctx) => addLocalIdentity(baseAuth.onHello?.(hello, ctx)),
+  };
+
+  const warm = async () => {
+    state = { status: 'loading' };
+    try {
+      await syncAuth.helloCapabilities?.({ docId });
+      state = { status: 'ready' };
+      return syncAuth;
+    } catch (error) {
+      state = { status: 'error', error };
+      throw error;
+    }
+  };
+
+  let ready = warm();
+
+  return {
+    syncAuth,
+    get ready() {
+      return ready;
+    },
+    getState: () => state,
+    refresh: () => {
+      ready = warm();
+      return ready;
+    },
+  };
+}

--- a/packages/treecrdt-auth/tests/session.test.ts
+++ b/packages/treecrdt-auth/tests/session.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from 'vitest';
+
+import {
+  TREECRDT_IDENTITY_CHAIN_CAPABILITY,
+  createTreecrdtAuthSession,
+  type TreecrdtIdentityChainV1,
+} from '../dist/index.js';
+
+function testKey(byte: number): Uint8Array {
+  return new Uint8Array(32).fill(byte);
+}
+
+function testIdentityChain(): TreecrdtIdentityChainV1 {
+  return {
+    identityPublicKey: testKey(1),
+    deviceCertBytes: new Uint8Array([2]),
+    replicaCertBytes: new Uint8Array([3]),
+  };
+}
+
+test('auth session warms sync auth and exposes ready state', async () => {
+  const session = createTreecrdtAuthSession({
+    docId: 'doc-auth-session-ready',
+    issuerPublicKeys: [],
+    localPrivateKey: testKey(4),
+    localPublicKey: testKey(5),
+    allowUnsigned: true,
+  });
+
+  expect(session.getState().status).toBe('loading');
+  await session.ready;
+  expect(session.getState().status).toBe('ready');
+});
+
+test('auth session advertises async local identity chain without app-side wrappers', async () => {
+  const session = createTreecrdtAuthSession({
+    docId: 'doc-auth-session-identity',
+    issuerPublicKeys: [],
+    localPrivateKey: testKey(4),
+    localPublicKey: testKey(5),
+    allowUnsigned: true,
+    localIdentityChain: async () => testIdentityChain(),
+  });
+
+  await session.ready;
+  const caps =
+    (await session.syncAuth.helloCapabilities?.({
+      docId: 'doc-auth-session-identity',
+    })) ?? [];
+
+  expect(caps.some((cap) => cap.name === TREECRDT_IDENTITY_CHAIN_CAPABILITY)).toBe(true);
+});
+
+test('auth session treats identity chain provider failures as best-effort', async () => {
+  const errors: unknown[] = [];
+  const session = createTreecrdtAuthSession({
+    docId: 'doc-auth-session-identity-error',
+    issuerPublicKeys: [],
+    localPrivateKey: testKey(4),
+    localPublicKey: testKey(5),
+    allowUnsigned: true,
+    localIdentityChain: async () => {
+      throw new Error('identity unavailable');
+    },
+    onIdentityChainError: (err) => errors.push(err),
+  });
+
+  await session.ready;
+  expect(session.getState().status).toBe('ready');
+  expect(errors).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

- Adds a framework-agnostic `createTreecrdtAuthSession` helper in `@treecrdt/auth`.
- Centralizes sync auth warmup plus optional async local identity-chain capability injection.
- Replaces the playground's inline `createTreecrdtCoseCwtAuth` wrapper with the reusable session helper.

Refs #107

## Scope

This is intentionally a first slice of #107. It does not add durable revocation storage, generic invite flows, or key rotation.
