### PR TITLE
Add SQLite client auth facade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
         pnpm -C packages/treecrdt-ts run build
         pnpm -C packages/treecrdt-riblt-wasm-js run build
         pnpm -C packages/sync/protocol run build
-        pnpm -C packages/sync/material/sqlite run build
         pnpm -C packages/treecrdt-auth run build
+        pnpm -C packages/sync/material/sqlite run build
         pnpm -C packages/treecrdt-crypto run build
         pnpm -C packages/treecrdt-wa-sqlite run build:ts
 

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -501,6 +501,14 @@ export default function App() {
     [notifyLocalUpdate, recordOps]
   );
 
+  const acceptLocalOps = React.useCallback(
+    async (ops: Operation[]) => {
+      await verifyLocalOps(ops);
+      recordLocalOps(ops);
+    },
+    [recordLocalOps, verifyLocalOps]
+  );
+
   const grantSubtreeToReplicaPubkey = React.useCallback(
     async (opts?: {
       recipientKey?: string;
@@ -710,7 +718,7 @@ export default function App() {
     try {
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
       const op = await client.local.move(replica, nodeId, newParent, placement);
-      recordLocalOps([op]);
+      await acceptLocalOps([op]);
     } catch (err) {
       console.error("Failed to append move op", err);
       setError("Failed to move node (see console)");
@@ -804,7 +812,7 @@ export default function App() {
         prev ? { ...prev, completed: normalizedCount, phase: "applying" } : prev
       );
 
-      recordLocalOps(ops);
+      await acceptLocalOps(ops);
       expandPathTo(parentId);
     } catch (err) {
       console.error("Failed to add nodes", err);
@@ -825,7 +833,7 @@ export default function App() {
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
       const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload);
-      recordLocalOps([op]);
+      await acceptLocalOps([op]);
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
       }
@@ -847,8 +855,7 @@ export default function App() {
           const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
           const encryptedPayload = await encryptPayloadBytes(payload);
           const op = await client.local.payload(replica, nodeId, encryptedPayload);
-          await verifyLocalOps([op]);
-          recordLocalOps([op]);
+          await acceptLocalOps([op]);
         } catch (err) {
           console.error("Failed to write payload", err);
           setError("Failed to write payload (see console)");
@@ -863,8 +870,7 @@ export default function App() {
     setBusy(true);
     try {
       const op = await client.local.delete(replica, nodeId);
-      await verifyLocalOps([op]);
-      recordLocalOps([op]);
+      await acceptLocalOps([op]);
     } catch (err) {
       console.error("Failed to delete node", err);
       setError("Failed to delete node (see console)");

--- a/examples/playground/src/auth.ts
+++ b/examples/playground/src/auth.ts
@@ -361,18 +361,28 @@ async function writeLocalIdentity(docId: string, localSk: Uint8Array, localToken
   lsSet(`${LOCAL_IDENTITY_SEALED_KEY_PREFIX}${docId}`, base64urlEncode(sealed));
 }
 
-export async function saveLocalKeys(docId: string, localSkB64: string) {
-  const localSk = base64urlDecode(localSkB64);
-  const existing = await readLocalIdentityOrNull(docId);
-  const localTokens = existing?.localTokens ?? [];
-  await writeLocalIdentity(docId, localSk, localTokens);
+export async function saveLocalKeys(
+  docId: string,
+  localSkB64: string,
+  opts: { ifMissing?: boolean } = {}
+): Promise<boolean> {
+  return await withGlobalLock(`treecrdt-playground-local-identity:${docId}`, async () => {
+    const localSk = base64urlDecode(localSkB64);
+    const existing = await readLocalIdentityOrNull(docId);
+    if (opts.ifMissing && existing) return false;
+    const localTokens = existing?.localTokens ?? [];
+    await writeLocalIdentity(docId, localSk, localTokens);
+    return true;
+  });
 }
 
 export async function saveLocalTokens(docId: string, tokensB64: string[]) {
-  const existing = await readLocalIdentityOrNull(docId);
-  if (!existing) throw new Error("local identity is missing; cannot store capability tokens");
-  const tokens = tokensB64.map((b64) => base64urlDecode(b64));
-  await writeLocalIdentity(docId, existing.localSk, tokens);
+  await withGlobalLock(`treecrdt-playground-local-identity:${docId}`, async () => {
+    const existing = await readLocalIdentityOrNull(docId);
+    if (!existing) throw new Error("local identity is missing; cannot store capability tokens");
+    const tokens = tokensB64.map((b64) => base64urlDecode(b64));
+    await writeLocalIdentity(docId, existing.localSk, tokens);
+  });
 }
 
 export function clearAuthMaterial(docId: string) {

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -11,7 +11,7 @@ import {
   issueTreecrdtDelegatedCapabilityTokenV1,
   type TreecrdtCapabilityTokenV1,
 } from "@treecrdt/auth";
-import { createTreecrdtSqliteAuthBackend } from "@treecrdt/sync-sqlite";
+import { createTreecrdtSqliteAuthBackend, createTreecrdtSqliteSyncDiagnostics } from "@treecrdt/sync-sqlite";
 import type { SyncAuth } from "@treecrdt/sync";
 import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 
@@ -1144,9 +1144,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     setAuthBusy(true);
     setAuthError(null);
     try {
-      const { pendingOpsStore } = createTreecrdtSqliteAuthBackend({ runner: client.runner, docId });
-      await pendingOpsStore.init();
-      const listed = await pendingOpsStore.listPendingOps();
+      const diagnostics = createTreecrdtSqliteSyncDiagnostics({ runner: client.runner, docId });
+      const listed = await diagnostics.listPendingOps();
       setPendingOps(
         listed.map((p) => ({
           id: `${bytesToHex(p.op.meta.id.replica)}:${p.op.meta.id.counter}`,

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -4,14 +4,17 @@ import type { Operation } from "@treecrdt/interface";
 import {
   base64urlDecode,
   base64urlEncode,
-  createTreecrdtAuthSession,
   describeTreecrdtCapabilityTokenV1,
   deriveKeyIdV1,
   deriveTokenIdV1,
   issueTreecrdtDelegatedCapabilityTokenV1,
   type TreecrdtCapabilityTokenV1,
 } from "@treecrdt/auth";
-import { createTreecrdtSqliteAuthBackend, createTreecrdtSqliteSyncDiagnostics } from "@treecrdt/sync-sqlite";
+import {
+  createTreecrdtSqliteAuthBackend,
+  createTreecrdtSqliteAuthSession,
+  createTreecrdtSqliteSyncDiagnostics,
+} from "@treecrdt/sync-sqlite";
 import type { SyncAuth } from "@treecrdt/sync";
 import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 
@@ -536,9 +539,9 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       const localSk = base64urlDecode(authMaterial.localSkB64);
       const localPk = base64urlDecode(authMaterial.localPkB64);
       const localTokens = authMaterial.localTokensB64.map((t) => base64urlDecode(t));
-      const authBackend = createTreecrdtSqliteAuthBackend({ runner: client.runner, docId });
 
-      const authSession = createTreecrdtAuthSession({
+      const authSession = createTreecrdtSqliteAuthSession({
+        runner: client.runner,
         docId,
         issuerPublicKeys: [issuerPk],
         localPrivateKey: localSk,
@@ -546,7 +549,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         localCapabilityTokens: localTokens,
         revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
         requireProofRef: true,
-        backend: authBackend,
         identity: {
           onPeer: onPeerIdentityChain,
           local: getLocalIdentityChain,

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -544,13 +544,13 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         localPrivateKey: localSk,
         localPublicKey: localPk,
         localCapabilityTokens: localTokens,
-        capabilityStore: authBackend.capabilityStore,
         revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
         requireProofRef: true,
-        scopeEvaluator: authBackend.scopeEvaluator,
-        opAuthStore: authBackend.opAuthStore,
-        onPeerIdentityChain,
-        localIdentityChain: getLocalIdentityChain,
+        backend: authBackend,
+        identity: {
+          onPeer: onPeerIdentityChain,
+          local: getLocalIdentityChain,
+        },
       });
 
       const preparedAuth = authSession.syncAuth;

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -5,18 +5,13 @@ import {
   base64urlDecode,
   base64urlEncode,
   createTreecrdtAuthSession,
-  createTreecrdtSqliteSubtreeScopeEvaluator,
   describeTreecrdtCapabilityTokenV1,
   deriveKeyIdV1,
   deriveTokenIdV1,
   issueTreecrdtDelegatedCapabilityTokenV1,
   type TreecrdtCapabilityTokenV1,
 } from "@treecrdt/auth";
-import {
-  createCapabilityMaterialStore,
-  createOpAuthStore,
-  createPendingOpsStore,
-} from "@treecrdt/sync-sqlite";
+import { createTreecrdtSqliteAuthBackend } from "@treecrdt/sync-sqlite";
 import type { SyncAuth } from "@treecrdt/sync";
 import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 
@@ -541,9 +536,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       const localSk = base64urlDecode(authMaterial.localSkB64);
       const localPk = base64urlDecode(authMaterial.localPkB64);
       const localTokens = authMaterial.localTokensB64.map((t) => base64urlDecode(t));
-      const scopeEvaluator = createTreecrdtSqliteSubtreeScopeEvaluator(client.runner);
-      const opAuthStore = createOpAuthStore({ runner: client.runner, docId });
-      const capabilityStore = createCapabilityMaterialStore({ runner: client.runner, docId });
+      const authBackend = createTreecrdtSqliteAuthBackend({ runner: client.runner, docId });
 
       const authSession = createTreecrdtAuthSession({
         docId,
@@ -551,11 +544,11 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         localPrivateKey: localSk,
         localPublicKey: localPk,
         localCapabilityTokens: localTokens,
-        capabilityStore,
+        capabilityStore: authBackend.capabilityStore,
         revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
         requireProofRef: true,
-        scopeEvaluator,
-        opAuthStore,
+        scopeEvaluator: authBackend.scopeEvaluator,
+        opAuthStore: authBackend.opAuthStore,
         onPeerIdentityChain,
         localIdentityChain: getLocalIdentityChain,
       });
@@ -994,7 +987,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
       const issuerPk = base64urlDecode(issuerPkB64);
       const proofTokenBytes = base64urlDecode(proofTokenB64);
-      const scopeEvaluator = client ? createTreecrdtSqliteSubtreeScopeEvaluator(client.runner) : undefined;
+      const scopeEvaluator = client ? createTreecrdtSqliteAuthBackend({ runner: client.runner, docId }).scopeEvaluator : undefined;
       const proofDesc = await describeTreecrdtCapabilityTokenV1({
         tokenBytes: proofTokenBytes,
         issuerPublicKeys: [issuerPk],
@@ -1151,9 +1144,9 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     setAuthBusy(true);
     setAuthError(null);
     try {
-      const store = createPendingOpsStore({ runner: client.runner, docId });
-      await store.init();
-      const listed = await store.listPendingOps();
+      const { pendingOpsStore } = createTreecrdtSqliteAuthBackend({ runner: client.runner, docId });
+      await pendingOpsStore.init();
+      const listed = await pendingOpsStore.listPendingOps();
       setPendingOps(
         listed.map((p) => ({
           id: `${bytesToHex(p.op.meta.id.replica)}:${p.op.meta.id.counter}`,
@@ -1294,7 +1287,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
         const issuerPk = base64urlDecode(issuerPkB64);
         const proofTokenBytes = base64urlDecode(proofTokenB64);
-        const scopeEvaluator = client ? createTreecrdtSqliteSubtreeScopeEvaluator(client.runner) : undefined;
+        const scopeEvaluator = client ? createTreecrdtSqliteAuthBackend({ runner: client.runner, docId }).scopeEvaluator : undefined;
         const proofDesc = await describeTreecrdtCapabilityTokenV1({
           tokenBytes: proofTokenBytes,
           issuerPublicKeys: [issuerPk],

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -521,59 +521,53 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       };
     }
 
-    if (
-      !authMaterial.issuerPkB64 ||
-      !authMaterial.localSkB64 ||
-      !authMaterial.localPkB64 ||
-      authMaterial.localTokensB64.length === 0
-    ) {
+    const { issuerPkB64, localSkB64, localPkB64 } = authMaterial;
+    const localTokensB64 = authMaterial.localTokensB64;
+
+    if (!issuerPkB64 || !localSkB64 || !localPkB64 || localTokensB64.length === 0) {
       localAuthSessionRef.current = null;
       return () => {
         cancelled = true;
       };
     }
 
-    try {
-      const issuerPk = base64urlDecode(authMaterial.issuerPkB64);
-      const localSk = base64urlDecode(authMaterial.localSkB64);
-      const localPk = base64urlDecode(authMaterial.localPkB64);
-      const localTokens = authMaterial.localTokensB64.map((t) => base64urlDecode(t));
+    void (async () => {
+      try {
+        const issuerPk = base64urlDecode(issuerPkB64);
+        const localSk = base64urlDecode(localSkB64);
+        const localPk = base64urlDecode(localPkB64);
+        const localTokens = localTokensB64.map((t) => base64urlDecode(t));
 
-      const authSession = client.auth.createSession({
-        docId,
-        trust: { issuerPublicKeys: [issuerPk] },
-        local: {
-          privateKey: localSk,
-          publicKey: localPk,
-          capabilityTokens: localTokens,
-        },
-        revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
-        requireProofRef: true,
-        identity: {
-          onPeer: onPeerIdentityChain,
-          local: getLocalIdentityChain,
-        },
-      });
+        const authSession = await client.auth.createSession({
+          docId,
+          trust: { issuerPublicKeys: [issuerPk] },
+          local: {
+            privateKey: localSk,
+            publicKey: localPk,
+            capabilityTokens: localTokens,
+          },
+          revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
+          requireProofRef: true,
+          identity: {
+            onPeer: onPeerIdentityChain,
+            local: getLocalIdentityChain,
+          },
+        });
+        if (cancelled) return;
 
-      const preparedAuth = authSession.syncAuth;
-      localAuthSessionRef.current = authSession;
+        const preparedAuth = authSession.syncAuth;
+        localAuthSessionRef.current = authSession;
 
-      void (async () => {
-        try {
-          await authSession.ready;
-          if (cancelled) return;
-          setSyncAuth(preparedAuth);
-        } catch (err) {
-          if (cancelled) return;
-          if (localAuthSessionRef.current === authSession) localAuthSessionRef.current = null;
-          setAuthError(err instanceof Error ? err.message : String(err));
-        }
-      })();
-    } catch (err) {
-      localAuthSessionRef.current = null;
-      setSyncAuth(null);
-      setAuthError(err instanceof Error ? err.message : String(err));
-    }
+        await authSession.ready;
+        if (cancelled) return;
+        setSyncAuth(preparedAuth);
+      } catch (err) {
+        if (cancelled) return;
+        localAuthSessionRef.current = null;
+        setSyncAuth(null);
+        setAuthError(err instanceof Error ? err.message : String(err));
+      }
+    })();
 
     return () => {
       cancelled = true;

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -9,10 +9,9 @@ import {
   deriveTokenIdV1,
   issueTreecrdtDelegatedCapabilityTokenV1,
   type TreecrdtCapabilityTokenV1,
+  type TreecrdtAuthSession,
 } from "@treecrdt/auth";
 import {
-  createTreecrdtSqliteAuthBackend,
-  createTreecrdtSqliteAuthSession,
   createTreecrdtSqliteSyncDiagnostics,
 } from "@treecrdt/sync-sqlite";
 import type { SyncAuth } from "@treecrdt/sync";
@@ -324,7 +323,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
   }));
 
   const [syncAuth, setSyncAuth] = useState<SyncAuth<Operation> | null>(null);
-  const localAuthRef = useRef<SyncAuth<Operation> | null>(null);
+  const localAuthSessionRef = useRef<TreecrdtAuthSession | null>(null);
   const localIdentityChainPromiseRef = useRef<
     Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
   >(null);
@@ -516,7 +515,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     setSyncAuth(null);
 
     if (!authEnabled || !client) {
-      localAuthRef.current = null;
+      localAuthSessionRef.current = null;
       return () => {
         cancelled = true;
       };
@@ -528,7 +527,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       !authMaterial.localPkB64 ||
       authMaterial.localTokensB64.length === 0
     ) {
-      localAuthRef.current = null;
+      localAuthSessionRef.current = null;
       return () => {
         cancelled = true;
       };
@@ -540,13 +539,14 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       const localPk = base64urlDecode(authMaterial.localPkB64);
       const localTokens = authMaterial.localTokensB64.map((t) => base64urlDecode(t));
 
-      const authSession = createTreecrdtSqliteAuthSession({
-        runner: client.runner,
+      const authSession = client.auth.createSession({
         docId,
-        issuerPublicKeys: [issuerPk],
-        localPrivateKey: localSk,
-        localPublicKey: localPk,
-        localCapabilityTokens: localTokens,
+        trust: { issuerPublicKeys: [issuerPk] },
+        local: {
+          privateKey: localSk,
+          publicKey: localPk,
+          capabilityTokens: localTokens,
+        },
         revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
         requireProofRef: true,
         identity: {
@@ -556,7 +556,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       });
 
       const preparedAuth = authSession.syncAuth;
-      localAuthRef.current = preparedAuth;
+      localAuthSessionRef.current = authSession;
 
       void (async () => {
         try {
@@ -565,19 +565,19 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
           setSyncAuth(preparedAuth);
         } catch (err) {
           if (cancelled) return;
-          if (localAuthRef.current === preparedAuth) localAuthRef.current = null;
+          if (localAuthSessionRef.current === authSession) localAuthSessionRef.current = null;
           setAuthError(err instanceof Error ? err.message : String(err));
         }
       })();
     } catch (err) {
-      localAuthRef.current = null;
+      localAuthSessionRef.current = null;
       setSyncAuth(null);
       setAuthError(err instanceof Error ? err.message : String(err));
     }
 
     return () => {
       cancelled = true;
-      if (localAuthRef.current) localAuthRef.current = null;
+      if (localAuthSessionRef.current) localAuthSessionRef.current = null;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -601,16 +601,9 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
   const verifyLocalOps = React.useCallback(
     async (ops: Operation[]) => {
       if (!authEnabled) return;
-      const auth = localAuthRef.current;
-      if (!auth?.signOps || !auth.verifyOps) throw new Error("auth is enabled but not configured");
-      const ctx = { docId, purpose: "reconcile" as const, filterId: "__local__" };
-      const authEntries = await auth.signOps(ops, ctx);
-      const res = await auth.verifyOps(ops, authEntries, ctx);
-      const dispositions = (res as any)?.dispositions as Array<{ status: string; message?: string }> | undefined;
-      const rejected = dispositions?.find((d) => d.status !== "allow");
-      if (rejected?.status === "pending_context") {
-        throw new Error(rejected.message ?? "missing subtree context to authorize op");
-      }
+      const session = localAuthSessionRef.current;
+      if (!session) throw new Error("auth is enabled but not configured");
+      await session.authorizeLocalOps(ops);
     },
     [authEnabled, docId]
   );
@@ -899,7 +892,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         setAuthError(null);
       } catch (err) {
         if (cancelled) return;
-        localAuthRef.current = null;
+        localAuthSessionRef.current = null;
         setAuthError(authEnabled ? (err instanceof Error ? err.message : String(err)) : null);
       }
     })();
@@ -989,13 +982,17 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
       const issuerPk = base64urlDecode(issuerPkB64);
       const proofTokenBytes = base64urlDecode(proofTokenB64);
-      const scopeEvaluator = client ? createTreecrdtSqliteAuthBackend({ runner: client.runner, docId }).scopeEvaluator : undefined;
-      const proofDesc = await describeTreecrdtCapabilityTokenV1({
-        tokenBytes: proofTokenBytes,
-        issuerPublicKeys: [issuerPk],
-        docId,
-        scopeEvaluator,
-      });
+      const proofDesc = client
+        ? await client.auth.describeCapabilityToken({
+            tokenBytes: proofTokenBytes,
+            trust: { issuerPublicKeys: [issuerPk] },
+            docId,
+          })
+        : await describeTreecrdtCapabilityTokenV1({
+            tokenBytes: proofTokenBytes,
+            issuerPublicKeys: [issuerPk],
+            docId,
+          });
       const proofActions = new Set(proofDesc.caps.flatMap((c) => c.actions ?? []));
       if (!proofActions.has("grant")) {
         throw new Error("This tab is verify-only and cannot mint invites (missing grant permission).");
@@ -1012,11 +1009,10 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         if (proofScope?.maxDepth !== undefined) {
           throw new Error("This tab can only mint delegated invites for its current subtree scope (maxDepth).");
         }
-        if (!scopeEvaluator) {
+        if (!client) {
           throw new Error("This tab can only mint delegated invites for its current subtree scope.");
         }
-        const tri = await scopeEvaluator({
-          docId,
+        const tri = await client.auth.evaluateScope({
           node: hexToBytes16(rootNodeId),
           scope: {
             root: hexToBytes16(proofRootId),
@@ -1288,13 +1284,17 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
         const issuerPk = base64urlDecode(issuerPkB64);
         const proofTokenBytes = base64urlDecode(proofTokenB64);
-        const scopeEvaluator = client ? createTreecrdtSqliteAuthBackend({ runner: client.runner, docId }).scopeEvaluator : undefined;
-        const proofDesc = await describeTreecrdtCapabilityTokenV1({
-          tokenBytes: proofTokenBytes,
-          issuerPublicKeys: [issuerPk],
-          docId,
-          scopeEvaluator,
-        });
+        const proofDesc = client
+          ? await client.auth.describeCapabilityToken({
+              tokenBytes: proofTokenBytes,
+              trust: { issuerPublicKeys: [issuerPk] },
+              docId,
+            })
+          : await describeTreecrdtCapabilityTokenV1({
+              tokenBytes: proofTokenBytes,
+              issuerPublicKeys: [issuerPk],
+              docId,
+            });
         const proofActions = new Set(proofDesc.caps.flatMap((c) => c.actions ?? []));
         if (!proofActions.has("grant")) {
           throw new Error("this tab cannot delegate grants (missing grant permission)");
@@ -1308,11 +1308,10 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
           if (proofScope?.maxDepth !== undefined) {
             throw new Error("this tab can only delegate grants for its current subtree scope (maxDepth)");
           }
-          if (!scopeEvaluator) {
+          if (!client) {
             throw new Error("this tab can only delegate grants for its current subtree scope");
           }
-          const tri = await scopeEvaluator({
-            docId,
+          const tri = await client.auth.evaluateScope({
             node: hexToBytes16(rootNodeId),
             scope: {
               root: hexToBytes16(proofRootId),

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -844,7 +844,13 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
           const { sk, pk } = await generateEd25519KeyPair();
           localPkB64 = base64urlEncode(pk);
           localSkB64 = base64urlEncode(sk);
-          await saveLocalKeys(docId, localSkB64);
+          const saved = await saveLocalKeys(docId, localSkB64, { ifMissing: true });
+          if (!saved) {
+            const latest = await loadAuthMaterial(docId);
+            localPkB64 = latest.localPkB64;
+            localSkB64 = latest.localSkB64;
+            localTokensB64 = latest.localTokensB64;
+          }
         } else if (!localPkB64 && localSkB64) {
           const localSk = base64urlDecode(localSkB64);
           const localPk = await deriveEd25519PublicKey(localSk);

--- a/packages/sync/material/sqlite/package.json
+++ b/packages/sync/material/sqlite/package.json
@@ -14,6 +14,10 @@
       "import": "./dist/backend.js",
       "types": "./dist/backend.d.ts"
     },
+    "./auth": {
+      "import": "./dist/auth.js",
+      "types": "./dist/auth.d.ts"
+    },
     "./proof-material": {
       "import": "./dist/proof-material/index.js",
       "types": "./dist/proof-material/index.d.ts"

--- a/packages/sync/material/sqlite/package.json
+++ b/packages/sync/material/sqlite/package.json
@@ -25,9 +25,10 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "pnpm -C ../../protocol run build && pnpm run build && vitest run"
+    "test": "pnpm -C ../../../treecrdt-ts run build && pnpm -C ../../protocol run build && pnpm -C ../../../treecrdt-auth run build && pnpm run build && vitest run"
   },
   "dependencies": {
+    "@treecrdt/auth": "workspace:*",
     "@treecrdt/interface": "workspace:*",
     "@treecrdt/sync": "workspace:*"
   },

--- a/packages/sync/material/sqlite/src/auth.ts
+++ b/packages/sync/material/sqlite/src/auth.ts
@@ -1,0 +1,41 @@
+import type { SqliteRunner } from '@treecrdt/interface/sqlite';
+import {
+  createTreecrdtSqliteSubtreeScopeEvaluator,
+  type TreecrdtScopeEvaluator,
+} from '@treecrdt/auth';
+
+import {
+  createCapabilityMaterialStore,
+  createOpAuthStore,
+  createPendingOpsStore,
+  type SqliteCapabilityMaterialStore,
+  type SqliteOpAuthStore,
+  type SqlitePendingOpsStore,
+} from './proof-material/index.js';
+
+export type TreecrdtSqliteAuthBackend = {
+  /**
+   * SQLite-backed subtree evaluator for capability scopes.
+   *
+   * Auth itself stays backend-agnostic; the storage adapter owns how scope checks read
+   * the local materialized tree.
+   */
+  scopeEvaluator: TreecrdtScopeEvaluator;
+  capabilityStore: SqliteCapabilityMaterialStore;
+  opAuthStore: SqliteOpAuthStore;
+  pendingOpsStore: SqlitePendingOpsStore;
+};
+
+export function createTreecrdtSqliteAuthBackend(opts: {
+  runner: SqliteRunner;
+  docId: string;
+  nowMs?: () => number;
+}): TreecrdtSqliteAuthBackend {
+  const storeOpts = { runner: opts.runner, docId: opts.docId, nowMs: opts.nowMs };
+  return {
+    scopeEvaluator: createTreecrdtSqliteSubtreeScopeEvaluator(opts.runner),
+    capabilityStore: createCapabilityMaterialStore(storeOpts),
+    opAuthStore: createOpAuthStore(storeOpts),
+    pendingOpsStore: createPendingOpsStore(storeOpts),
+  };
+}

--- a/packages/sync/material/sqlite/src/auth.ts
+++ b/packages/sync/material/sqlite/src/auth.ts
@@ -7,10 +7,8 @@ import {
 import {
   createCapabilityMaterialStore,
   createOpAuthStore,
-  createPendingOpsStore,
   type SqliteCapabilityMaterialStore,
   type SqliteOpAuthStore,
-  type SqlitePendingOpsStore,
 } from './proof-material/index.js';
 
 export type TreecrdtSqliteAuthBackend = {
@@ -23,7 +21,6 @@ export type TreecrdtSqliteAuthBackend = {
   scopeEvaluator: TreecrdtScopeEvaluator;
   capabilityStore: SqliteCapabilityMaterialStore;
   opAuthStore: SqliteOpAuthStore;
-  pendingOpsStore: SqlitePendingOpsStore;
 };
 
 export function createTreecrdtSqliteAuthBackend(opts: {
@@ -36,6 +33,5 @@ export function createTreecrdtSqliteAuthBackend(opts: {
     scopeEvaluator: createTreecrdtSqliteSubtreeScopeEvaluator(opts.runner),
     capabilityStore: createCapabilityMaterialStore(storeOpts),
     opAuthStore: createOpAuthStore(storeOpts),
-    pendingOpsStore: createPendingOpsStore(storeOpts),
   };
 }

--- a/packages/sync/material/sqlite/src/auth.ts
+++ b/packages/sync/material/sqlite/src/auth.ts
@@ -1,9 +1,13 @@
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import {
   createTreecrdtAuthSession,
+  describeTreecrdtCapabilityTokenV1,
   createTreecrdtSqliteSubtreeScopeEvaluator,
+  type TreecrdtAuthSessionTrust,
   type TreecrdtAuthSession,
   type TreecrdtAuthSessionOptions,
+  type TreecrdtCapabilityRevocationOptions,
+  type TreecrdtCapabilityTokenV1,
   type TreecrdtScopeEvaluator,
 } from '@treecrdt/auth';
 
@@ -47,6 +51,13 @@ export type TreecrdtSqliteAuthSessionOptions = Omit<
   nowMs?: () => number;
 };
 
+export type TreecrdtSqliteClientAuthSessionOptions = Omit<
+  TreecrdtSqliteAuthSessionOptions,
+  'runner' | 'docId'
+> & {
+  docId?: string;
+};
+
 export function createTreecrdtSqliteAuthSession(
   opts: TreecrdtSqliteAuthSessionOptions,
 ): TreecrdtAuthSession {
@@ -59,4 +70,57 @@ export function createTreecrdtSqliteAuthSession(
       nowMs,
     }),
   });
+}
+
+export type TreecrdtSqliteDescribeCapabilityTokenOptions = {
+  tokenBytes: Uint8Array;
+  issuerPublicKeys?: readonly Uint8Array[];
+  trust?: TreecrdtAuthSessionTrust;
+  docId?: string;
+  nowSec?: number;
+} & TreecrdtCapabilityRevocationOptions;
+
+export type TreecrdtSqliteEvaluateScopeOptions = Omit<
+  Parameters<TreecrdtScopeEvaluator>[0],
+  'docId'
+> & {
+  docId?: string;
+};
+
+export type TreecrdtSqliteAuthApi = {
+  createSession: (opts: TreecrdtSqliteClientAuthSessionOptions) => TreecrdtAuthSession;
+  describeCapabilityToken: (
+    opts: TreecrdtSqliteDescribeCapabilityTokenOptions,
+  ) => Promise<TreecrdtCapabilityTokenV1>;
+  evaluateScope: (opts: TreecrdtSqliteEvaluateScopeOptions) => ReturnType<TreecrdtScopeEvaluator>;
+};
+
+export function createTreecrdtSqliteAuthApi(opts: {
+  runner: SqliteRunner;
+  docId: string;
+  nowMs?: () => number;
+}): TreecrdtSqliteAuthApi {
+  const scopeEvaluator = createTreecrdtSqliteSubtreeScopeEvaluator(opts.runner);
+  return {
+    createSession: (sessionOpts) =>
+      createTreecrdtSqliteAuthSession({
+        ...sessionOpts,
+        runner: opts.runner,
+        docId: sessionOpts.docId ?? opts.docId,
+        nowMs: sessionOpts.nowMs ?? opts.nowMs,
+      }),
+    describeCapabilityToken: (describeOpts) =>
+      describeTreecrdtCapabilityTokenV1({
+        ...describeOpts,
+        issuerPublicKeys:
+          describeOpts.trust?.issuerPublicKeys ?? describeOpts.issuerPublicKeys ?? [],
+        docId: describeOpts.docId ?? opts.docId,
+        scopeEvaluator,
+      }),
+    evaluateScope: (scopeOpts) =>
+      scopeEvaluator({
+        ...scopeOpts,
+        docId: scopeOpts.docId ?? opts.docId,
+      }),
+  };
 }

--- a/packages/sync/material/sqlite/src/auth.ts
+++ b/packages/sync/material/sqlite/src/auth.ts
@@ -1,6 +1,9 @@
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import {
+  createTreecrdtAuthSession,
   createTreecrdtSqliteSubtreeScopeEvaluator,
+  type TreecrdtAuthSession,
+  type TreecrdtAuthSessionOptions,
   type TreecrdtScopeEvaluator,
 } from '@treecrdt/auth';
 
@@ -34,4 +37,26 @@ export function createTreecrdtSqliteAuthBackend(opts: {
     capabilityStore: createCapabilityMaterialStore(storeOpts),
     opAuthStore: createOpAuthStore(storeOpts),
   };
+}
+
+export type TreecrdtSqliteAuthSessionOptions = Omit<
+  TreecrdtAuthSessionOptions,
+  'backend' | 'scopeEvaluator' | 'capabilityStore' | 'opAuthStore'
+> & {
+  runner: SqliteRunner;
+  nowMs?: () => number;
+};
+
+export function createTreecrdtSqliteAuthSession(
+  opts: TreecrdtSqliteAuthSessionOptions,
+): TreecrdtAuthSession {
+  const { runner, nowMs, ...sessionOpts } = opts;
+  return createTreecrdtAuthSession({
+    ...sessionOpts,
+    backend: createTreecrdtSqliteAuthBackend({
+      runner,
+      docId: sessionOpts.docId,
+      nowMs,
+    }),
+  });
 }

--- a/packages/sync/material/sqlite/src/diagnostics.ts
+++ b/packages/sync/material/sqlite/src/diagnostics.ts
@@ -1,0 +1,36 @@
+import type { Operation } from '@treecrdt/interface';
+import type { SqliteRunner } from '@treecrdt/interface/sqlite';
+import type { PendingOp } from '@treecrdt/sync';
+
+import { createPendingOpsStore } from './proof-material/index.js';
+
+export type TreecrdtSqliteSyncDiagnostics = {
+  /**
+   * Lists ops that sync has persisted for retry after missing auth/subtree context is resolved.
+   *
+   * This is diagnostics/sync state, not part of the auth session inputs.
+   */
+  listPendingOps: () => Promise<Array<PendingOp<Operation>>>;
+};
+
+export function createTreecrdtSqliteSyncDiagnostics(opts: {
+  runner: SqliteRunner;
+  docId: string;
+  nowMs?: () => number;
+}): TreecrdtSqliteSyncDiagnostics {
+  const pendingOpsStore = createPendingOpsStore(opts);
+  let ready = false;
+
+  const ensureReady = async () => {
+    if (ready) return;
+    await pendingOpsStore.init();
+    ready = true;
+  };
+
+  return {
+    listPendingOps: async () => {
+      await ensureReady();
+      return pendingOpsStore.listPendingOps();
+    },
+  };
+}

--- a/packages/sync/material/sqlite/src/index.ts
+++ b/packages/sync/material/sqlite/src/index.ts
@@ -1,3 +1,4 @@
 export * from './auth.js';
 export * from './backend.js';
+export * from './diagnostics.js';
 export * from './proof-material/index.js';

--- a/packages/sync/material/sqlite/src/index.ts
+++ b/packages/sync/material/sqlite/src/index.ts
@@ -1,2 +1,3 @@
+export * from './auth.js';
 export * from './backend.js';
 export * from './proof-material/index.js';

--- a/packages/sync/material/sqlite/src/proof-material/sqlite.ts
+++ b/packages/sync/material/sqlite/src/proof-material/sqlite.ts
@@ -288,7 +288,7 @@ FROM (
   SELECT json_object('name', name, 'value', value) AS obj
   FROM treecrdt_sync_capability
   WHERE doc_id = ?1
-  ORDER BY created_at_ms ASC, name ASC, value ASC
+  ORDER BY name ASC, value ASC
 )
 `;
 

--- a/packages/sync/material/sqlite/tests/proof-material.test.ts
+++ b/packages/sync/material/sqlite/tests/proof-material.test.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { expect, test } from 'vitest';
 import { defineProofMaterialStoreContract } from '../../protocol/tests/helpers/proof-material-contract.ts';
 import { definePendingProofMaterialStoreContract } from '../../protocol/tests/helpers/pending-proof-material-contract.ts';
 import { defineReplayOnlyAuthStoreContract } from '../../protocol/tests/helpers/replay-only-auth-contract.ts';
@@ -8,6 +9,7 @@ import {
   createCapabilityMaterialStore,
   createOpAuthStore,
   createPendingOpsStore,
+  createTreecrdtSqliteAuthBackend,
 } from '../dist/index.js';
 
 function createRunner(db: Database.Database): SqliteRunner {
@@ -32,6 +34,30 @@ function createRunner(db: Database.Database): SqliteRunner {
     },
   };
 }
+
+test('sqlite auth backend helper bundles scope evaluator and auth stores', async () => {
+  const db = new Database(':memory:');
+  const runner = createRunner(db);
+
+  try {
+    const backend = createTreecrdtSqliteAuthBackend({ runner, docId: 'doc-auth-helper' });
+    expect(typeof backend.scopeEvaluator).toBe('function');
+
+    await backend.capabilityStore.init();
+    await backend.opAuthStore.init();
+    await backend.pendingOpsStore.init();
+
+    await backend.capabilityStore.storeCapabilities([
+      { name: 'auth.capability', value: 'token-a' },
+    ]);
+    await expect(backend.capabilityStore.listCapabilities()).resolves.toEqual([
+      { name: 'auth.capability', value: 'token-a' },
+    ]);
+    await expect(backend.pendingOpsStore.listPendingOps()).resolves.toEqual([]);
+  } finally {
+    db.close();
+  }
+});
 
 defineProofMaterialStoreContract('sqlite proof material stores', async () => {
   const db = new Database(':memory:');

--- a/packages/sync/material/sqlite/tests/proof-material.test.ts
+++ b/packages/sync/material/sqlite/tests/proof-material.test.ts
@@ -10,6 +10,7 @@ import {
   createOpAuthStore,
   createPendingOpsStore,
   createTreecrdtSqliteAuthBackend,
+  createTreecrdtSqliteSyncDiagnostics,
 } from '../dist/index.js';
 
 function createRunner(db: Database.Database): SqliteRunner {
@@ -42,10 +43,10 @@ test('sqlite auth backend helper bundles scope evaluator and auth stores', async
   try {
     const backend = createTreecrdtSqliteAuthBackend({ runner, docId: 'doc-auth-helper' });
     expect(typeof backend.scopeEvaluator).toBe('function');
+    expect('pendingOpsStore' in backend).toBe(false);
 
     await backend.capabilityStore.init();
     await backend.opAuthStore.init();
-    await backend.pendingOpsStore.init();
 
     await backend.capabilityStore.storeCapabilities([
       { name: 'auth.capability', value: 'token-a' },
@@ -53,7 +54,21 @@ test('sqlite auth backend helper bundles scope evaluator and auth stores', async
     await expect(backend.capabilityStore.listCapabilities()).resolves.toEqual([
       { name: 'auth.capability', value: 'token-a' },
     ]);
-    await expect(backend.pendingOpsStore.listPendingOps()).resolves.toEqual([]);
+  } finally {
+    db.close();
+  }
+});
+
+test('sqlite sync diagnostics lists pending ops without exposing the raw store', async () => {
+  const db = new Database(':memory:');
+  const runner = createRunner(db);
+
+  try {
+    const diagnostics = createTreecrdtSqliteSyncDiagnostics({
+      runner,
+      docId: 'doc-diagnostics',
+    });
+    await expect(diagnostics.listPendingOps()).resolves.toEqual([]);
   } finally {
     db.close();
   }

--- a/packages/sync/material/sqlite/tests/proof-material.test.ts
+++ b/packages/sync/material/sqlite/tests/proof-material.test.ts
@@ -10,8 +10,13 @@ import {
   createOpAuthStore,
   createPendingOpsStore,
   createTreecrdtSqliteAuthBackend,
+  createTreecrdtSqliteAuthSession,
   createTreecrdtSqliteSyncDiagnostics,
 } from '../dist/index.js';
+
+function testKey(byte: number): Uint8Array {
+  return new Uint8Array(32).fill(byte);
+}
 
 function createRunner(db: Database.Database): SqliteRunner {
   const toBindings = (params: unknown[]) =>
@@ -54,6 +59,26 @@ test('sqlite auth backend helper bundles scope evaluator and auth stores', async
     await expect(backend.capabilityStore.listCapabilities()).resolves.toEqual([
       { name: 'auth.capability', value: 'token-a' },
     ]);
+  } finally {
+    db.close();
+  }
+});
+
+test('sqlite auth session helper wires the backend automatically', async () => {
+  const db = new Database(':memory:');
+  const runner = createRunner(db);
+
+  try {
+    const session = createTreecrdtSqliteAuthSession({
+      runner,
+      docId: 'doc-auth-session-helper',
+      issuerPublicKeys: [],
+      localPrivateKey: testKey(4),
+      localPublicKey: testKey(5),
+      allowUnsigned: true,
+    });
+    await session.ready;
+    expect(session.getState().status).toBe('ready');
   } finally {
     db.close();
   }

--- a/packages/sync/material/sqlite/tests/proof-material.test.ts
+++ b/packages/sync/material/sqlite/tests/proof-material.test.ts
@@ -9,6 +9,7 @@ import {
   createCapabilityMaterialStore,
   createOpAuthStore,
   createPendingOpsStore,
+  createTreecrdtSqliteAuthApi,
   createTreecrdtSqliteAuthBackend,
   createTreecrdtSqliteAuthSession,
   createTreecrdtSqliteSyncDiagnostics,
@@ -72,11 +73,38 @@ test('sqlite auth session helper wires the backend automatically', async () => {
     const session = createTreecrdtSqliteAuthSession({
       runner,
       docId: 'doc-auth-session-helper',
-      issuerPublicKeys: [],
-      localPrivateKey: testKey(4),
-      localPublicKey: testKey(5),
+      trust: { issuerPublicKeys: [] },
+      local: {
+        privateKey: testKey(4),
+        publicKey: testKey(5),
+      },
       allowUnsigned: true,
     });
+    await session.ready;
+    expect(session.getState().status).toBe('ready');
+  } finally {
+    db.close();
+  }
+});
+
+test('sqlite client auth api hides runner wiring', async () => {
+  const db = new Database(':memory:');
+  const runner = createRunner(db);
+
+  try {
+    const auth = createTreecrdtSqliteAuthApi({
+      runner,
+      docId: 'doc-client-auth-api',
+    });
+    const session = auth.createSession({
+      trust: { issuerPublicKeys: [] },
+      local: {
+        privateKey: testKey(4),
+        publicKey: testKey(5),
+      },
+      allowUnsigned: true,
+    });
+
     await session.ready;
     expect(session.getState().status).toBe('ready');
   } finally {

--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -17,20 +17,52 @@ export type TreecrdtAuthSessionState =
   | { status: 'ready' }
   | { status: 'error'; error: unknown };
 
-export type TreecrdtAuthSessionOptions = Omit<TreecrdtCoseCwtAuthOptions, 'localIdentityChain'> & {
-  /** Doc used to warm local auth material before the session is handed to sync. */
-  docId: string;
+export type TreecrdtAuthSessionBackend = Pick<
+  TreecrdtCoseCwtAuthOptions,
+  'scopeEvaluator' | 'capabilityStore' | 'opAuthStore'
+>;
+
+export type TreecrdtAuthSessionIdentity = {
   /**
    * Optional local identity chain, or provider for apps that create it lazily.
    *
    * Provider failures are intentionally best-effort: identity disclosure should not prevent
    * signed capability auth from becoming ready.
    */
+  local?:
+    | TreecrdtIdentityChainV1
+    | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
+  onLocalError?: (error: unknown) => void;
+  onPeer?: TreecrdtCoseCwtAuthOptions['onPeerIdentityChain'];
+};
+
+type LegacyTreecrdtAuthSessionOptions = Pick<
+  TreecrdtCoseCwtAuthOptions,
+  'scopeEvaluator' | 'capabilityStore' | 'opAuthStore' | 'onPeerIdentityChain'
+> & {
+  /** Prefer `identity.local`; kept so existing callers do not need to migrate immediately. */
   localIdentityChain?:
     | TreecrdtIdentityChainV1
     | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
+  /** Prefer `identity.onLocalError`; kept so existing callers do not need to migrate immediately. */
   onIdentityChainError?: (error: unknown) => void;
 };
+
+export type TreecrdtAuthSessionOptions = Omit<
+  TreecrdtCoseCwtAuthOptions,
+  | 'localIdentityChain'
+  | 'scopeEvaluator'
+  | 'capabilityStore'
+  | 'opAuthStore'
+  | 'onPeerIdentityChain'
+> &
+  LegacyTreecrdtAuthSessionOptions & {
+    /** Doc used to warm local auth material before the session is handed to sync. */
+    docId: string;
+    /** Backend-owned auth dependencies, e.g. subtree scope checks and proof-material stores. */
+    backend?: TreecrdtAuthSessionBackend;
+    identity?: TreecrdtAuthSessionIdentity;
+  };
 
 export type TreecrdtAuthSession = {
   syncAuth: SyncAuth<Operation>;
@@ -46,18 +78,40 @@ export type TreecrdtAuthSession = {
  * awaiting `ready` before passing it into sync startup, avoiding per-app warmup wrappers.
  */
 export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): TreecrdtAuthSession {
-  const { docId, localIdentityChain, onIdentityChainError, ...authOpts } = opts;
+  const {
+    docId,
+    backend,
+    identity,
+    localIdentityChain,
+    onIdentityChainError,
+    scopeEvaluator,
+    capabilityStore,
+    opAuthStore,
+    onPeerIdentityChain,
+    ...authOptsBase
+  } = opts;
+  const authOpts: TreecrdtCoseCwtAuthOptions = {
+    ...authOptsBase,
+    scopeEvaluator: backend?.scopeEvaluator ?? scopeEvaluator,
+    capabilityStore: backend?.capabilityStore ?? capabilityStore,
+    opAuthStore: backend?.opAuthStore ?? opAuthStore,
+    onPeerIdentityChain: identity?.onPeer ?? onPeerIdentityChain,
+  };
+  const resolvedLocalIdentityChain = identity?.local ?? localIdentityChain;
+  const resolvedOnIdentityChainError = identity?.onLocalError ?? onIdentityChainError;
   const baseAuth = createTreecrdtCoseCwtAuth(authOpts);
   let state: TreecrdtAuthSessionState = { status: 'loading' };
 
   const localIdentityCapability = async () => {
-    if (!localIdentityChain) return null;
+    if (!resolvedLocalIdentityChain) return null;
     try {
       const chain =
-        typeof localIdentityChain === 'function' ? await localIdentityChain() : localIdentityChain;
+        typeof resolvedLocalIdentityChain === 'function'
+          ? await resolvedLocalIdentityChain()
+          : resolvedLocalIdentityChain;
       return chain ? createTreecrdtIdentityChainCapabilityV1(chain) : null;
     } catch (err) {
-      onIdentityChainError?.(err);
+      resolvedOnIdentityChainError?.(err);
       return null;
     }
   };

--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -1,5 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
-import type { Capability, SyncAuth } from '@treecrdt/sync';
+import type { Capability, OpAuth, SyncAuth, SyncAuthOpsContext } from '@treecrdt/sync';
 
 import {
   createTreecrdtIdentityChainCapabilityV1,
@@ -36,17 +36,40 @@ export type TreecrdtAuthSessionIdentity = {
   onPeer?: TreecrdtCoseCwtAuthOptions['onPeerIdentityChain'];
 };
 
+export type TreecrdtAuthSessionTrust = {
+  issuerPublicKeys: Uint8Array[];
+};
+
+export type TreecrdtAuthSessionLocal = {
+  privateKey: Uint8Array;
+  publicKey: Uint8Array;
+  capabilityTokens?: Uint8Array[];
+  revocationRecords?: Uint8Array[];
+};
+
+export type TreecrdtAuthSessionLocalAuthorizeOptions = Partial<SyncAuthOpsContext>;
+
 type LegacyTreecrdtAuthSessionOptions = Pick<
   TreecrdtCoseCwtAuthOptions,
   'scopeEvaluator' | 'capabilityStore' | 'opAuthStore' | 'onPeerIdentityChain'
-> & {
-  /** Prefer `identity.local`; kept so existing callers do not need to migrate immediately. */
-  localIdentityChain?:
-    | TreecrdtIdentityChainV1
-    | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
-  /** Prefer `identity.onLocalError`; kept so existing callers do not need to migrate immediately. */
-  onIdentityChainError?: (error: unknown) => void;
-};
+> &
+  Partial<
+    Pick<
+      TreecrdtCoseCwtAuthOptions,
+      | 'issuerPublicKeys'
+      | 'localPrivateKey'
+      | 'localPublicKey'
+      | 'localCapabilityTokens'
+      | 'localRevocationRecords'
+    >
+  > & {
+    /** Prefer `identity.local`; kept so existing callers do not need to migrate immediately. */
+    localIdentityChain?:
+      | TreecrdtIdentityChainV1
+      | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
+    /** Prefer `identity.onLocalError`; kept so existing callers do not need to migrate immediately. */
+    onIdentityChainError?: (error: unknown) => void;
+  };
 
 export type TreecrdtAuthSessionOptions = Omit<
   TreecrdtCoseCwtAuthOptions,
@@ -55,6 +78,11 @@ export type TreecrdtAuthSessionOptions = Omit<
   | 'capabilityStore'
   | 'opAuthStore'
   | 'onPeerIdentityChain'
+  | 'issuerPublicKeys'
+  | 'localPrivateKey'
+  | 'localPublicKey'
+  | 'localCapabilityTokens'
+  | 'localRevocationRecords'
 > &
   LegacyTreecrdtAuthSessionOptions & {
     /** Doc used to warm local auth material before the session is handed to sync. */
@@ -62,6 +90,8 @@ export type TreecrdtAuthSessionOptions = Omit<
     /** Backend-owned auth dependencies, e.g. subtree scope checks and proof-material stores. */
     backend?: TreecrdtAuthSessionBackend;
     identity?: TreecrdtAuthSessionIdentity;
+    trust?: TreecrdtAuthSessionTrust;
+    local?: TreecrdtAuthSessionLocal;
   };
 
 export type TreecrdtAuthSession = {
@@ -69,6 +99,10 @@ export type TreecrdtAuthSession = {
   readonly ready: Promise<SyncAuth<Operation>>;
   getState: () => TreecrdtAuthSessionState;
   refresh: () => Promise<SyncAuth<Operation>>;
+  authorizeLocalOps: (
+    ops: readonly Operation[],
+    opts?: TreecrdtAuthSessionLocalAuthorizeOptions,
+  ) => Promise<OpAuth[]>;
 };
 
 /**
@@ -82,16 +116,35 @@ export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): Tre
     docId,
     backend,
     identity,
+    trust,
+    local,
     localIdentityChain,
     onIdentityChainError,
     scopeEvaluator,
     capabilityStore,
     opAuthStore,
     onPeerIdentityChain,
+    issuerPublicKeys,
+    localPrivateKey,
+    localPublicKey,
+    localCapabilityTokens,
+    localRevocationRecords,
     ...authOptsBase
   } = opts;
+  const resolvedIssuerPublicKeys = trust?.issuerPublicKeys ?? issuerPublicKeys;
+  const resolvedLocalPrivateKey = local?.privateKey ?? localPrivateKey;
+  const resolvedLocalPublicKey = local?.publicKey ?? localPublicKey;
+  if (!resolvedIssuerPublicKeys) throw new Error('auth session requires trust.issuerPublicKeys');
+  if (!resolvedLocalPrivateKey) throw new Error('auth session requires local.privateKey');
+  if (!resolvedLocalPublicKey) throw new Error('auth session requires local.publicKey');
+
   const authOpts: TreecrdtCoseCwtAuthOptions = {
     ...authOptsBase,
+    issuerPublicKeys: resolvedIssuerPublicKeys,
+    localPrivateKey: resolvedLocalPrivateKey,
+    localPublicKey: resolvedLocalPublicKey,
+    localCapabilityTokens: local?.capabilityTokens ?? localCapabilityTokens,
+    localRevocationRecords: local?.revocationRecords ?? localRevocationRecords,
     scopeEvaluator: backend?.scopeEvaluator ?? scopeEvaluator,
     capabilityStore: backend?.capabilityStore ?? capabilityStore,
     opAuthStore: backend?.opAuthStore ?? opAuthStore,
@@ -143,6 +196,38 @@ export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): Tre
 
   let ready = warm();
 
+  const authorizeLocalOps: TreecrdtAuthSession['authorizeLocalOps'] = async (
+    ops,
+    ctxOverrides = {},
+  ) => {
+    if (ops.length === 0) return [];
+    if (!syncAuth.signOps || !syncAuth.verifyOps) {
+      throw new Error('auth session is missing local op signing/verification hooks');
+    }
+    const ctx: SyncAuthOpsContext = {
+      docId,
+      purpose: 'reconcile',
+      filterId: '__local__',
+      ...ctxOverrides,
+    };
+    const auth = await syncAuth.signOps(ops, ctx);
+    if (auth.length !== ops.length) {
+      throw new Error(`signOps returned ${auth.length} entries for ${ops.length} ops`);
+    }
+    const res = await syncAuth.verifyOps(ops, auth, ctx);
+    const dispositions = res?.dispositions;
+    if (dispositions && dispositions.length !== ops.length) {
+      throw new Error(
+        `verifyOps returned ${dispositions.length} dispositions for ${ops.length} ops`,
+      );
+    }
+    const rejected = dispositions?.find((d) => d.status !== 'allow');
+    if (rejected?.status === 'pending_context') {
+      throw new Error(rejected.message ?? 'missing subtree context to authorize op');
+    }
+    return auth;
+  };
+
   return {
     syncAuth,
     get ready() {
@@ -153,5 +238,6 @@ export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): Tre
       ready = warm();
       return ready;
     },
+    authorizeLocalOps,
   };
 }

--- a/packages/treecrdt-auth/tests/session.test.ts
+++ b/packages/treecrdt-auth/tests/session.test.ts
@@ -55,9 +55,11 @@ test('auth session accepts grouped backend and identity options', async () => {
   let listedCapabilities = 0;
   const session = createTreecrdtAuthSession({
     docId: 'doc-auth-session-grouped',
-    issuerPublicKeys: [],
-    localPrivateKey: testKey(4),
-    localPublicKey: testKey(5),
+    trust: { issuerPublicKeys: [] },
+    local: {
+      privateKey: testKey(4),
+      publicKey: testKey(5),
+    },
     allowUnsigned: true,
     backend: {
       scopeEvaluator: async () => 'deny',

--- a/packages/treecrdt-auth/tests/session.test.ts
+++ b/packages/treecrdt-auth/tests/session.test.ts
@@ -51,6 +51,45 @@ test('auth session advertises async local identity chain without app-side wrappe
   expect(caps.some((cap) => cap.name === TREECRDT_IDENTITY_CHAIN_CAPABILITY)).toBe(true);
 });
 
+test('auth session accepts grouped backend and identity options', async () => {
+  let listedCapabilities = 0;
+  const session = createTreecrdtAuthSession({
+    docId: 'doc-auth-session-grouped',
+    issuerPublicKeys: [],
+    localPrivateKey: testKey(4),
+    localPublicKey: testKey(5),
+    allowUnsigned: true,
+    backend: {
+      scopeEvaluator: async () => 'deny',
+      capabilityStore: {
+        listCapabilities: async () => {
+          listedCapabilities += 1;
+          return [];
+        },
+        storeCapabilities: async () => {},
+      },
+      opAuthStore: {
+        storeOpAuth: async () => {},
+        getOpAuthByOpRefs: async (opRefs) => opRefs.map(() => null),
+      },
+    },
+    identity: {
+      local: async () => testIdentityChain(),
+      onPeer: () => undefined,
+    },
+  });
+
+  await session.ready;
+  expect(listedCapabilities).toBeGreaterThan(0);
+
+  const caps =
+    (await session.syncAuth.helloCapabilities?.({
+      docId: 'doc-auth-session-grouped',
+    })) ?? [];
+
+  expect(caps.some((cap) => cap.name === TREECRDT_IDENTITY_CHAIN_CAPABILITY)).toBe(true);
+});
+
 test('auth session treats identity chain provider failures as best-effort', async () => {
   const errors: unknown[] = [];
   const session = createTreecrdtAuthSession({

--- a/packages/treecrdt-sqlite-node/package.json
+++ b/packages/treecrdt-sqlite-node/package.json
@@ -24,7 +24,8 @@
     "better-sqlite3": "^9.0.0"
   },
   "dependencies": {
-    "@treecrdt/interface": "workspace:*"
+    "@treecrdt/interface": "workspace:*",
+    "@treecrdt/sync-sqlite": "workspace:*"
   },
   "devDependencies": {
     "@noble/ed25519": "^3.0.0",
@@ -36,7 +37,6 @@
     "@treecrdt/postgres-napi": "workspace:*",
     "@treecrdt/engine-conformance": "workspace:*",
     "@treecrdt/sync": "workspace:*",
-    "@treecrdt/sync-sqlite": "workspace:*",
     "@treecrdt/sync-server-postgres-node": "workspace:*",
     "better-sqlite3": "^9.0.0",
     "cborg": "^4.3.2",

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -21,7 +21,10 @@ import {
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
-import { createTreecrdtSqliteAuthApi, type TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite';
+import {
+  createTreecrdtSqliteAuthApi,
+  type TreecrdtSqliteAuthApi,
+} from '@treecrdt/sync-sqlite/auth';
 
 export type LoadOptions = {
   extensionPath?: string;

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -21,6 +21,7 @@ import {
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import { createTreecrdtSqliteAuthApi, type TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite';
 
 export type LoadOptions = {
   extensionPath?: string;
@@ -119,7 +120,7 @@ export function createSqliteNodeApi(db: any, opts: { maxBulkOps?: number } = {})
 export function createTreecrdtClient(
   db: any,
   opts: { docId?: string; maxBulkOps?: number } = {},
-): Promise<TreecrdtEngine & { runner: SqliteRunner }> {
+): Promise<TreecrdtEngine & { runner: SqliteRunner; auth: TreecrdtSqliteAuthApi }> {
   const runner = createRunner(db);
   const materialized = createMaterializationDispatcher();
   const adapter = createTreecrdtSqliteAdapter(runner, {
@@ -222,6 +223,7 @@ export function createTreecrdtClient(
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
+    auth: createTreecrdtSqliteAuthApi({ runner, docId }),
     local: {
       insert: localInsertImpl,
       move: localMoveImpl,

--- a/packages/treecrdt-wa-sqlite/e2e/tests/bench-opfs.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/bench-opfs.spec.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 import { repoRootFromImportMeta, writeResult } from '@treecrdt/benchmark/node';
 import type { BenchResult } from '../src/bench.js';
 
+test.skip(!!process.env.CI, 'Raw browser benchmarks run in the benchmark workflow.');
+
 test('wa-sqlite OPFS benchmarks', async ({ page }) => {
   test.setTimeout(180_000);
   page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));

--- a/packages/treecrdt-wa-sqlite/e2e/tests/bench-sync.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/bench-sync.spec.ts
@@ -9,6 +9,8 @@ import {
 import { repoRootFromImportMeta, writeResult } from '@treecrdt/benchmark/node';
 import type { SyncBenchResult } from '../src/sync.js';
 
+test.skip(!!process.env.CI, 'Raw browser benchmarks run in the benchmark workflow.');
+
 test('wa-sqlite sync OPFS benchmarks', async ({ page }) => {
   test.setTimeout(600_000);
   page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));

--- a/packages/treecrdt-wa-sqlite/package.json
+++ b/packages/treecrdt-wa-sqlite/package.json
@@ -40,7 +40,8 @@
     "postinstall": "pnpm run prep:opfs"
   },
   "dependencies": {
-    "@treecrdt/interface": "workspace:*"
+    "@treecrdt/interface": "workspace:*",
+    "@treecrdt/sync-sqlite": "workspace:*"
   },
   "devDependencies": {
     "@treecrdt/wa-sqlite-vendor": "workspace:*",

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -20,10 +20,7 @@ import {
 } from '@treecrdt/interface/ids';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
-import {
-  createTreecrdtSqliteAuthApi,
-  type TreecrdtSqliteAuthApi,
-} from '@treecrdt/sync-sqlite/auth';
+import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
 import type {
@@ -45,8 +42,20 @@ export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
   storage: StorageMode;
   runner: SqliteRunner;
-  auth: TreecrdtSqliteAuthApi;
+  auth: TreecrdtClientAuthApi;
   drop: () => Promise<void>;
+};
+
+type TreecrdtSqliteAuthModule = typeof import('@treecrdt/sync-sqlite/auth');
+
+export type TreecrdtClientAuthApi = {
+  createSession: (
+    ...args: Parameters<TreecrdtSqliteAuthApi['createSession']>
+  ) => Promise<ReturnType<TreecrdtSqliteAuthApi['createSession']>>;
+  describeCapabilityToken: TreecrdtSqliteAuthApi['describeCapabilityToken'];
+  evaluateScope: (
+    ...args: Parameters<TreecrdtSqliteAuthApi['evaluateScope']>
+  ) => Promise<Awaited<ReturnType<TreecrdtSqliteAuthApi['evaluateScope']>>>;
 };
 
 export type ClientOptions = {
@@ -110,6 +119,32 @@ type WorkerProxy = {
 };
 
 type RpcCall = <M extends RpcMethod>(method: M, params: RpcParams<M>) => Promise<RpcResult<M>>;
+
+let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
+
+function loadSqliteAuthModule(): Promise<TreecrdtSqliteAuthModule> {
+  // Auth is an opt-in capability path for browser clients. Apps that only open
+  // local trees do not need auth sessions or proof material until they call client.auth.*.
+  sqliteAuthModulePromise ??= import('@treecrdt/sync-sqlite/auth');
+  return sqliteAuthModulePromise;
+}
+
+function createLazyAuthApi(opts: { runner: SqliteRunner; docId: string }): TreecrdtClientAuthApi {
+  let authApiPromise: Promise<TreecrdtSqliteAuthApi> | null = null;
+  const getAuthApi = () => {
+    authApiPromise ??= loadSqliteAuthModule().then(({ createTreecrdtSqliteAuthApi }) =>
+      createTreecrdtSqliteAuthApi(opts),
+    );
+    return authApiPromise;
+  };
+
+  return {
+    createSession: async (...args) => (await getAuthApi()).createSession(...args),
+    describeCapabilityToken: async (...args) =>
+      (await getAuthApi()).describeCapabilityToken(...args),
+    evaluateScope: async (...args) => await (await getAuthApi()).evaluateScope(...args),
+  };
+}
 
 async function createWorkerClient(opts: {
   baseUrl: string;
@@ -565,7 +600,7 @@ function makeTreecrdtClientFromCall(opts: {
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
-    auth: createTreecrdtSqliteAuthApi({ runner, docId: opts.docId }),
+    auth: createLazyAuthApi({ runner, docId: opts.docId }),
     local: {
       insert: localInsertImpl,
       move: localMoveImpl,

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -20,7 +20,10 @@ import {
 } from '@treecrdt/interface/ids';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
-import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
+import {
+  createTreecrdtSqliteAuthApi,
+  type TreecrdtSqliteAuthApi,
+} from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
 import type {
@@ -42,20 +45,8 @@ export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
   storage: StorageMode;
   runner: SqliteRunner;
-  auth: TreecrdtClientAuthApi;
+  auth: TreecrdtSqliteAuthApi;
   drop: () => Promise<void>;
-};
-
-type TreecrdtSqliteAuthModule = typeof import('@treecrdt/sync-sqlite/auth');
-
-export type TreecrdtClientAuthApi = {
-  createSession: (
-    ...args: Parameters<TreecrdtSqliteAuthApi['createSession']>
-  ) => Promise<ReturnType<TreecrdtSqliteAuthApi['createSession']>>;
-  describeCapabilityToken: TreecrdtSqliteAuthApi['describeCapabilityToken'];
-  evaluateScope: (
-    ...args: Parameters<TreecrdtSqliteAuthApi['evaluateScope']>
-  ) => Promise<Awaited<ReturnType<TreecrdtSqliteAuthApi['evaluateScope']>>>;
 };
 
 export type ClientOptions = {
@@ -119,32 +110,6 @@ type WorkerProxy = {
 };
 
 type RpcCall = <M extends RpcMethod>(method: M, params: RpcParams<M>) => Promise<RpcResult<M>>;
-
-let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
-
-function loadSqliteAuthModule(): Promise<TreecrdtSqliteAuthModule> {
-  // Browser clients should not pay the auth/crypto/proof-material bundle cost unless auth is used.
-  // Dynamic import splits that code into a separate chunk, so wa-sqlite auth calls are async.
-  sqliteAuthModulePromise ??= import('@treecrdt/sync-sqlite/auth');
-  return sqliteAuthModulePromise;
-}
-
-function createLazyAuthApi(opts: { runner: SqliteRunner; docId: string }): TreecrdtClientAuthApi {
-  let authApiPromise: Promise<TreecrdtSqliteAuthApi> | null = null;
-  const getAuthApi = () => {
-    authApiPromise ??= loadSqliteAuthModule().then(({ createTreecrdtSqliteAuthApi }) =>
-      createTreecrdtSqliteAuthApi(opts),
-    );
-    return authApiPromise;
-  };
-
-  return {
-    createSession: async (...args) => (await getAuthApi()).createSession(...args),
-    describeCapabilityToken: async (...args) =>
-      (await getAuthApi()).describeCapabilityToken(...args),
-    evaluateScope: async (...args) => await (await getAuthApi()).evaluateScope(...args),
-  };
-}
 
 async function createWorkerClient(opts: {
   baseUrl: string;
@@ -600,7 +565,7 @@ function makeTreecrdtClientFromCall(opts: {
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
-    auth: createLazyAuthApi({ runner, docId: opts.docId }),
+    auth: createTreecrdtSqliteAuthApi({ runner, docId: opts.docId }),
     local: {
       insert: localInsertImpl,
       move: localMoveImpl,

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -20,7 +20,7 @@ import {
 } from '@treecrdt/interface/ids';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
-import { createTreecrdtSqliteAuthApi, type TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite';
+import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
 import type {
@@ -42,8 +42,20 @@ export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
   storage: StorageMode;
   runner: SqliteRunner;
-  auth: TreecrdtSqliteAuthApi;
+  auth: TreecrdtClientAuthApi;
   drop: () => Promise<void>;
+};
+
+type TreecrdtSqliteAuthModule = typeof import('@treecrdt/sync-sqlite/auth');
+
+export type TreecrdtClientAuthApi = {
+  createSession: (
+    ...args: Parameters<TreecrdtSqliteAuthApi['createSession']>
+  ) => Promise<ReturnType<TreecrdtSqliteAuthApi['createSession']>>;
+  describeCapabilityToken: TreecrdtSqliteAuthApi['describeCapabilityToken'];
+  evaluateScope: (
+    ...args: Parameters<TreecrdtSqliteAuthApi['evaluateScope']>
+  ) => Promise<Awaited<ReturnType<TreecrdtSqliteAuthApi['evaluateScope']>>>;
 };
 
 export type ClientOptions = {
@@ -107,6 +119,30 @@ type WorkerProxy = {
 };
 
 type RpcCall = <M extends RpcMethod>(method: M, params: RpcParams<M>) => Promise<RpcResult<M>>;
+
+let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
+
+function loadSqliteAuthModule(): Promise<TreecrdtSqliteAuthModule> {
+  sqliteAuthModulePromise ??= import('@treecrdt/sync-sqlite/auth');
+  return sqliteAuthModulePromise;
+}
+
+function createLazyAuthApi(opts: { runner: SqliteRunner; docId: string }): TreecrdtClientAuthApi {
+  let authApiPromise: Promise<TreecrdtSqliteAuthApi> | null = null;
+  const getAuthApi = () => {
+    authApiPromise ??= loadSqliteAuthModule().then(({ createTreecrdtSqliteAuthApi }) =>
+      createTreecrdtSqliteAuthApi(opts),
+    );
+    return authApiPromise;
+  };
+
+  return {
+    createSession: async (...args) => (await getAuthApi()).createSession(...args),
+    describeCapabilityToken: async (...args) =>
+      (await getAuthApi()).describeCapabilityToken(...args),
+    evaluateScope: async (...args) => await (await getAuthApi()).evaluateScope(...args),
+  };
+}
 
 async function createWorkerClient(opts: {
   baseUrl: string;
@@ -562,7 +598,7 @@ function makeTreecrdtClientFromCall(opts: {
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
-    auth: createTreecrdtSqliteAuthApi({ runner, docId: opts.docId }),
+    auth: createLazyAuthApi({ runner, docId: opts.docId }),
     local: {
       insert: localInsertImpl,
       move: localMoveImpl,

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -20,6 +20,7 @@ import {
 } from '@treecrdt/interface/ids';
 import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import { createTreecrdtSqliteAuthApi, type TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
 import type {
@@ -41,6 +42,7 @@ export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
   storage: StorageMode;
   runner: SqliteRunner;
+  auth: TreecrdtSqliteAuthApi;
   drop: () => Promise<void>;
 };
 
@@ -560,6 +562,7 @@ function makeTreecrdtClientFromCall(opts: {
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
+    auth: createTreecrdtSqliteAuthApi({ runner, docId: opts.docId }),
     local: {
       insert: localInsertImpl,
       move: localMoveImpl,

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -123,6 +123,8 @@ type RpcCall = <M extends RpcMethod>(method: M, params: RpcParams<M>) => Promise
 let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
 
 function loadSqliteAuthModule(): Promise<TreecrdtSqliteAuthModule> {
+  // Browser clients should not pay the auth/crypto/proof-material bundle cost unless auth is used.
+  // Dynamic import splits that code into a separate chunk, so wa-sqlite auth calls are async.
   sqliteAuthModulePromise ??= import('@treecrdt/sync-sqlite/auth');
   return sqliteAuthModulePromise;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       '@treecrdt/interface':
         specifier: workspace:*
         version: link:../treecrdt-ts
+      '@treecrdt/sync-sqlite':
+        specifier: workspace:*
+        version: link:../sync/material/sqlite
     devDependencies:
       '@noble/ed25519':
         specifier: ^3.0.0
@@ -414,9 +417,6 @@ importers:
       '@treecrdt/sync-server-postgres-node':
         specifier: workspace:*
         version: link:../sync/server/postgres-node
-      '@treecrdt/sync-sqlite':
-        specifier: workspace:*
-        version: link:../sync/material/sqlite
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
@@ -456,6 +456,9 @@ importers:
       '@treecrdt/interface':
         specifier: workspace:*
         version: link:../treecrdt-ts
+      '@treecrdt/sync-sqlite':
+        specifier: workspace:*
+        version: link:../sync/material/sqlite
     devDependencies:
       '@treecrdt/benchmark':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
 
   packages/sync/material/sqlite:
     dependencies:
+      '@treecrdt/auth':
+        specifier: workspace:*
+        version: link:../../../treecrdt-auth
       '@treecrdt/interface':
         specifier: workspace:*
         version: link:../../../treecrdt-ts


### PR DESCRIPTION
## Summary

- Adds a `client.auth` facade to sqlite-node and wa-sqlite clients, backed by shared `@treecrdt/sync-sqlite` auth helpers.
- Adds SQLite auth session helpers around `createTreecrdtAuthSession`, including grouped `trust`, `local`, `backend`, and `identity` options while preserving legacy flat options.
- Updates the playground auth hook to use `client.auth.createSession`, `client.auth.describeCapabilityToken`, `client.auth.evaluateScope`, and `session.authorizeLocalOps(ops)` instead of manually wiring runner/backend helpers.
- Treats browser auth as an opt-in capability path: wa-sqlite creates the auth facade on first `client.auth.*` call, while sqlite-node keeps synchronous auth construction.
- Keeps raw browser benchmark specs out of normal CI; the benchmark workflow remains responsible for benchmark runs.

Refs #107

## Before / After

Before, apps had to manually assemble the SQLite auth backend pieces before creating sync auth:

```ts
const backend = createTreecrdtSqliteAuthBackend({ runner: client.runner, docId });

const authSession = createTreecrdtAuthSession({
  docId,
  trust: { issuerPublicKeys: [issuerPk] },
  local: { privateKey: localSk, publicKey: localPk, capabilityTokens },
  backend,
  identity: {
    onPeer: onPeerIdentityChain,
    local: getLocalIdentityChain,
  },
});
await authSession.ready;

// Current low-level sync setup; #130 is expected to wrap this for websocket sync.
const syncBackend = createTreecrdtSyncBackendFromClient(client, docId);
const peer = new SyncPeer(syncBackend, { auth: authSession.syncAuth });

const op = await client.local.payload(replica, nodeId, payload);
await authSession.authorizeLocalOps([op]);
```

After, the SQLite client owns the runner-specific auth wiring:

```ts
const client = await createTreecrdtClient({ docId });

const authSession = await client.auth.createSession({
  docId,
  trust: { issuerPublicKeys: [issuerPk] },
  local: { privateKey: localSk, publicKey: localPk, capabilityTokens },
  identity: {
    onPeer: onPeerIdentityChain,
    local: getLocalIdentityChain,
  },
});
await authSession.ready;

// Current low-level sync setup; #130 is expected to wrap this for websocket sync.
const syncBackend = createTreecrdtSyncBackendFromClient(client, docId);
const peer = new SyncPeer(syncBackend, { auth: authSession.syncAuth });

const op = await client.local.payload(replica, nodeId, payload);
await authSession.authorizeLocalOps([op]); // optional fail-fast check before sync/upload
```

The `ops` passed to `authorizeLocalOps` are local operations the app just created, for example from `client.local.insert`, `client.local.move`, `client.local.payload`, or `client.local.delete`. The normal sync path uses `authSession.syncAuth`: `SyncPeer` signs outgoing batches and verifies incoming batches. `authorizeLocalOps` is useful when the app wants to reject announcing or uploading a local edit if the current capability does not allow it.

This PR does not make local writes transactional with auth. Local ops are still minted by `client.local.*` first; a future prepare/authorize/commit path would be needed before `client.local.*({ authSession })` can provide rollback semantics.

This replaces app-side wiring of SQLite scope evaluators, proof-material stores, and runner-specific auth dependencies.

## Scope

This is the SQLite/client facade slice stacked after #128. It does not change core auth semantics, durable revocation storage, generic invite flows, key rotation, or transactional auth-aware local writes. Pending-op inspection remains a SQLite sync diagnostic rather than part of the auth facade.

The goal is API shape and playground cleanup: apps can use `client.auth.*` directly, while the storage-specific runner/backend wiring stays inside the SQLite client packages. Browser apps that never enter signed sync/capability flows do not need the auth facade to be created during normal tree storage setup.
