### PR TITLE
Add auth-aware prepared local writes

### DIFF
--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "vite build",
     "preview": "vite preview",
-    "test:e2e": "pnpm -C ../../packages/discovery run build && pnpm -C ../../packages/sync-protocol/protocol run build && pnpm -C ../../packages/sync-protocol/server/core run build && pnpm -C ../../packages/treecrdt-auth run build && pnpm -C ../../packages/treecrdt-wa-sqlite-vendor run build && pnpm -C ../../packages/treecrdt-wa-sqlite run build:ts && playwright test",
+    "test:e2e": "pnpm -C ../../packages/discovery run build && pnpm -C ../../packages/sync-protocol/protocol run build && pnpm -C ../../packages/sync-protocol/server/core run build && pnpm -C ../../packages/treecrdt-auth run build && pnpm -C ../../packages/sync-protocol/material/sqlite run build && pnpm -C ../../packages/treecrdt-wa-sqlite-vendor run build && pnpm -C ../../packages/treecrdt-wa-sqlite run build:ts && playwright test",
     "deploy": "pnpm run build && gh-pages -d dist"
   },
   "dependencies": {

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -469,7 +469,7 @@ export default function App() {
     liveAllEnabled,
     setLiveAllEnabled,
     toggleLiveChildren,
-    notifyLocalUpdate,
+    queueLocalOpsForSync,
     handleSync,
     handleScopedSync,
     postBroadcastMessage,
@@ -497,12 +497,13 @@ export default function App() {
     onRemoteOpsImported: recordOps,
   });
 
-  const recordLocalOps = React.useCallback(
+  const handleCommittedLocalOps = React.useCallback(
     (ops: Operation[]) => {
-      notifyLocalUpdate(ops);
+      // The local write already committed. This only feeds playground sync and debug UI state.
+      queueLocalOpsForSync(ops);
       recordOps(ops, { assumeSorted: true });
     },
-    [notifyLocalUpdate, recordOps]
+    [queueLocalOpsForSync, recordOps]
   );
 
   const grantSubtreeToReplicaPubkey = React.useCallback(
@@ -715,7 +716,7 @@ export default function App() {
     try {
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
       const op = await localWriter.move(nodeId, newParent, placement);
-      recordLocalOps([op]);
+      handleCommittedLocalOps([op]);
     } catch (err) {
       console.error("Failed to append move op", err);
       setError("Failed to move node (see console)");
@@ -811,11 +812,11 @@ export default function App() {
         prev ? { ...prev, completed: normalizedCount, phase: "applying" } : prev
       );
 
-      recordLocalOps(ops);
+      handleCommittedLocalOps(ops);
       opsRecorded = true;
       expandPathTo(parentId);
     } catch (err) {
-      if (!opsRecorded && ops.length > 0) recordLocalOps(ops);
+      if (!opsRecorded && ops.length > 0) handleCommittedLocalOps(ops);
       console.error("Failed to add nodes", err);
       setError("Failed to add nodes (see console)");
     } finally {
@@ -835,7 +836,7 @@ export default function App() {
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
       const op = await localWriter.insert(parentId, nodeId, { type: "last" }, encryptedPayload);
-      recordLocalOps([op]);
+      handleCommittedLocalOps([op]);
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
       }
@@ -859,7 +860,7 @@ export default function App() {
           const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
           const encryptedPayload = await encryptPayloadBytes(payload);
           const op = await localWriter.payload(nodeId, encryptedPayload);
-          recordLocalOps([op]);
+          handleCommittedLocalOps([op]);
         } catch (err) {
           console.error("Failed to write payload", err);
           setError("Failed to write payload (see console)");
@@ -875,7 +876,7 @@ export default function App() {
     setBusy(true);
     try {
       const op = await localWriter.delete(nodeId);
-      recordLocalOps([op]);
+      handleCommittedLocalOps([op]);
     } catch (err) {
       console.error("Failed to delete node", err);
       setError("Failed to delete node (see console)");

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { type Operation } from "@treecrdt/interface";
-import type { MaterializationEvent } from "@treecrdt/interface/engine";
+import type { BoundTreecrdtEngineLocal, MaterializationEvent } from "@treecrdt/interface/engine";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import { createTreecrdtClient, type TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 import { detectOpfsSupport } from "@treecrdt/wa-sqlite/opfs";
@@ -452,6 +452,10 @@ export default function App() {
   };
 
   const { index, childrenByParent } = treeState;
+  const getLocalWriter = React.useCallback((): BoundTreecrdtEngineLocal | null => {
+    if (!client || !replica) return null;
+    return client.local.forReplica(replica, getLocalWriteOptions());
+  }, [client, getLocalWriteOptions, replica]);
 
   const {
     peers,
@@ -704,12 +708,13 @@ export default function App() {
   };
 
   const appendMoveAfter = async (nodeId: string, newParent: string, after: string | null) => {
-    if (!client || !replica) return;
+    const localWriter = getLocalWriter();
+    if (!localWriter) return;
     if (authEnabled && (!canWriteStructure || (isScopedAccess && newParent === ROOT_ID))) return;
     setBusy(true);
     try {
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
-      const op = await client.local.move(replica, nodeId, newParent, placement, getLocalWriteOptions());
+      const op = await localWriter.move(nodeId, newParent, placement);
       recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to append move op", err);
@@ -720,7 +725,8 @@ export default function App() {
   };
 
   const handleAddNodes = async (parentId: string, count: number, opts: { fanout?: number } = {}) => {
-    if (!client || !replica) return;
+    const localWriter = getLocalWriter();
+    if (!localWriter) return;
     if (authEnabled && !canWriteStructure) return;
     const normalizedCount = Math.max(0, Math.min(MAX_COMPOSER_NODE_COUNT, Math.floor(count)));
     if (normalizedCount <= 0) return;
@@ -731,7 +737,6 @@ export default function App() {
     const ops: Operation[] = [];
     let opsRecorded = false;
     try {
-      const writeOpts = getLocalWriteOptions();
       const fanoutLimit = Math.max(0, Math.floor(opts.fanout ?? fanout));
       const valueBase = canWritePayload ? newNodeValue.trim() : "";
       const shouldSetValue = canWritePayload && valueBase.length > 0;
@@ -742,7 +747,7 @@ export default function App() {
           const value = normalizedCount > 1 ? `${valueBase} ${i + 1}` : valueBase;
           const payload = shouldSetValue ? textEncoder.encode(value) : null;
           const encryptedPayload = await encryptPayloadBytes(payload);
-          ops.push(await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload, writeOpts));
+          ops.push(await localWriter.insert(parentId, nodeId, { type: "last" }, encryptedPayload));
           const completed = i + 1;
           if (completed === normalizedCount || completed % progressStep === 0) {
             setBulkAddProgress((prev) =>
@@ -789,7 +794,7 @@ export default function App() {
           const value = normalizedCount > 1 ? `${valueBase} ${i + 1}` : valueBase;
           const payload = shouldSetValue ? textEncoder.encode(value) : null;
           const encryptedPayload = await encryptPayloadBytes(payload);
-          ops.push(await client.local.insert(replica, targetParent, nodeId, { type: "last" }, encryptedPayload, writeOpts));
+          ops.push(await localWriter.insert(targetParent, nodeId, { type: "last" }, encryptedPayload));
 
           setChildCount(targetParent, childCount + 1);
           queue.push(nodeId);
@@ -820,7 +825,8 @@ export default function App() {
   };
 
   const handleInsert = async (parentId: string) => {
-    if (!client || !replica) return;
+    const localWriter = getLocalWriter();
+    if (!localWriter) return;
     if (authEnabled && !canWriteStructure) return;
     setBusy(true);
     try {
@@ -828,7 +834,7 @@ export default function App() {
       const payload = valueBase.length > 0 ? textEncoder.encode(valueBase) : null;
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
-      const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload, getLocalWriteOptions());
+      const op = await localWriter.insert(parentId, nodeId, { type: "last" }, encryptedPayload);
       recordLocalOps([op]);
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
@@ -846,11 +852,13 @@ export default function App() {
     const run = payloadWriteQueueRef.current
       .catch(() => undefined)
       .then(async () => {
-        if (nodeId === ROOT_ID || !client || !replica) return;
+        if (nodeId === ROOT_ID) return;
+        const localWriter = getLocalWriter();
+        if (!localWriter) return;
         try {
           const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
           const encryptedPayload = await encryptPayloadBytes(payload);
-          const op = await client.local.payload(replica, nodeId, encryptedPayload, getLocalWriteOptions());
+          const op = await localWriter.payload(nodeId, encryptedPayload);
           recordLocalOps([op]);
         } catch (err) {
           console.error("Failed to write payload", err);
@@ -862,10 +870,11 @@ export default function App() {
   };
 
   const handleDelete = async (nodeId: string) => {
-    if (nodeId === ROOT_ID || !client || !replica) return;
+    const localWriter = getLocalWriter();
+    if (nodeId === ROOT_ID || !localWriter) return;
     setBusy(true);
     try {
-      const op = await client.local.delete(replica, nodeId, getLocalWriteOptions());
+      const op = await localWriter.delete(nodeId);
       recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to delete node", err);

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -245,7 +245,7 @@ export default function App() {
     openMintingPeerTab,
     openNewIsolatedPeerTab,
     openShareForNode,
-    verifyLocalOps,
+    getLocalWriteOptions,
     copyToClipboard,
     onAuthGrantMessage,
   } = usePlaygroundAuth({
@@ -501,14 +501,6 @@ export default function App() {
     [notifyLocalUpdate, recordOps]
   );
 
-  const acceptLocalOps = React.useCallback(
-    async (ops: Operation[]) => {
-      await verifyLocalOps(ops);
-      recordLocalOps(ops);
-    },
-    [recordLocalOps, verifyLocalOps]
-  );
-
   const grantSubtreeToReplicaPubkey = React.useCallback(
     async (opts?: {
       recipientKey?: string;
@@ -717,8 +709,8 @@ export default function App() {
     setBusy(true);
     try {
       const placement = after ? { type: "after" as const, after } : { type: "first" as const };
-      const op = await client.local.move(replica, nodeId, newParent, placement);
-      await acceptLocalOps([op]);
+      const op = await client.local.move(replica, nodeId, newParent, placement, getLocalWriteOptions());
+      recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to append move op", err);
       setError("Failed to move node (see console)");
@@ -736,8 +728,10 @@ export default function App() {
     const startedAtMs = Date.now();
     const progressStep = normalizedCount >= 1_000 ? 50 : normalizedCount >= 200 ? 20 : normalizedCount >= 50 ? 5 : 1;
     setBulkAddProgress({ total: normalizedCount, completed: 0, phase: "creating", startedAtMs });
+    const ops: Operation[] = [];
+    let opsRecorded = false;
     try {
-      const ops: Operation[] = [];
+      const writeOpts = getLocalWriteOptions();
       const fanoutLimit = Math.max(0, Math.floor(opts.fanout ?? fanout));
       const valueBase = canWritePayload ? newNodeValue.trim() : "";
       const shouldSetValue = canWritePayload && valueBase.length > 0;
@@ -748,7 +742,7 @@ export default function App() {
           const value = normalizedCount > 1 ? `${valueBase} ${i + 1}` : valueBase;
           const payload = shouldSetValue ? textEncoder.encode(value) : null;
           const encryptedPayload = await encryptPayloadBytes(payload);
-          ops.push(await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload));
+          ops.push(await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload, writeOpts));
           const completed = i + 1;
           if (completed === normalizedCount || completed % progressStep === 0) {
             setBulkAddProgress((prev) =>
@@ -795,7 +789,7 @@ export default function App() {
           const value = normalizedCount > 1 ? `${valueBase} ${i + 1}` : valueBase;
           const payload = shouldSetValue ? textEncoder.encode(value) : null;
           const encryptedPayload = await encryptPayloadBytes(payload);
-          ops.push(await client.local.insert(replica, targetParent, nodeId, { type: "last" }, encryptedPayload));
+          ops.push(await client.local.insert(replica, targetParent, nodeId, { type: "last" }, encryptedPayload, writeOpts));
 
           setChildCount(targetParent, childCount + 1);
           queue.push(nodeId);
@@ -812,9 +806,11 @@ export default function App() {
         prev ? { ...prev, completed: normalizedCount, phase: "applying" } : prev
       );
 
-      await acceptLocalOps(ops);
+      recordLocalOps(ops);
+      opsRecorded = true;
       expandPathTo(parentId);
     } catch (err) {
+      if (!opsRecorded && ops.length > 0) recordLocalOps(ops);
       console.error("Failed to add nodes", err);
       setError("Failed to add nodes (see console)");
     } finally {
@@ -832,8 +828,8 @@ export default function App() {
       const payload = valueBase.length > 0 ? textEncoder.encode(valueBase) : null;
       const encryptedPayload = await encryptPayloadBytes(payload);
       const nodeId = makeNodeId();
-      const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload);
-      await acceptLocalOps([op]);
+      const op = await client.local.insert(replica, parentId, nodeId, { type: "last" }, encryptedPayload, getLocalWriteOptions());
+      recordLocalOps([op]);
       if (!Object.prototype.hasOwnProperty.call(treeStateRef.current.childrenByParent, parentId)) {
         await ensureChildrenLoaded(parentId, { force: true });
       }
@@ -854,8 +850,8 @@ export default function App() {
         try {
           const payload = value.trim().length === 0 ? null : textEncoder.encode(value);
           const encryptedPayload = await encryptPayloadBytes(payload);
-          const op = await client.local.payload(replica, nodeId, encryptedPayload);
-          await acceptLocalOps([op]);
+          const op = await client.local.payload(replica, nodeId, encryptedPayload, getLocalWriteOptions());
+          recordLocalOps([op]);
         } catch (err) {
           console.error("Failed to write payload", err);
           setError("Failed to write payload (see console)");
@@ -869,8 +865,8 @@ export default function App() {
     if (nodeId === ROOT_ID || !client || !replica) return;
     setBusy(true);
     try {
-      const op = await client.local.delete(replica, nodeId);
-      await acceptLocalOps([op]);
+      const op = await client.local.delete(replica, nodeId, getLocalWriteOptions());
+      recordLocalOps([op]);
     } catch (err) {
       console.error("Failed to delete node", err);
       setError("Failed to delete node (see console)");

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import type { Operation } from "@treecrdt/interface";
+import type { LocalWriteOptions } from "@treecrdt/interface/engine";
 import {
   base64urlDecode,
   base64urlEncode,
@@ -269,7 +270,7 @@ export type PlaygroundAuthApi = {
   openNewIsolatedPeerTab: (opts: { autoInvite: boolean; rootNodeId?: string }) => Promise<void>;
   openShareForNode: (nodeId: string) => void;
 
-  verifyLocalOps: (ops: Operation[]) => Promise<void>;
+  getLocalWriteOptions: () => LocalWriteOptions | undefined;
   copyToClipboard: (text: string) => Promise<void>;
   onAuthGrantMessage: (grant: AuthGrantMessageV1) => void;
 };
@@ -592,14 +593,14 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
   ]);
   const selfPeerId = useMemo(() => (replica ? bytesToHex(replica) : null), [replica]);
 
-  const verifyLocalOps = React.useCallback(
-    async (ops: Operation[]) => {
+  const getLocalWriteOptions = React.useCallback(
+    (): LocalWriteOptions | undefined => {
       if (!authEnabled) return;
       const session = localAuthSessionRef.current;
       if (!session) throw new Error("auth is enabled but not configured");
-      await session.authorizeLocalOps(ops);
+      return { authSession: session };
     },
-    [authEnabled, docId]
+    [authEnabled]
   );
 
   useEffect(() => {
@@ -1478,7 +1479,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     openMintingPeerTab,
     openNewIsolatedPeerTab,
     openShareForNode,
-    verifyLocalOps,
+    getLocalWriteOptions,
     copyToClipboard,
     onAuthGrantMessage,
   };

--- a/examples/playground/src/playground/hooks/usePlaygroundSync.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundSync.ts
@@ -164,7 +164,7 @@ type PlaygroundSyncApi = {
   liveAllEnabled: boolean;
   setLiveAllEnabled: React.Dispatch<React.SetStateAction<boolean>>;
   toggleLiveChildren: (parentId: string) => void;
-  notifyLocalUpdate: (ops?: Operation[]) => void;
+  queueLocalOpsForSync: (ops?: Operation[]) => void;
   handleSync: (filter: Filter) => Promise<void>;
   handleScopedSync: () => Promise<void>;
   postBroadcastMessage: (
@@ -445,7 +445,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     });
   };
 
-  const notifyLocalUpdate = (ops?: Operation[]) => {
+  const queueLocalOpsForSync = (ops?: Operation[]) => {
     void syncPeerRef.current?.notifyLocalUpdate(ops);
     queueRemoteUploadHints(ops);
     if (remoteLivePushRunningRef.current) {
@@ -1227,7 +1227,7 @@ export function usePlaygroundSync(opts: UsePlaygroundSyncOptions): PlaygroundSyn
     liveAllEnabled,
     setLiveAllEnabled,
     toggleLiveChildren,
-    notifyLocalUpdate,
+    queueLocalOpsForSync,
     handleSync,
     handleScopedSync,
     postBroadcastMessage,

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -36,6 +36,6 @@ pub use traits::{
 pub use tree::TreeCrdt;
 pub use types::{
     ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
-    NodeExport, NodeSnapshotExport,
+    NodeExport, NodeSnapshotExport, PreparedLocalOp,
 };
 pub use version_vector::VersionVector;

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -12,7 +12,7 @@ use crate::traits::{
 };
 use crate::types::{
     ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
-    NodeExport, NodeSnapshotExport,
+    NodeExport, NodeSnapshotExport, PreparedLocalOp,
 };
 use crate::version_vector::VersionVector;
 
@@ -143,6 +143,17 @@ where
         placement: LocalPlacement,
         payload: Option<Vec<u8>>,
     ) -> Result<(Operation, LocalFinalizePlan)> {
+        let prepared = self.prepare_local_insert(parent, node, placement, payload)?;
+        self.commit_prepared_local(prepared)
+    }
+
+    pub fn prepare_local_insert(
+        &mut self,
+        parent: NodeId,
+        node: NodeId,
+        placement: LocalPlacement,
+        payload: Option<Vec<u8>>,
+    ) -> Result<PreparedLocalOp> {
         let after = self.resolve_after_for_placement(parent, placement, None)?;
         let payload_after = payload.clone();
         let (replica, counter, lamport, seed) = self.next_op_meta();
@@ -150,10 +161,9 @@ where
         let op = Operation::insert_with_optional_payload(
             &replica, counter, lamport, parent, node, order_key, payload,
         );
-        let op = self.commit_local(op)?;
-        Ok((
+        Ok(PreparedLocalOp {
             op,
-            LocalFinalizePlan {
+            plan: LocalFinalizePlan {
                 parent_hints: vec![parent],
                 extra_index_records: Vec::new(),
                 changes: vec![MaterializationChange::Insert {
@@ -162,7 +172,7 @@ where
                     payload: payload_after,
                 }],
             },
-        ))
+        })
     }
 
     pub fn local_move(
@@ -171,12 +181,21 @@ where
         new_parent: NodeId,
         placement: LocalPlacement,
     ) -> Result<(Operation, LocalFinalizePlan)> {
+        let prepared = self.prepare_local_move(node, new_parent, placement)?;
+        self.commit_prepared_local(prepared)
+    }
+
+    pub fn prepare_local_move(
+        &mut self,
+        node: NodeId,
+        new_parent: NodeId,
+        placement: LocalPlacement,
+    ) -> Result<PreparedLocalOp> {
         let old_parent = self.parent(node)?;
         let after = self.resolve_after_for_placement(new_parent, placement, Some(node))?;
         let (replica, counter, lamport, seed) = self.next_op_meta();
         let order_key = self.allocate_child_key_after(new_parent, node, after, &seed)?;
         let op = Operation::move_node(&replica, counter, lamport, node, new_parent, order_key);
-        let op = self.commit_local(op)?;
 
         let mut parent_hints = vec![new_parent];
         if let Some(parent) = old_parent {
@@ -190,9 +209,9 @@ where
             }
         }
 
-        Ok((
+        Ok(PreparedLocalOp {
             op,
-            LocalFinalizePlan {
+            plan: LocalFinalizePlan {
                 parent_hints,
                 extra_index_records,
                 changes: vec![MaterializationChange::Move {
@@ -201,18 +220,22 @@ where
                     parent_after: new_parent,
                 }],
             },
-        ))
+        })
     }
 
     pub fn local_delete(&mut self, node: NodeId) -> Result<(Operation, LocalFinalizePlan)> {
+        let prepared = self.prepare_local_delete(node)?;
+        self.commit_prepared_local(prepared)
+    }
+
+    pub fn prepare_local_delete(&mut self, node: NodeId) -> Result<PreparedLocalOp> {
         let old_parent = self.parent(node)?;
         let (replica, counter, lamport, _seed) = self.next_op_meta();
         let known_state = Some(self.nodes.subtree_version_vector(node)?);
         let op = Operation::delete(&replica, counter, lamport, node, known_state);
-        let op = self.commit_local(op)?;
-        Ok((
+        Ok(PreparedLocalOp {
             op,
-            LocalFinalizePlan {
+            plan: LocalFinalizePlan {
                 parent_hints: parent_hints_from(old_parent),
                 extra_index_records: Vec::new(),
                 changes: vec![MaterializationChange::Delete {
@@ -220,7 +243,7 @@ where
                     parent_before: old_parent.filter(|parent| *parent != NodeId::TRASH),
                 }],
             },
-        ))
+        })
     }
 
     pub fn local_payload(
@@ -228,6 +251,15 @@ where
         node: NodeId,
         payload: Option<Vec<u8>>,
     ) -> Result<(Operation, LocalFinalizePlan)> {
+        let prepared = self.prepare_local_payload(node, payload)?;
+        self.commit_prepared_local(prepared)
+    }
+
+    pub fn prepare_local_payload(
+        &mut self,
+        node: NodeId,
+        payload: Option<Vec<u8>>,
+    ) -> Result<PreparedLocalOp> {
         let parent = self.parent(node)?;
         let payload_after = payload.clone();
         let (replica, counter, lamport, _seed) = self.next_op_meta();
@@ -236,10 +268,9 @@ where
         } else {
             Operation::clear_payload(&replica, counter, lamport, node)
         };
-        let op = self.commit_local(op)?;
-        Ok((
+        Ok(PreparedLocalOp {
             op,
-            LocalFinalizePlan {
+            plan: LocalFinalizePlan {
                 parent_hints: parent_hints_from(parent),
                 extra_index_records: Vec::new(),
                 changes: vec![MaterializationChange::Payload {
@@ -247,7 +278,15 @@ where
                     payload: payload_after,
                 }],
             },
-        ))
+        })
+    }
+
+    pub fn commit_prepared_local(
+        &mut self,
+        prepared: PreparedLocalOp,
+    ) -> Result<(Operation, LocalFinalizePlan)> {
+        let op = self.commit_local(prepared.op)?;
+        Ok((op, prepared.plan))
     }
 
     pub fn apply_remote(&mut self, op: Operation) -> Result<()> {

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::ids::{NodeId, OperationId};
+use crate::ops::Operation;
 use crate::version_vector::VersionVector;
 
 #[cfg(feature = "serde")]
@@ -157,4 +158,10 @@ pub struct LocalFinalizePlan {
     pub parent_hints: Vec<NodeId>,
     pub extra_index_records: Vec<(NodeId, OperationId)>,
     pub changes: Vec<MaterializationChange>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PreparedLocalOp {
+    pub op: Operation,
+    pub plan: LocalFinalizePlan,
 }

--- a/packages/treecrdt-core/tests/operations.rs
+++ b/packages/treecrdt-core/tests/operations.rs
@@ -43,6 +43,31 @@ fn duplicate_operations_are_ignored() {
 }
 
 #[test]
+fn prepared_local_op_does_not_mutate_until_committed() {
+    let mut crdt = TreeCrdt::new(
+        ReplicaId::new(b"a"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+
+    let node = NodeId(1);
+    let prepared = crdt
+        .prepare_local_insert(NodeId::ROOT, node, LocalPlacement::First, Some(vec![1]))
+        .unwrap();
+
+    assert_eq!(crdt.children(NodeId::ROOT).unwrap(), Vec::<NodeId>::new());
+    assert_eq!(crdt.parent(node).unwrap(), None);
+
+    let (op, plan) = crdt.commit_prepared_local(prepared).unwrap();
+
+    assert_eq!(op.kind.node(), node);
+    assert_eq!(plan.changes.len(), 1);
+    assert_eq!(crdt.children(NodeId::ROOT).unwrap(), &[node]);
+    assert_eq!(crdt.parent(node).unwrap(), Some(NodeId::ROOT));
+}
+
+#[test]
 fn delete_marks_tombstone_and_removes_from_parent() {
     let mut crdt = TreeCrdt::new(
         ReplicaId::new(b"a"),

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -94,6 +94,44 @@ pub struct NativeLocalOpResult {
     pub outcome: NativeMaterializationOutcome,
 }
 
+#[napi]
+pub struct NativePreparedLocalOpTx {
+    tx: Option<treecrdt_postgres::PreparedLocalOpTx>,
+}
+
+#[napi]
+impl NativePreparedLocalOpTx {
+    #[napi]
+    pub fn op(&self) -> napi::Result<NativeOp> {
+        let tx = self
+            .tx
+            .as_ref()
+            .ok_or_else(|| map_err("prepared local op transaction is already closed"))?;
+        core_to_native_op(tx.op().clone()).map_err(map_core_err)
+    }
+
+    #[napi]
+    pub fn commit(&mut self) -> napi::Result<NativeLocalOpResult> {
+        let tx = self
+            .tx
+            .take()
+            .ok_or_else(|| map_err("prepared local op transaction is already closed"))?;
+        let result = tx.commit().map_err(map_core_err)?;
+        Ok(NativeLocalOpResult {
+            op: core_to_native_op(result.op).map_err(map_core_err)?,
+            outcome: outcome_to_native(result.outcome),
+        })
+    }
+
+    #[napi]
+    pub fn rollback(&mut self) -> napi::Result<()> {
+        if let Some(tx) = self.tx.take() {
+            tx.rollback().map_err(map_core_err)?;
+        }
+        Ok(())
+    }
+}
+
 fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOutcome {
     let changes = outcome
         .changes
@@ -600,6 +638,20 @@ impl PgBackend {
         after: Option<Buffer>,
         payload: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
+        let mut tx = self.prepare_local_insert(replica, parent, node, placement, after, payload)?;
+        tx.commit()
+    }
+
+    #[napi]
+    pub fn prepare_local_insert(
+        &self,
+        replica: Buffer,
+        parent: Buffer,
+        node: Buffer,
+        placement: String,
+        after: Option<Buffer>,
+        payload: Option<Buffer>,
+    ) -> napi::Result<NativePreparedLocalOpTx> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -611,7 +663,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let result = treecrdt_postgres::local_insert(
+        let tx = treecrdt_postgres::prepare_local_insert_tx(
             &client,
             &self.doc_id,
             &replica,
@@ -622,10 +674,7 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        Ok(NativeLocalOpResult {
-            op: core_to_native_op(result.op).map_err(map_core_err)?,
-            outcome: outcome_to_native(result.outcome),
-        })
+        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
     }
 
     #[napi]
@@ -637,6 +686,19 @@ impl PgBackend {
         placement: String,
         after: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
+        let mut tx = self.prepare_local_move(replica, node, new_parent, placement, after)?;
+        tx.commit()
+    }
+
+    #[napi]
+    pub fn prepare_local_move(
+        &self,
+        replica: Buffer,
+        node: Buffer,
+        new_parent: Buffer,
+        placement: String,
+        after: Option<Buffer>,
+    ) -> napi::Result<NativePreparedLocalOpTx> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -648,7 +710,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let result = treecrdt_postgres::local_move(
+        let tx = treecrdt_postgres::prepare_local_move_tx(
             &client,
             &self.doc_id,
             &replica,
@@ -658,25 +720,29 @@ impl PgBackend {
             after_id,
         )
         .map_err(map_core_err)?;
-        Ok(NativeLocalOpResult {
-            op: core_to_native_op(result.op).map_err(map_core_err)?,
-            outcome: outcome_to_native(result.outcome),
-        })
+        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
     }
 
     #[napi]
     pub fn local_delete(&self, replica: Buffer, node: Buffer) -> napi::Result<NativeLocalOpResult> {
+        let mut tx = self.prepare_local_delete(replica, node)?;
+        tx.commit()
+    }
+
+    #[napi]
+    pub fn prepare_local_delete(
+        &self,
+        replica: Buffer,
+        node: Buffer,
+    ) -> napi::Result<NativePreparedLocalOpTx> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let result = treecrdt_postgres::local_delete(&client, &self.doc_id, &replica, node)
+        let tx = treecrdt_postgres::prepare_local_delete_tx(&client, &self.doc_id, &replica, node)
             .map_err(map_core_err)?;
-        Ok(NativeLocalOpResult {
-            op: core_to_native_op(result.op).map_err(map_core_err)?,
-            outcome: outcome_to_native(result.outcome),
-        })
+        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
     }
 
     #[napi]
@@ -686,12 +752,23 @@ impl PgBackend {
         node: Buffer,
         payload: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
+        let mut tx = self.prepare_local_payload(replica, node, payload)?;
+        tx.commit()
+    }
+
+    #[napi]
+    pub fn prepare_local_payload(
+        &self,
+        replica: Buffer,
+        node: Buffer,
+        payload: Option<Buffer>,
+    ) -> napi::Result<NativePreparedLocalOpTx> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let result = treecrdt_postgres::local_payload(
+        let tx = treecrdt_postgres::prepare_local_payload_tx(
             &client,
             &self.doc_id,
             &replica,
@@ -699,9 +776,6 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        Ok(NativeLocalOpResult {
-            op: core_to_native_op(result.op).map_err(map_core_err)?,
-            outcome: outcome_to_native(result.outcome),
-        })
+        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
     }
 }

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -1,6 +1,9 @@
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import { nodeIdFromBytes16, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
-import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import {
+  createMaterializationDispatcher,
+  createTreecrdtEngineLocal,
+} from '@treecrdt/interface/engine';
 import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
@@ -217,6 +220,13 @@ export async function createTreecrdtPostgresClient(
     return finishPreparedLocalOp(tx, writeOpts);
   };
 
+  const local = createTreecrdtEngineLocal({
+    insert: localInsertImpl,
+    move: localMoveImpl,
+    delete: localDeleteImpl,
+    payload: localPayloadImpl,
+  });
+
   return {
     mode: 'node',
     storage: 'postgres',
@@ -259,12 +269,7 @@ export async function createTreecrdtPostgresClient(
       headLamport: headLamportImpl,
       replicaMaxCounter: replicaMaxCounterImpl,
     },
-    local: {
-      insert: localInsertImpl,
-      move: localMoveImpl,
-      delete: localDeleteImpl,
-      payload: localPayloadImpl,
-    },
+    local,
     onMaterialized: materialized.onMaterialized,
     close: async () => {
       // no-op: native layer opens per-call connections

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -1,7 +1,7 @@
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import { nodeIdFromBytes16, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
-import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 import {
@@ -35,6 +35,12 @@ function placementToArgs(placement: TreecrdtSqlitePlacement): {
   if (placement.type === 'first') return { type: 'first', after: null };
   if (placement.type === 'last') return { type: 'last', after: null };
   return { type: 'after', after: nodeIdToBytes16(placement.after) };
+}
+
+function assertNoLocalAuthOptions(writeOpts?: LocalWriteOptions): void {
+  if (writeOpts?.authSession) {
+    throw new Error('auth-aware local writes are not implemented for the postgres client');
+  }
 }
 
 /**
@@ -146,7 +152,9 @@ export async function createTreecrdtPostgresClient(
     node: string,
     placement: TreecrdtSqlitePlacement,
     payload: Uint8Array | null,
+    writeOpts?: LocalWriteOptions,
   ) => {
+    assertNoLocalAuthOptions(writeOpts);
     const { type, after } = placementToArgs(placement);
     const result = backend.localInsert(
       encodeReplica(replica),
@@ -164,7 +172,9 @@ export async function createTreecrdtPostgresClient(
     node: string,
     newParent: string,
     placement: TreecrdtSqlitePlacement,
+    writeOpts?: LocalWriteOptions,
   ) => {
+    assertNoLocalAuthOptions(writeOpts);
     const { type, after } = placementToArgs(placement);
     const result = backend.localMove(
       encodeReplica(replica),
@@ -176,12 +186,23 @@ export async function createTreecrdtPostgresClient(
     return finishLocalOp(result);
   };
 
-  const localDeleteImpl = async (replica: ReplicaId, node: string) => {
+  const localDeleteImpl = async (
+    replica: ReplicaId,
+    node: string,
+    writeOpts?: LocalWriteOptions,
+  ) => {
+    assertNoLocalAuthOptions(writeOpts);
     const result = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
     return finishLocalOp(result);
   };
 
-  const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) => {
+  const localPayloadImpl = async (
+    replica: ReplicaId,
+    node: string,
+    payload: Uint8Array | null,
+    writeOpts?: LocalWriteOptions,
+  ) => {
+    assertNoLocalAuthOptions(writeOpts);
     const result = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
     return finishLocalOp(result);
   };

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -13,6 +13,7 @@ import {
   loadNative,
   type NativeLocalOpResult,
   type NativeMaterializationOutcome,
+  type NativePreparedLocalOpTx,
 } from './native.js';
 
 function ensureNonEmptyString(name: string, value: string): void {
@@ -35,12 +36,6 @@ function placementToArgs(placement: TreecrdtSqlitePlacement): {
   if (placement.type === 'first') return { type: 'first', after: null };
   if (placement.type === 'last') return { type: 'last', after: null };
   return { type: 'after', after: nodeIdToBytes16(placement.after) };
-}
-
-function assertNoLocalAuthOptions(writeOpts?: LocalWriteOptions): void {
-  if (writeOpts?.authSession) {
-    throw new Error('auth-aware local writes are not implemented for the postgres client');
-  }
 }
 
 /**
@@ -69,6 +64,25 @@ export async function createTreecrdtPostgresClient(
   const finishLocalOp = (result: NativeLocalOpResult): Operation => {
     emitNativeOutcome(result.outcome);
     return nativeToOperation(result.op);
+  };
+  const finishPreparedLocalOp = async (
+    tx: NativePreparedLocalOpTx,
+    writeOpts?: LocalWriteOptions,
+  ): Promise<Operation> => {
+    if (writeOpts?.authSession) {
+      const op = nativeToOperation(tx.op());
+      try {
+        await writeOpts.authSession.authorizeLocalOps([op]);
+      } catch (err) {
+        try {
+          tx.rollback();
+        } catch {
+          // Preserve the auth failure. The native transaction also rolls back on drop.
+        }
+        throw err;
+      }
+    }
+    return finishLocalOp(tx.commit());
   };
   const ensureMaterializedImpl = () => {
     emitNativeOutcome(backend.ensureMaterialized());
@@ -154,9 +168,8 @@ export async function createTreecrdtPostgresClient(
     payload: Uint8Array | null,
     writeOpts?: LocalWriteOptions,
   ) => {
-    assertNoLocalAuthOptions(writeOpts);
     const { type, after } = placementToArgs(placement);
-    const result = backend.localInsert(
+    const tx = backend.prepareLocalInsert(
       encodeReplica(replica),
       nodeIdToBytes16(parent),
       nodeIdToBytes16(node),
@@ -164,7 +177,7 @@ export async function createTreecrdtPostgresClient(
       after,
       payload,
     );
-    return finishLocalOp(result);
+    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   const localMoveImpl = async (
@@ -174,16 +187,15 @@ export async function createTreecrdtPostgresClient(
     placement: TreecrdtSqlitePlacement,
     writeOpts?: LocalWriteOptions,
   ) => {
-    assertNoLocalAuthOptions(writeOpts);
     const { type, after } = placementToArgs(placement);
-    const result = backend.localMove(
+    const tx = backend.prepareLocalMove(
       encodeReplica(replica),
       nodeIdToBytes16(node),
       nodeIdToBytes16(newParent),
       type,
       after,
     );
-    return finishLocalOp(result);
+    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   const localDeleteImpl = async (
@@ -191,9 +203,8 @@ export async function createTreecrdtPostgresClient(
     node: string,
     writeOpts?: LocalWriteOptions,
   ) => {
-    assertNoLocalAuthOptions(writeOpts);
-    const result = backend.localDelete(encodeReplica(replica), nodeIdToBytes16(node));
-    return finishLocalOp(result);
+    const tx = backend.prepareLocalDelete(encodeReplica(replica), nodeIdToBytes16(node));
+    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   const localPayloadImpl = async (
@@ -202,9 +213,8 @@ export async function createTreecrdtPostgresClient(
     payload: Uint8Array | null,
     writeOpts?: LocalWriteOptions,
   ) => {
-    assertNoLocalAuthOptions(writeOpts);
-    const result = backend.localPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
-    return finishLocalOp(result);
+    const tx = backend.prepareLocalPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
+    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   return {

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -36,6 +36,12 @@ export type NativeLocalOpResult = {
   outcome: NativeMaterializationOutcome;
 };
 
+export type NativePreparedLocalOpTx = {
+  op(): NativeOp;
+  commit(): NativeLocalOpResult;
+  rollback(): void;
+};
+
 export type NativeBackend = {
   maxLamport(): bigint;
   listOpRefsAll(): Uint8Array[];
@@ -71,6 +77,14 @@ export type NativeBackend = {
     after: Uint8Array | null,
     payload: Uint8Array | null,
   ): NativeLocalOpResult;
+  prepareLocalInsert(
+    replica: Uint8Array,
+    parent: Uint8Array,
+    node: Uint8Array,
+    placement: string,
+    after: Uint8Array | null,
+    payload: Uint8Array | null,
+  ): NativePreparedLocalOpTx;
   localMove(
     replica: Uint8Array,
     node: Uint8Array,
@@ -78,12 +92,25 @@ export type NativeBackend = {
     placement: string,
     after: Uint8Array | null,
   ): NativeLocalOpResult;
+  prepareLocalMove(
+    replica: Uint8Array,
+    node: Uint8Array,
+    newParent: Uint8Array,
+    placement: string,
+    after: Uint8Array | null,
+  ): NativePreparedLocalOpTx;
   localDelete(replica: Uint8Array, node: Uint8Array): NativeLocalOpResult;
+  prepareLocalDelete(replica: Uint8Array, node: Uint8Array): NativePreparedLocalOpTx;
   localPayload(
     replica: Uint8Array,
     node: Uint8Array,
     payload: Uint8Array | null,
   ): NativeLocalOpResult;
+  prepareLocalPayload(
+    replica: Uint8Array,
+    node: Uint8Array,
+    payload: Uint8Array | null,
+  ): NativePreparedLocalOpTx;
 };
 
 export type NativeFactory = {

--- a/packages/treecrdt-postgres-napi/tests/conformance.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/conformance.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import type { Operation } from '@treecrdt/interface';
 import type { TreecrdtEngine } from '@treecrdt/interface/engine';
@@ -16,6 +16,12 @@ import { createTreecrdtPostgresClient } from '../dist/index.js';
 
 const POSTGRES_URL = process.env.TREECRDT_POSTGRES_URL;
 const maybeDescribe = POSTGRES_URL ? describe : describe.skip;
+const root = '0'.repeat(32);
+const replica = Uint8Array.from({ length: 32 }, (_, i) => (i === 31 ? 1 : 0));
+
+function nodeIdFromInt(n: number): string {
+  return n.toString(16).padStart(32, '0');
+}
 
 function publicOpRef(docId: string, op: Operation): Uint8Array {
   return deriveOpRefV0(docId, {
@@ -73,6 +79,63 @@ test('conformance registry includes materialization-event scenarios', () => {
 });
 
 maybeDescribe('engine conformance scenarios (postgres-napi engine)', () => {
+  test('postgres auth-aware local write rolls back on auth failure', async () => {
+    const client = await createTreecrdtPostgresClient(POSTGRES_URL!, {
+      docId: internalDocId('postgres-auth-local-rollback', 'auth-failure'),
+    });
+    const events: unknown[] = [];
+    const unsubscribe = client.onMaterialized((event) => events.push(event));
+    const authSession = {
+      authorizeLocalOps: vi.fn(async () => {
+        throw new Error('local auth denied');
+      }),
+    };
+    const node = nodeIdFromInt(10);
+
+    try {
+      await expect(
+        client.local.insert(replica, root, node, { type: 'last' }, null, { authSession }),
+      ).rejects.toThrow('local auth denied');
+
+      expect(authSession.authorizeLocalOps).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(0);
+      expect(await client.tree.exists(node)).toBe(false);
+      expect(await client.ops.all()).toHaveLength(0);
+    } finally {
+      unsubscribe();
+      await client.close();
+    }
+  });
+
+  test('postgres auth-aware local write emits materialization after auth succeeds', async () => {
+    const client = await createTreecrdtPostgresClient(POSTGRES_URL!, {
+      docId: internalDocId('postgres-auth-local-success', 'auth-success'),
+    });
+    const events: unknown[] = [];
+    const unsubscribe = client.onMaterialized((event) => events.push(event));
+    const authSession = {
+      authorizeLocalOps: vi.fn(async () => {
+        expect(events).toHaveLength(0);
+      }),
+    };
+    const node = nodeIdFromInt(11);
+
+    try {
+      const op = await client.local.insert(replica, root, node, { type: 'last' }, null, {
+        authSession,
+      });
+
+      expect(op.kind.type).toBe('insert');
+      expect(authSession.authorizeLocalOps).toHaveBeenCalledTimes(1);
+      expect(events).toHaveLength(1);
+      expect(await client.tree.exists(node)).toBe(true);
+      expect(await client.ops.all()).toHaveLength(1);
+    } finally {
+      unsubscribe();
+      await client.close();
+    }
+  });
+
   for (const scenario of treecrdtEngineConformanceScenarios()) {
     test(`postgres engine conformance: ${scenario.name}`, async () => {
       const persistentInternal = new Map<string, string>();

--- a/packages/treecrdt-postgres-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-rs/src/lib.rs
@@ -11,7 +11,10 @@ mod reads;
 mod schema;
 mod store;
 
-pub use local_ops::{local_delete, local_insert, local_move, local_payload};
+pub use local_ops::{
+    local_delete, local_insert, local_move, local_payload, prepare_local_delete_tx,
+    prepare_local_insert_tx, prepare_local_move_tx, prepare_local_payload_tx, PreparedLocalOpTx,
+};
 pub use reads::{
     get_ops_by_op_refs, list_op_refs_all, list_op_refs_children,
     list_op_refs_children_with_parent_payload, max_lamport, ops_since, replica_max_counter,

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -5,7 +5,7 @@ use postgres::Client;
 
 use treecrdt_core::{
     Error, LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor,
-    MaterializationOutcome, NodeId, Operation, ReplicaId, Result, TreeCrdt,
+    MaterializationOutcome, NodeId, Operation, PreparedLocalOp, ReplicaId, Result, TreeCrdt,
 };
 
 use crate::store::{
@@ -37,26 +37,19 @@ impl std::ops::Deref for LocalOpResult {
     }
 }
 
-fn run_in_tx<T>(client: &Rc<RefCell<Client>>, f: impl FnOnce() -> Result<T>) -> Result<T> {
-    {
-        let mut c = client.borrow_mut();
-        c.batch_execute("BEGIN").map_err(|e| Error::Storage(e.to_string()))?;
-    }
+fn begin_tx(client: &Rc<RefCell<Client>>) -> Result<()> {
+    let mut c = client.borrow_mut();
+    c.batch_execute("BEGIN").map_err(|e| Error::Storage(e.to_string()))
+}
 
-    let res = f();
+fn commit_tx(client: &Rc<RefCell<Client>>) -> Result<()> {
+    let mut c = client.borrow_mut();
+    c.batch_execute("COMMIT").map_err(|e| Error::Storage(e.to_string()))
+}
 
-    match res {
-        Ok(v) => {
-            let mut c = client.borrow_mut();
-            c.batch_execute("COMMIT").map_err(|e| Error::Storage(e.to_string()))?;
-            Ok(v)
-        }
-        Err(e) => {
-            let mut c = client.borrow_mut();
-            let _ = c.batch_execute("ROLLBACK");
-            Err(e)
-        }
-    }
+fn rollback_tx(client: &Rc<RefCell<Client>>) -> Result<()> {
+    let mut c = client.borrow_mut();
+    c.batch_execute("ROLLBACK").map_err(|e| Error::Storage(e.to_string()))
 }
 
 fn begin_local_core_op(
@@ -98,8 +91,8 @@ fn finish_local_core_op(
     let mut outcome = MaterializationOutcome::empty(session.meta.state().head_seq());
 
     let mut op_index = PgParentOpIndex::new(session.ctx.clone());
-    // commit_local() already persisted the op and updated node/payload state. The finalize step
-    // refreshes adapter-owned derived state that lives outside TreeCrdt itself.
+    // commit_prepared_local() already persisted the op and updated node/payload state. The finalize
+    // step refreshes adapter-owned derived state that lives outside TreeCrdt itself.
     match session.crdt.finalize_local_with_outcome(
         op,
         &mut op_index,
@@ -144,6 +137,81 @@ fn finish_local_core_op(
     Ok(outcome)
 }
 
+pub struct PreparedLocalOpTx {
+    session: Option<LocalOpSession>,
+    prepared: Option<PreparedLocalOp>,
+}
+
+impl PreparedLocalOpTx {
+    pub fn op(&self) -> &Operation {
+        &self.prepared.as_ref().expect("prepared local op already closed").op
+    }
+
+    pub fn commit(mut self) -> Result<LocalOpResult> {
+        let mut session = self.session.take().expect("prepared local op already closed");
+        let prepared = self.prepared.take().expect("prepared local op already closed");
+        let res = (|| {
+            let (op, plan) = session.crdt.commit_prepared_local(prepared)?;
+            let outcome = finish_local_core_op(&mut session, &op, plan)?;
+            Ok(LocalOpResult { op, outcome })
+        })();
+
+        match res {
+            Ok(v) => {
+                if let Err(e) = commit_tx(&session.ctx.client) {
+                    let _ = rollback_tx(&session.ctx.client);
+                    return Err(e);
+                }
+                Ok(v)
+            }
+            Err(e) => {
+                let _ = rollback_tx(&session.ctx.client);
+                Err(e)
+            }
+        }
+    }
+
+    pub fn rollback(mut self) -> Result<()> {
+        let Some(session) = self.session.take() else {
+            return Ok(());
+        };
+        self.prepared.take();
+        rollback_tx(&session.ctx.client)
+    }
+}
+
+impl Drop for PreparedLocalOpTx {
+    fn drop(&mut self) {
+        if let Some(session) = self.session.take() {
+            let _ = rollback_tx(&session.ctx.client);
+        }
+    }
+}
+
+fn prepare_local_core_op<F>(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    build: F,
+) -> Result<PreparedLocalOpTx>
+where
+    F: FnOnce(&mut LocalCrdt) -> Result<PreparedLocalOp>,
+{
+    begin_tx(client)?;
+    let res = (|| {
+        let mut session = begin_local_core_op(client, doc_id, replica)?;
+        let prepared = build(&mut session.crdt)?;
+        Ok(PreparedLocalOpTx {
+            session: Some(session),
+            prepared: Some(prepared),
+        })
+    })();
+    if res.is_err() {
+        let _ = rollback_tx(client);
+    }
+    res
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn local_insert(
     client: &Rc<RefCell<Client>>,
@@ -155,12 +223,26 @@ pub fn local_insert(
     after: Option<NodeId>,
     payload: Option<Vec<u8>>,
 ) -> Result<LocalOpResult> {
-    run_in_tx(client, || {
-        let mut session = begin_local_core_op(client, doc_id, replica)?;
+    prepare_local_insert_tx(
+        client, doc_id, replica, parent, node, placement, after, payload,
+    )?
+    .commit()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn prepare_local_insert_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    parent: NodeId,
+    node: NodeId,
+    placement: &str,
+    after: Option<NodeId>,
+    payload: Option<Vec<u8>>,
+) -> Result<PreparedLocalOpTx> {
+    prepare_local_core_op(client, doc_id, replica, |crdt| {
         let placement = LocalPlacement::from_parts(placement, after)?;
-        let (op, plan) = session.crdt.local_insert(parent, node, placement, payload)?;
-        let outcome = finish_local_core_op(&mut session, &op, plan)?;
-        Ok(LocalOpResult { op, outcome })
+        crdt.prepare_local_insert(parent, node, placement, payload)
     })
 }
 
@@ -173,12 +255,21 @@ pub fn local_move(
     placement: &str,
     after: Option<NodeId>,
 ) -> Result<LocalOpResult> {
-    run_in_tx(client, || {
-        let mut session = begin_local_core_op(client, doc_id, replica)?;
+    prepare_local_move_tx(client, doc_id, replica, node, new_parent, placement, after)?.commit()
+}
+
+pub fn prepare_local_move_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    node: NodeId,
+    new_parent: NodeId,
+    placement: &str,
+    after: Option<NodeId>,
+) -> Result<PreparedLocalOpTx> {
+    prepare_local_core_op(client, doc_id, replica, |crdt| {
         let placement = LocalPlacement::from_parts(placement, after)?;
-        let (op, plan) = session.crdt.local_move(node, new_parent, placement)?;
-        let outcome = finish_local_core_op(&mut session, &op, plan)?;
-        Ok(LocalOpResult { op, outcome })
+        crdt.prepare_local_move(node, new_parent, placement)
     })
 }
 
@@ -188,11 +279,17 @@ pub fn local_delete(
     replica: &ReplicaId,
     node: NodeId,
 ) -> Result<LocalOpResult> {
-    run_in_tx(client, || {
-        let mut session = begin_local_core_op(client, doc_id, replica)?;
-        let (op, plan) = session.crdt.local_delete(node)?;
-        let outcome = finish_local_core_op(&mut session, &op, plan)?;
-        Ok(LocalOpResult { op, outcome })
+    prepare_local_delete_tx(client, doc_id, replica, node)?.commit()
+}
+
+pub fn prepare_local_delete_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    node: NodeId,
+) -> Result<PreparedLocalOpTx> {
+    prepare_local_core_op(client, doc_id, replica, |crdt| {
+        crdt.prepare_local_delete(node)
     })
 }
 
@@ -203,10 +300,17 @@ pub fn local_payload(
     node: NodeId,
     payload: Option<Vec<u8>>,
 ) -> Result<LocalOpResult> {
-    run_in_tx(client, || {
-        let mut session = begin_local_core_op(client, doc_id, replica)?;
-        let (op, plan) = session.crdt.local_payload(node, payload)?;
-        let outcome = finish_local_core_op(&mut session, &op, plan)?;
-        Ok(LocalOpResult { op, outcome })
+    prepare_local_payload_tx(client, doc_id, replica, node, payload)?.commit()
+}
+
+pub fn prepare_local_payload_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    node: NodeId,
+    payload: Option<Vec<u8>>,
+) -> Result<PreparedLocalOpTx> {
+    prepare_local_core_op(client, doc_id, replica, |crdt| {
+        crdt.prepare_local_payload(node, payload)
     })
 }

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -9,8 +9,8 @@ use treecrdt_core::{MaterializationOutcome, NodeId, Operation, ReplicaId, Versio
 use treecrdt_postgres::{
     append_ops, append_ops_with_materialization_outcome, ensure_materialized, ensure_schema,
     get_ops_by_op_refs, list_op_refs_all, list_op_refs_children, local_delete, local_insert,
-    local_move, local_payload, max_lamport, replica_max_counter, reset_doc_for_tests,
-    tree_children, tree_payload,
+    local_move, local_payload, max_lamport, prepare_local_insert_tx, replica_max_counter,
+    reset_doc_for_tests, tree_children, tree_payload,
 };
 use treecrdt_test_support::{
     self as materialization_conformance, node, order_key_from_position,
@@ -29,6 +29,17 @@ fn ensure_schema_once(client: &Rc<RefCell<Client>>) {
         let mut c = client.borrow_mut();
         ensure_schema(&mut c).unwrap();
     });
+}
+
+fn op_count(client: &Rc<RefCell<Client>>, doc_id: &str) -> u64 {
+    let mut c = client.borrow_mut();
+    let row = c
+        .query_one(
+            "SELECT COUNT(*) FROM treecrdt_ops WHERE doc_id = $1",
+            &[&doc_id],
+        )
+        .unwrap();
+    row.get::<_, i64>(0).max(0) as u64
 }
 
 struct PgConformanceHarness {
@@ -54,14 +65,7 @@ impl MaterializationConformanceHarness for PgConformanceHarness {
     }
 
     fn op_count(&self) -> u64 {
-        let mut c = self.client.borrow_mut();
-        let row = c
-            .query_one(
-                "SELECT COUNT(*) FROM treecrdt_ops WHERE doc_id = $1",
-                &[&self.doc_id],
-            )
-            .unwrap();
-        row.get::<_, i64>(0).max(0) as u64
+        op_count(&self.client, &self.doc_id)
     }
 
     fn replay_frontier(&self) -> Option<treecrdt_core::MaterializationFrontier> {
@@ -672,5 +676,63 @@ fn postgres_backend_local_ops_drive_core_materialization_flow() {
     assert_eq!(
         replica_max_counter(&client, &doc_id, replica.as_bytes()).unwrap(),
         op6.meta.id.counter
+    );
+}
+
+#[test]
+fn postgres_backend_prepared_local_tx_rolls_back_until_committed() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    {
+        let mut c = client.borrow_mut();
+        reset_doc_for_tests(&mut c, &doc_id).unwrap();
+    }
+
+    let replica = ReplicaId::new(b"loc-auth");
+    let node_rejected = node(1101);
+    let rejected = prepare_local_insert_tx(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        node_rejected,
+        "first",
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(rejected.op().meta.id.counter, 1);
+    rejected.rollback().unwrap();
+    assert_eq!(op_count(&client, &doc_id), 0);
+    assert!(tree_children(&client, &doc_id, NodeId::ROOT).unwrap().is_empty());
+
+    let node_committed = node(1102);
+    let committed = prepare_local_insert_tx(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        node_committed,
+        "first",
+        None,
+        Some(vec![7]),
+    )
+    .unwrap();
+    assert_eq!(committed.op().meta.id.counter, 1);
+    let result = committed.commit().unwrap();
+
+    assert_eq!(result.op.kind.node(), node_committed);
+    assert_eq!(op_count(&client, &doc_id), 1);
+    assert_eq!(
+        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
+        vec![node_committed]
+    );
+    assert_eq!(
+        tree_payload(&client, &doc_id, node_committed).unwrap(),
+        Some(vec![7])
     );
 }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -10,7 +10,7 @@ use super::util::{
 use super::*;
 use treecrdt_core::{
     LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor, Operation,
-    OperationKind, ReplicaId, TreeCrdt,
+    OperationKind, PreparedLocalOp, ReplicaId, TreeCrdt,
 };
 
 #[derive(serde::Serialize)]
@@ -293,10 +293,14 @@ fn run_local_core_op<F>(
     build: F,
 ) -> Result<JsonLocalOpResult, c_int>
 where
-    F: FnOnce(&mut LocalCrdt) -> treecrdt_core::Result<(Operation, LocalFinalizePlan)>,
+    F: FnOnce(&mut LocalCrdt) -> treecrdt_core::Result<PreparedLocalOp>,
 {
     let mut session = begin_local_core_op(db, &doc_id, &replica, savepoint_name)?;
-    let (op, plan) = match build(&mut session.crdt) {
+    let prepared = match build(&mut session.crdt) {
+        Ok(v) => v,
+        Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
+    };
+    let (op, plan) = match session.crdt.commit_prepared_local(prepared) {
         Ok(v) => v,
         Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
     };
@@ -395,7 +399,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_insert(
         }
     };
     let out = match run_local_core_op(db, doc_id, replica, "treecrdt_local_insert", |crdt| {
-        crdt.local_insert(parent_id, node_id, placement, payload.clone())
+        crdt.prepare_local_insert(parent_id, node_id, placement, payload.clone())
     }) {
         Ok(v) => v,
         Err(rc) => {
@@ -498,7 +502,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_move(
         }
     };
     let out = match run_local_core_op(db, doc_id, replica, "treecrdt_local_move", |crdt| {
-        crdt.local_move(node_id, new_parent_id, placement)
+        crdt.prepare_local_move(node_id, new_parent_id, placement)
     }) {
         Ok(v) => v,
         Err(rc) => {
@@ -568,7 +572,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_delete(
 
     let node_id = NodeId(u128::from_be_bytes(node));
     let out = match run_local_core_op(db, doc_id, replica, "treecrdt_local_delete", |crdt| {
-        crdt.local_delete(node_id)
+        crdt.prepare_local_delete(node_id)
     }) {
         Ok(v) => v,
         Err(rc) => {
@@ -640,7 +644,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_payload(
 
     let node_id = NodeId(u128::from_be_bytes(node));
     let out = match run_local_core_op(db, doc_id, replica, "treecrdt_local_payload", |crdt| {
-        crdt.local_payload(node_id, payload.clone())
+        crdt.prepare_local_payload(node_id, payload.clone())
     }) {
         Ok(v) => v,
         Err(rc) => {

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -19,7 +19,10 @@ import {
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
-import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import {
+  createMaterializationDispatcher,
+  createTreecrdtEngineLocal,
+} from '@treecrdt/interface/engine';
 import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import {
   createTreecrdtSqliteAuthApi,
@@ -204,6 +207,13 @@ export function createTreecrdtClient(
     writeOpts?: LocalWriteOptions,
   ) => localWriterFor(replica).payload(node, payload, writeOpts);
 
+  const local = createTreecrdtEngineLocal({
+    insert: localInsertImpl,
+    move: localMoveImpl,
+    delete: localDeleteImpl,
+    payload: localPayloadImpl,
+  });
+
   return ready.then(() => ({
     mode: 'node',
     storage: 'sqlite',
@@ -237,12 +247,7 @@ export function createTreecrdtClient(
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
     auth: createTreecrdtSqliteAuthApi({ runner, docId }),
-    local: {
-      insert: localInsertImpl,
-      move: localMoveImpl,
-      delete: localDeleteImpl,
-      payload: localPayloadImpl,
-    },
+    local,
     onMaterialized: materialized.onMaterialized,
     runner,
     close: async () => {

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -20,7 +20,7 @@ import {
 } from '@treecrdt/interface/ids';
 import type { Operation, ReplicaId, TreecrdtAdapter } from '@treecrdt/interface';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
-import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import {
   createTreecrdtSqliteAuthApi,
   type TreecrdtSqliteAuthApi,
@@ -182,17 +182,27 @@ export function createTreecrdtClient(
     node: string,
     placement: TreecrdtSqlitePlacement,
     payload: Uint8Array | null,
-  ) => localWriterFor(replica).insert(parent, node, placement, payload ? { payload } : {});
+    writeOpts?: LocalWriteOptions,
+  ) =>
+    localWriterFor(replica).insert(parent, node, placement, {
+      ...writeOpts,
+      ...(payload ? { payload } : {}),
+    });
   const localMoveImpl = async (
     replica: ReplicaId,
     node: string,
     newParent: string,
     placement: TreecrdtSqlitePlacement,
-  ) => localWriterFor(replica).move(node, newParent, placement);
-  const localDeleteImpl = async (replica: ReplicaId, node: string) =>
-    localWriterFor(replica).delete(node);
-  const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) =>
-    localWriterFor(replica).payload(node, payload);
+    writeOpts?: LocalWriteOptions,
+  ) => localWriterFor(replica).move(node, newParent, placement, writeOpts);
+  const localDeleteImpl = async (replica: ReplicaId, node: string, writeOpts?: LocalWriteOptions) =>
+    localWriterFor(replica).delete(node, writeOpts);
+  const localPayloadImpl = async (
+    replica: ReplicaId,
+    node: string,
+    payload: Uint8Array | null,
+    writeOpts?: LocalWriteOptions,
+  ) => localWriterFor(replica).payload(node, payload, writeOpts);
 
   return ready.then(() => ({
     mode: 'node',

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -12,6 +12,13 @@ import {
   defaultExtensionPath,
   loadTreecrdtExtension,
 } from '../dist/index.js';
+
+const root = '0'.repeat(32);
+const replica = Uint8Array.from({ length: 32 }, (_, i) => (i === 31 ? 1 : 0));
+
+function nodeIdFromInt(n: number): string {
+  return n.toString(16).padStart(32, '0');
+}
 
 async function createNodeEngine(opts: { docId: string; path?: string }) {
   const { default: Database } = await import('better-sqlite3').catch((err) => {
@@ -30,6 +37,59 @@ test('conformance registry includes materialization-event scenarios', () => {
   expect(names).toContain('materialization events: structural batch');
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
+});
+
+test('sqlite auth-aware local write rolls back on auth failure', async () => {
+  const client = await createNodeEngine({ docId: 'sqlite-auth-local-rollback' });
+  const events: unknown[] = [];
+  const unsubscribe = client.onMaterialized((event) => events.push(event));
+  const authSession = {
+    authorizeLocalOps: vi.fn(async () => {
+      throw new Error('local auth denied');
+    }),
+  };
+  const node = nodeIdFromInt(10);
+
+  try {
+    await expect(
+      client.local.insert(replica, root, node, { type: 'last' }, null, { authSession }),
+    ).rejects.toThrow('local auth denied');
+
+    expect(authSession.authorizeLocalOps).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(0);
+    expect(await client.tree.exists(node)).toBe(false);
+    expect(await client.ops.all()).toHaveLength(0);
+  } finally {
+    unsubscribe();
+    await client.close();
+  }
+});
+
+test('sqlite auth-aware local write emits materialization after auth succeeds', async () => {
+  const client = await createNodeEngine({ docId: 'sqlite-auth-local-success' });
+  const events: unknown[] = [];
+  const unsubscribe = client.onMaterialized((event) => events.push(event));
+  const authSession = {
+    authorizeLocalOps: vi.fn(async () => {
+      expect(events).toHaveLength(0);
+    }),
+  };
+  const node = nodeIdFromInt(11);
+
+  try {
+    const op = await client.local.insert(replica, root, node, { type: 'last' }, null, {
+      authSession,
+    });
+
+    expect(op.kind.type).toBe('insert');
+    expect(authSession.authorizeLocalOps).toHaveBeenCalledTimes(1);
+    expect(events).toHaveLength(1);
+    expect(await client.tree.exists(node)).toBe(true);
+    expect(await client.ops.all()).toHaveLength(1);
+  } finally {
+    unsubscribe();
+    await client.close();
+  }
 });
 
 for (const scenario of treecrdtEngineConformanceScenarios()) {

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -116,6 +116,28 @@ export type TreecrdtEngineMeta = {
   replicaMaxCounter: (replica: ReplicaId) => Promise<number>;
 };
 
+export type BoundTreecrdtEngineLocal = {
+  insert: (
+    parent: string,
+    node: string,
+    placement: TreecrdtSqlitePlacement,
+    payload: Uint8Array | null,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
+  move: (
+    node: string,
+    newParent: string,
+    placement: TreecrdtSqlitePlacement,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
+  delete: (node: string, opts?: LocalWriteOptions) => Promise<Operation>;
+  payload: (
+    node: string,
+    payload: Uint8Array | null,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
+};
+
 export type TreecrdtEngineLocal = {
   insert: (
     replica: ReplicaId,
@@ -139,7 +161,40 @@ export type TreecrdtEngineLocal = {
     payload: Uint8Array | null,
     opts?: LocalWriteOptions,
   ) => Promise<Operation>;
+  forReplica: (replica: ReplicaId, opts?: LocalWriteOptions) => BoundTreecrdtEngineLocal;
 };
+
+export type TreecrdtEngineLocalMethods = Omit<TreecrdtEngineLocal, 'forReplica'>;
+
+export function createBoundTreecrdtEngineLocal(
+  local: TreecrdtEngineLocalMethods,
+  replica: ReplicaId,
+  defaults: LocalWriteOptions = {},
+): BoundTreecrdtEngineLocal {
+  const hasDefaults = Object.keys(defaults).length > 0;
+  const mergeOptions = (opts?: LocalWriteOptions): LocalWriteOptions | undefined => {
+    if (!hasDefaults) return opts;
+    return { ...defaults, ...opts };
+  };
+
+  return {
+    insert: (parent, node, placement, payload, opts) =>
+      local.insert(replica, parent, node, placement, payload, mergeOptions(opts)),
+    move: (node, newParent, placement, opts) =>
+      local.move(replica, node, newParent, placement, mergeOptions(opts)),
+    delete: (node, opts) => local.delete(replica, node, mergeOptions(opts)),
+    payload: (node, payload, opts) => local.payload(replica, node, payload, mergeOptions(opts)),
+  };
+}
+
+export function createTreecrdtEngineLocal(
+  methods: TreecrdtEngineLocalMethods,
+): TreecrdtEngineLocal {
+  return {
+    ...methods,
+    forReplica: (replica, opts) => createBoundTreecrdtEngineLocal(methods, replica, opts),
+  };
+}
 
 /**
  * Common high-level engine surface shared across the Node and wa-sqlite backends.

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -69,6 +69,20 @@ export type WriteOptions = {
   writeId?: string;
 };
 
+export type LocalWriteAuthSession = {
+  authorizeLocalOps: (ops: readonly Operation[]) => Promise<unknown>;
+};
+
+export type LocalWriteOptions = {
+  /**
+   * Authorizes the minted local op before it is exposed to callers as committed.
+   *
+   * SQLite clients wrap this in a savepoint so auth failures roll back the local
+   * op and defer materialization events until auth succeeds.
+   */
+  authSession?: LocalWriteAuthSession;
+};
+
 export type TreecrdtEngineOps = {
   append: (op: Operation, opts?: WriteOptions) => Promise<void>;
   appendMany: (ops: Operation[], opts?: WriteOptions) => Promise<void>;
@@ -109,15 +123,22 @@ export type TreecrdtEngineLocal = {
     node: string,
     placement: TreecrdtSqlitePlacement,
     payload: Uint8Array | null,
+    opts?: LocalWriteOptions,
   ) => Promise<Operation>;
   move: (
     replica: ReplicaId,
     node: string,
     newParent: string,
     placement: TreecrdtSqlitePlacement,
+    opts?: LocalWriteOptions,
   ) => Promise<Operation>;
-  delete: (replica: ReplicaId, node: string) => Promise<Operation>;
-  payload: (replica: ReplicaId, node: string, payload: Uint8Array | null) => Promise<Operation>;
+  delete: (replica: ReplicaId, node: string, opts?: LocalWriteOptions) => Promise<Operation>;
+  payload: (
+    replica: ReplicaId,
+    node: string,
+    payload: Uint8Array | null,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
 };
 
 /**

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -59,6 +59,25 @@ async function sqliteExec(runner: SqliteRunner, sql: string): Promise<void> {
 
 let localAuthSavepointCounter = 0;
 
+function decodeLocalOpResult(
+  raw: any,
+  sql: string,
+): { op: Operation; outcome: MaterializationOutcome } {
+  const ops = decodeSqliteOps([raw.op]);
+  if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
+  return {
+    op: ops[0]!,
+    outcome: decodeSqliteMaterializationOutcome(raw.outcome),
+  };
+}
+
+function emitLocalOutcome(
+  outcome: MaterializationOutcome,
+  emit?: (event: MaterializationEvent) => void,
+): void {
+  if (outcome.changes.length > 0) emit?.({ ...outcome });
+}
+
 const ROOT_NODE_BYTES = nodeIdToBytes16(ROOT_NODE_ID_HEX);
 
 function buildAppendOp(
@@ -594,27 +613,26 @@ export function createTreecrdtSqliteWriter(
   ) => {
     const authSession = writeOpts?.authSession;
     if (!authSession) {
-      const raw = await sqliteGetJson<any>(runner, sql, params);
-      const ops = decodeSqliteOps([raw.op]);
-      if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
-      const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
-      if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
-      return ops[0]!;
+      const { op, outcome } = decodeLocalOpResult(
+        await sqliteGetJson<any>(runner, sql, params),
+        sql,
+      );
+      emitLocalOutcome(outcome, opts.onMaterialized);
+      return op;
     }
 
     const savepoint = `treecrdt_local_auth_${++localAuthSavepointCounter}`;
     let released = false;
     await sqliteExec(runner, `SAVEPOINT ${savepoint}`);
     try {
-      const raw = await sqliteGetJson<any>(runner, sql, params);
-      const ops = decodeSqliteOps([raw.op]);
-      if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
-      const op = ops[0]!;
-      const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
+      const { op, outcome } = decodeLocalOpResult(
+        await sqliteGetJson<any>(runner, sql, params),
+        sql,
+      );
       await authSession.authorizeLocalOps([op]);
       await sqliteExec(runner, `RELEASE ${savepoint}`);
       released = true;
-      if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
+      emitLocalOutcome(outcome, opts.onMaterialized);
       return op;
     } catch (err) {
       if (!released) {

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,6 +1,6 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
 import { emptyMaterializationOutcome } from './engine.js';
-import type { MaterializationEvent, MaterializationOutcome } from './engine.js';
+import type { LocalWriteOptions, MaterializationEvent, MaterializationOutcome } from './engine.js';
 import {
   decodeNodeId,
   decodeReplicaId,
@@ -52,6 +52,12 @@ async function sqliteGetNumber(
   if (!Number.isFinite(value)) throw new Error(`expected numeric result for query: ${sql}`);
   return value;
 }
+
+async function sqliteExec(runner: SqliteRunner, sql: string): Promise<void> {
+  await runner.exec(sql);
+}
+
+let localAuthSavepointCounter = 0;
 
 const ROOT_NODE_BYTES = nodeIdToBytes16(ROOT_NODE_ID_HEX);
 
@@ -555,11 +561,20 @@ export type TreecrdtSqliteWriter = {
     parent: string,
     node: string,
     placement: TreecrdtSqlitePlacement,
-    opts?: { payload?: Uint8Array },
+    opts?: { payload?: Uint8Array } & LocalWriteOptions,
   ) => Promise<Operation>;
-  move: (node: string, newParent: string, placement: TreecrdtSqlitePlacement) => Promise<Operation>;
-  delete: (node: string) => Promise<Operation>;
-  payload: (node: string, payload: Uint8Array | null) => Promise<Operation>;
+  move: (
+    node: string,
+    newParent: string,
+    placement: TreecrdtSqlitePlacement,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
+  delete: (node: string, opts?: LocalWriteOptions) => Promise<Operation>;
+  payload: (
+    node: string,
+    payload: Uint8Array | null,
+    opts?: LocalWriteOptions,
+  ) => Promise<Operation>;
 };
 
 export function createTreecrdtSqliteWriter(
@@ -572,54 +587,97 @@ export function createTreecrdtSqliteWriter(
   const replica = opts.replica;
   const replicaBytes = replicaIdToBytes(replica);
 
-  const getLocalOp = async (sql: string, params: SqlCall['params']) => {
-    const raw = await sqliteGetJson<any>(runner, sql, params);
-    const ops = decodeSqliteOps([raw.op]);
-    if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
-    const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
-    if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
-    return ops[0]!;
+  const getLocalOp = async (
+    sql: string,
+    params: SqlCall['params'],
+    writeOpts?: LocalWriteOptions,
+  ) => {
+    const authSession = writeOpts?.authSession;
+    if (!authSession) {
+      const raw = await sqliteGetJson<any>(runner, sql, params);
+      const ops = decodeSqliteOps([raw.op]);
+      if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
+      const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
+      if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
+      return ops[0]!;
+    }
+
+    const savepoint = `treecrdt_local_auth_${++localAuthSavepointCounter}`;
+    let released = false;
+    await sqliteExec(runner, `SAVEPOINT ${savepoint}`);
+    try {
+      const raw = await sqliteGetJson<any>(runner, sql, params);
+      const ops = decodeSqliteOps([raw.op]);
+      if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
+      const op = ops[0]!;
+      const outcome = decodeSqliteMaterializationOutcome(raw.outcome);
+      await authSession.authorizeLocalOps([op]);
+      await sqliteExec(runner, `RELEASE ${savepoint}`);
+      released = true;
+      if (outcome.changes.length > 0) opts.onMaterialized?.({ ...outcome });
+      return op;
+    } catch (err) {
+      if (!released) {
+        try {
+          await sqliteExec(runner, `ROLLBACK TO ${savepoint}`);
+        } finally {
+          await sqliteExec(runner, `RELEASE ${savepoint}`);
+        }
+      }
+      throw err;
+    }
   };
 
   const insert = async (
     parent: string,
     node: string,
     placement: TreecrdtSqlitePlacement,
-    o: { payload?: Uint8Array } = {},
+    o: { payload?: Uint8Array } & LocalWriteOptions = {},
   ) => {
     const afterNode = placement.type === 'after' ? nodeIdToBytes16(placement.after) : null;
     const payload = o.payload ?? null;
-    return getLocalOp('SELECT treecrdt_local_insert(?1,?2,?3,?4,?5,?6)', [
-      replicaBytes,
-      nodeIdToBytes16(parent),
-      nodeIdToBytes16(node),
-      placement.type,
-      afterNode,
-      payload,
-    ]);
+    return getLocalOp(
+      'SELECT treecrdt_local_insert(?1,?2,?3,?4,?5,?6)',
+      [
+        replicaBytes,
+        nodeIdToBytes16(parent),
+        nodeIdToBytes16(node),
+        placement.type,
+        afterNode,
+        payload,
+      ],
+      o,
+    );
   };
 
-  const move = async (node: string, newParent: string, placement: TreecrdtSqlitePlacement) => {
+  const move = async (
+    node: string,
+    newParent: string,
+    placement: TreecrdtSqlitePlacement,
+    writeOpts?: LocalWriteOptions,
+  ) => {
     const afterNode = placement.type === 'after' ? nodeIdToBytes16(placement.after) : null;
-    return getLocalOp('SELECT treecrdt_local_move(?1,?2,?3,?4,?5)', [
-      replicaBytes,
-      nodeIdToBytes16(node),
-      nodeIdToBytes16(newParent),
-      placement.type,
-      afterNode,
-    ]);
+    return getLocalOp(
+      'SELECT treecrdt_local_move(?1,?2,?3,?4,?5)',
+      [replicaBytes, nodeIdToBytes16(node), nodeIdToBytes16(newParent), placement.type, afterNode],
+      writeOpts,
+    );
   };
 
-  const del = async (node: string) => {
-    return getLocalOp('SELECT treecrdt_local_delete(?1,?2)', [replicaBytes, nodeIdToBytes16(node)]);
+  const del = async (node: string, writeOpts?: LocalWriteOptions) => {
+    return getLocalOp(
+      'SELECT treecrdt_local_delete(?1,?2)',
+      [replicaBytes, nodeIdToBytes16(node)],
+      writeOpts,
+    );
   };
 
-  const payload = async (node: string, next: Uint8Array | null) => {
-    return getLocalOp('SELECT treecrdt_local_payload(?1,?2,?3)', [
-      replicaBytes,
-      nodeIdToBytes16(node),
-      next,
-    ]);
+  const payload = async (node: string, next: Uint8Array | null, writeOpts?: LocalWriteOptions) => {
+    return getLocalOp(
+      'SELECT treecrdt_local_payload(?1,?2,?3)',
+      [replicaBytes, nodeIdToBytes16(node), next],
+      writeOpts,
+    );
   };
 
   return { insert, move, delete: del, payload };

--- a/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
@@ -13,6 +13,7 @@ import {
   type SyncBenchWorkload,
 } from '@treecrdt/benchmark';
 import type { Operation } from '@treecrdt/interface';
+import type { LocalWriteOptions } from '@treecrdt/interface/engine';
 import { bytesToHex, nodeIdToBytes16 } from '@treecrdt/interface/ids';
 import {
   createInMemoryConnectedPeers,
@@ -307,6 +308,83 @@ export async function runTreecrdtMaterializationEventE2E(): Promise<{
   } finally {
     await client.close();
   }
+}
+
+async function runAuthLocalWriteCase(opts: {
+  storage: 'memory' | 'opfs';
+  preferWorker?: boolean;
+}): Promise<{
+  rollback: { exists: boolean; eventCount: number; opCount: number };
+  success: { exists: boolean; eventCount: number; opCount: number; authorizedBeforeEvent: boolean };
+}> {
+  const docId = `e2e-auth-local-write-${opts.storage}-${crypto.randomUUID()}`;
+  const client = await createTreecrdtClient({
+    storage: opts.storage,
+    preferWorker: opts.preferWorker,
+    docId,
+  });
+  const root = '0'.repeat(32);
+  const replica = replicaFromLabel('auth-local-write');
+  const rollbackNode = nodeIdFromInt(201);
+  const successNode = nodeIdFromInt(202);
+  const events: unknown[] = [];
+  const unsubscribe = client.onMaterialized((event) => events.push(event));
+
+  try {
+    const rejectAuth: LocalWriteOptions['authSession'] = {
+      authorizeLocalOps: async () => {
+        throw new Error('local auth denied');
+      },
+    };
+
+    try {
+      await client.local.insert(replica, root, rollbackNode, { type: 'last' }, null, {
+        authSession: rejectAuth,
+      });
+      throw new Error('expected local auth denial');
+    } catch (err) {
+      if (!(err instanceof Error) || !err.message.includes('local auth denied')) throw err;
+    }
+
+    const rollback = {
+      exists: await client.tree.exists(rollbackNode),
+      eventCount: events.length,
+      opCount: (await client.ops.all()).length,
+    };
+
+    let authorizedBeforeEvent = false;
+    const allowAuth: LocalWriteOptions['authSession'] = {
+      authorizeLocalOps: async () => {
+        authorizedBeforeEvent = events.length === 0;
+      },
+    };
+
+    await client.local.insert(replica, root, successNode, { type: 'last' }, null, {
+      authSession: allowAuth,
+    });
+
+    const success = {
+      exists: await client.tree.exists(successNode),
+      eventCount: events.length,
+      opCount: (await client.ops.all()).length,
+      authorizedBeforeEvent,
+    };
+
+    return { rollback, success };
+  } finally {
+    unsubscribe();
+    await client.close();
+  }
+}
+
+export async function runTreecrdtAuthLocalWriteE2E(): Promise<{
+  ok: true;
+  direct: Awaited<ReturnType<typeof runAuthLocalWriteCase>>;
+  worker: Awaited<ReturnType<typeof runAuthLocalWriteCase>>;
+}> {
+  const direct = await runAuthLocalWriteCase({ storage: 'memory' });
+  const worker = await runAuthLocalWriteCase({ storage: 'opfs', preferWorker: true });
+  return { ok: true, direct, worker };
 }
 
 export async function runTreecrdtSyncLargeFanoutE2E(): Promise<{ ok: true }> {
@@ -622,6 +700,7 @@ declare global {
   interface Window {
     runTreecrdtSyncE2E?: typeof runTreecrdtSyncE2E;
     runTreecrdtMaterializationEventE2E?: typeof runTreecrdtMaterializationEventE2E;
+    runTreecrdtAuthLocalWriteE2E?: typeof runTreecrdtAuthLocalWriteE2E;
     runTreecrdtSyncLargeFanoutE2E?: typeof runTreecrdtSyncLargeFanoutE2E;
     runTreecrdtSyncSubscribeE2E?: typeof runTreecrdtSyncSubscribeE2E;
     runTreecrdtSyncBench?: typeof runTreecrdtSyncBench;
@@ -631,6 +710,7 @@ declare global {
 if (typeof window !== 'undefined') {
   window.runTreecrdtSyncE2E = runTreecrdtSyncE2E;
   window.runTreecrdtMaterializationEventE2E = runTreecrdtMaterializationEventE2E;
+  window.runTreecrdtAuthLocalWriteE2E = runTreecrdtAuthLocalWriteE2E;
   window.runTreecrdtSyncLargeFanoutE2E = runTreecrdtSyncLargeFanoutE2E;
   window.runTreecrdtSyncSubscribeE2E = runTreecrdtSyncSubscribeE2E;
   window.runTreecrdtSyncBench = runTreecrdtSyncBench;

--- a/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/sync.spec.ts
@@ -32,3 +32,26 @@ test('appendMany emits materialization event e2e', async ({ page }) => {
   expect(result.eventIds).toEqual([...result.eventIds].sort());
   expect(result.children.length).toBe(1);
 });
+
+test('auth-aware local writes roll back and defer materialization events e2e', async ({ page }) => {
+  test.setTimeout(90_000);
+  await page.goto('/');
+  await page.waitForFunction(() => typeof window.runTreecrdtAuthLocalWriteE2E === 'function');
+
+  const result = await page.evaluate(async () => {
+    const runner = window.runTreecrdtAuthLocalWriteE2E;
+    if (!runner) throw new Error('runTreecrdtAuthLocalWriteE2E not available');
+    return await runner();
+  });
+
+  expect(result.ok).toBe(true);
+  for (const mode of [result.direct, result.worker]) {
+    expect(mode.rollback.exists).toBe(false);
+    expect(mode.rollback.eventCount).toBe(0);
+    expect(mode.rollback.opCount).toBe(0);
+    expect(mode.success.exists).toBe(true);
+    expect(mode.success.eventCount).toBe(1);
+    expect(mode.success.opCount).toBe(1);
+    expect(mode.success.authorizedBeforeEvent).toBe(true);
+  }
+});

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -19,7 +19,10 @@ import {
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
 import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
-import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
+import {
+  createMaterializationDispatcher,
+  createTreecrdtEngineLocal,
+} from '@treecrdt/interface/engine';
 import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
@@ -537,6 +540,13 @@ function makeTreecrdtClientFromCall(opts: {
     writeOpts?: LocalWriteOptions,
   ) => localWriterFor(replica).payload(node, payload, writeOpts);
 
+  const local = createTreecrdtEngineLocal({
+    insert: localInsertImpl,
+    move: localMoveImpl,
+    delete: localDeleteImpl,
+    payload: localPayloadImpl,
+  });
+
   const closeImpl = async () => {
     if (closePromise) return await closePromise;
     closePromise = (async () => {
@@ -581,12 +591,7 @@ function makeTreecrdtClientFromCall(opts: {
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
     auth: createLazyAuthApi({ runner, docId: opts.docId }),
-    local: {
-      insert: localInsertImpl,
-      move: localMoveImpl,
-      delete: localDeleteImpl,
-      payload: localPayloadImpl,
-    },
+    local,
     onMaterialized: materialized.onMaterialized,
     close: closeImpl,
     drop: opts.drop,

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -298,19 +298,6 @@ async function createDirectClient(opts: {
     exec: (sql) => db.exec(sql),
     getText: (sql, params = []) => dbGetText(db, sql, params),
   };
-  const localWriters = new Map<string, TreecrdtSqliteWriter>();
-  const localWriterKey = (replica: ReplicaId) => bytesToHex(replica);
-  const localWriterFor = (replica: ReplicaId) => {
-    const key = localWriterKey(replica);
-    const existing = localWriters.get(key);
-    if (existing) return existing;
-    const next = createTreecrdtSqliteWriter(runner, {
-      replica,
-      onMaterialized: materialized.emitEvent,
-    });
-    localWriters.set(key, next);
-    return next;
-  };
   const wrapError = (stage: string, err: unknown) =>
     new Error(
       JSON.stringify({
@@ -406,31 +393,6 @@ async function createDirectClient(opts: {
         case 'replicaMaxCounter': {
           const [rawReplica] = params as RpcParams<'replicaMaxCounter'>;
           return (await adapter.replicaMaxCounter(Uint8Array.from(rawReplica))) as any;
-        }
-        case 'localInsert': {
-          const [replica, parent, node, placement, payload] = params as RpcParams<'localInsert'>;
-          return (await localWriterFor(Uint8Array.from(replica)).insert(
-            parent,
-            node,
-            placement,
-            payload ? { payload } : {},
-          )) as any;
-        }
-        case 'localMove': {
-          const [replica, node, newParent, placement] = params as RpcParams<'localMove'>;
-          return (await localWriterFor(Uint8Array.from(replica)).move(
-            node,
-            newParent,
-            placement,
-          )) as any;
-        }
-        case 'localDelete': {
-          const [replica, node] = params as RpcParams<'localDelete'>;
-          return (await localWriterFor(Uint8Array.from(replica)).delete(node)) as any;
-        }
-        case 'localPayload': {
-          const [replica, node, payload] = params as RpcParams<'localPayload'>;
-          return (await localWriterFor(Uint8Array.from(replica)).payload(node, payload)) as any;
         }
         case 'close': {
           if (db.close) await db.close();
@@ -554,58 +516,26 @@ function makeTreecrdtClientFromCall(opts: {
     placement: TreecrdtSqlitePlacement,
     payload: Uint8Array | null,
     writeOpts?: LocalWriteOptions,
-  ) => {
-    if (writeOpts?.authSession) {
-      return localWriterFor(replica).insert(parent, node, placement, {
-        ...writeOpts,
-        ...(payload ? { payload } : {}),
-      });
-    }
-    const rid = Array.from(replica);
-    return (await call('localInsert', [
-      rid,
-      parent,
-      node,
-      placement,
-      payload,
-    ])) as unknown as Operation;
-  };
+  ) =>
+    localWriterFor(replica).insert(parent, node, placement, {
+      ...writeOpts,
+      ...(payload ? { payload } : {}),
+    });
   const localMoveImpl = async (
     replica: ReplicaId,
     node: string,
     newParent: string,
     placement: TreecrdtSqlitePlacement,
     writeOpts?: LocalWriteOptions,
-  ) => {
-    if (writeOpts?.authSession) {
-      return localWriterFor(replica).move(node, newParent, placement, writeOpts);
-    }
-    const rid = Array.from(replica);
-    return (await call('localMove', [rid, node, newParent, placement])) as unknown as Operation;
-  };
-  const localDeleteImpl = async (
-    replica: ReplicaId,
-    node: string,
-    writeOpts?: LocalWriteOptions,
-  ) => {
-    if (writeOpts?.authSession) {
-      return localWriterFor(replica).delete(node, writeOpts);
-    }
-    const rid = Array.from(replica);
-    return (await call('localDelete', [rid, node])) as unknown as Operation;
-  };
+  ) => localWriterFor(replica).move(node, newParent, placement, writeOpts);
+  const localDeleteImpl = async (replica: ReplicaId, node: string, writeOpts?: LocalWriteOptions) =>
+    localWriterFor(replica).delete(node, writeOpts);
   const localPayloadImpl = async (
     replica: ReplicaId,
     node: string,
     payload: Uint8Array | null,
     writeOpts?: LocalWriteOptions,
-  ) => {
-    if (writeOpts?.authSession) {
-      return localWriterFor(replica).payload(node, payload, writeOpts);
-    }
-    const rid = Array.from(replica);
-    return (await call('localPayload', [rid, node, payload])) as unknown as Operation;
-  };
+  ) => localWriterFor(replica).payload(node, payload, writeOpts);
 
   const closeImpl = async () => {
     if (closePromise) return await closePromise;

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -165,10 +165,16 @@ async function createWorkerClient(opts: {
   >();
   let terminalError: Error | null = null;
   let closed = false;
+  let callQueue: Promise<void> = Promise.resolve();
 
   const closedError = new Error(CLIENT_CLOSED_ERROR);
+  const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
+    promise.then(
+      () => undefined,
+      () => undefined,
+    );
 
-  const call = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+  const callRaw = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
     if (closed) return Promise.reject(closedError);
     const id = nextId++;
     if (terminalError) return Promise.reject(terminalError);
@@ -176,6 +182,11 @@ async function createWorkerClient(opts: {
       pending.set(id, { resolve, reject });
       worker.postMessage({ id, method, params } satisfies RpcRequest<M>);
     });
+  };
+  const call = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+    const run = callQueue.then(() => callRaw(method, params));
+    callQueue = settleQueue(run);
+    return run;
   };
 
   const onMessage = (ev: MessageEvent<RpcResponse | RpcPushMessage>) => {

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -18,7 +18,7 @@ import {
   nodeIdToBytes16,
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
-import type { TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
@@ -486,6 +486,19 @@ function makeTreecrdtClientFromCall(opts: {
     exec: (sql) => call('sqlExec', [sql]).then(() => undefined),
     getText: (sql, params = []) => call('sqlGetText', [sql, params]),
   };
+  const localWriters = new Map<string, TreecrdtSqliteWriter>();
+  const localWriterKey = (replica: ReplicaId) => bytesToHex(replica);
+  const localWriterFor = (replica: ReplicaId) => {
+    const key = localWriterKey(replica);
+    const existing = localWriters.get(key);
+    if (existing) return existing;
+    const next = createTreecrdtSqliteWriter(runner, {
+      replica,
+      onMaterialized: materialized.emitEvent,
+    });
+    localWriters.set(key, next);
+    return next;
+  };
 
   const opsSinceImpl = async (lamport: number, root?: string) => {
     const rows = await call('opsSince', [lamport, root]);
@@ -529,7 +542,14 @@ function makeTreecrdtClientFromCall(opts: {
     node: string,
     placement: TreecrdtSqlitePlacement,
     payload: Uint8Array | null,
+    writeOpts?: LocalWriteOptions,
   ) => {
+    if (writeOpts?.authSession) {
+      return localWriterFor(replica).insert(parent, node, placement, {
+        ...writeOpts,
+        ...(payload ? { payload } : {}),
+      });
+    }
     const rid = Array.from(replica);
     return (await call('localInsert', [
       rid,
@@ -544,15 +564,34 @@ function makeTreecrdtClientFromCall(opts: {
     node: string,
     newParent: string,
     placement: TreecrdtSqlitePlacement,
+    writeOpts?: LocalWriteOptions,
   ) => {
+    if (writeOpts?.authSession) {
+      return localWriterFor(replica).move(node, newParent, placement, writeOpts);
+    }
     const rid = Array.from(replica);
     return (await call('localMove', [rid, node, newParent, placement])) as unknown as Operation;
   };
-  const localDeleteImpl = async (replica: ReplicaId, node: string) => {
+  const localDeleteImpl = async (
+    replica: ReplicaId,
+    node: string,
+    writeOpts?: LocalWriteOptions,
+  ) => {
+    if (writeOpts?.authSession) {
+      return localWriterFor(replica).delete(node, writeOpts);
+    }
     const rid = Array.from(replica);
     return (await call('localDelete', [rid, node])) as unknown as Operation;
   };
-  const localPayloadImpl = async (replica: ReplicaId, node: string, payload: Uint8Array | null) => {
+  const localPayloadImpl = async (
+    replica: ReplicaId,
+    node: string,
+    payload: Uint8Array | null,
+    writeOpts?: LocalWriteOptions,
+  ) => {
+    if (writeOpts?.authSession) {
+      return localWriterFor(replica).payload(node, payload, writeOpts);
+    }
     const rid = Array.from(replica);
     return (await call('localPayload', [rid, node, payload])) as unknown as Operation;
   };

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -1,6 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
 import type { MaterializationEvent, MaterializationOutcome } from '@treecrdt/interface/engine';
-import type { TreecrdtSqlitePlacement } from '@treecrdt/interface/sqlite';
 
 export type RpcStorageMode = 'memory' | 'opfs';
 
@@ -44,30 +43,6 @@ export type RpcSchema = {
   treePayload: { params: [node: string]; result: number[] | null };
   headLamport: { params: []; result: number };
   replicaMaxCounter: { params: [replica: number[]]; result: number };
-  localInsert: {
-    params: [
-      replica: number[],
-      parent: string,
-      node: string,
-      placement: TreecrdtSqlitePlacement,
-      payload: Uint8Array | null,
-    ];
-    result: Operation;
-  };
-  localMove: {
-    params: [
-      replica: number[],
-      node: string,
-      newParent: string,
-      placement: TreecrdtSqlitePlacement,
-    ];
-    result: Operation;
-  };
-  localDelete: { params: [replica: number[], node: string]; result: Operation };
-  localPayload: {
-    params: [replica: number[], node: string, payload: Uint8Array | null];
-    result: Operation;
-  };
   close: { params: []; result: void };
   drop: { params: []; result: void };
 };

--- a/packages/treecrdt-wa-sqlite/src/worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/worker.ts
@@ -1,15 +1,9 @@
 /// <reference lib="webworker" />
 import { dbGetText } from './sql.js';
 import type { Database } from './index.js';
-import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
-import type { Operation, ReplicaId } from '@treecrdt/interface';
+import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
+import type { Operation } from '@treecrdt/interface';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
-import {
-  createTreecrdtSqliteWriter,
-  type SqliteRunner,
-  type TreecrdtSqlitePlacement,
-  type TreecrdtSqliteWriter,
-} from '@treecrdt/interface/sqlite';
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
 import type { RpcMethod, RpcRequest, RpcSqlParams } from './rpc.js';
 import { openTreecrdtDb } from './open.js';
@@ -19,8 +13,6 @@ let db: Database | null = null;
 let storedFilename: string | undefined;
 let storedStorage: 'memory' | 'opfs' = 'memory';
 let api: TreecrdtAdapter | null = null;
-let runner: SqliteRunner | null = null;
-const localWriters = new Map<string, TreecrdtSqliteWriter>();
 
 function postMaterialized(event: MaterializationEvent) {
   (self as unknown as Worker).postMessage({ type: 'materialized', event });
@@ -45,10 +37,6 @@ const methods = {
   treePayload,
   headLamport,
   replicaMaxCounter,
-  localInsert,
-  localMove,
-  localDelete,
-  localPayload,
   close,
   drop,
 } as const;
@@ -82,7 +70,6 @@ async function init(
     if (db.close) await db.close();
     db = null;
     api = null;
-    runner = null;
   }
   const opened = await openTreecrdtDb({
     baseUrl,
@@ -94,10 +81,8 @@ async function init(
   });
   db = opened.db;
   api = opened.api;
-  runner = makeRunner(opened.db);
   storedFilename = opened.filename;
   storedStorage = opened.storage;
-  localWriters.clear();
   return opened.opfsError
     ? { storage: opened.storage, opfsError: opened.opfsError }
     : { storage: opened.storage };
@@ -201,45 +186,12 @@ async function replicaMaxCounter(replica: number[]) {
   return await api.replicaMaxCounter(Uint8Array.from(replica));
 }
 
-async function localInsert(
-  replica: number[],
-  parent: string,
-  node: string,
-  placement: TreecrdtSqlitePlacement,
-  payload: Uint8Array | null,
-) {
-  const writer = ensureLocalWriter(Uint8Array.from(replica));
-  return await writer.insert(parent, node, placement, payload ? { payload } : {});
-}
-
-async function localMove(
-  replica: number[],
-  node: string,
-  newParent: string,
-  placement: TreecrdtSqlitePlacement,
-) {
-  const writer = ensureLocalWriter(Uint8Array.from(replica));
-  return await writer.move(node, newParent, placement);
-}
-
-async function localDelete(replica: number[], node: string) {
-  const writer = ensureLocalWriter(Uint8Array.from(replica));
-  return await writer.delete(node);
-}
-
-async function localPayload(replica: number[], node: string, payload: Uint8Array | null) {
-  const writer = ensureLocalWriter(Uint8Array.from(replica));
-  return await writer.payload(node, payload);
-}
-
 async function closeDbAndReset() {
   if (db?.close) await db.close();
   db = null;
   api = null;
-  runner = null;
   storedFilename = undefined;
   storedStorage = 'memory';
-  localWriters.clear();
 }
 
 async function close() {
@@ -265,32 +217,4 @@ function ensureApi(): TreecrdtAdapter {
 function ensureDb(): Database {
   if (!db) throw new Error('db not initialized');
   return db;
-}
-
-function ensureRunner(): SqliteRunner {
-  if (!runner) throw new Error('db not initialized');
-  return runner;
-}
-
-function makeRunner(db: Database): SqliteRunner {
-  return {
-    exec: (sql) => db.exec(sql),
-    getText: (sql, params = []) => dbGetText(db, sql, params),
-  };
-}
-
-function replicaKey(replica: ReplicaId): string {
-  return bytesToHex(replica);
-}
-
-function ensureLocalWriter(replica: ReplicaId): TreecrdtSqliteWriter {
-  const key = replicaKey(replica);
-  const existing = localWriters.get(key);
-  if (existing) return existing;
-  const writer = createTreecrdtSqliteWriter(ensureRunner(), {
-    replica,
-    onMaterialized: postMaterialized,
-  });
-  localWriters.set(key, writer);
-  return writer;
 }


### PR DESCRIPTION
## Summary

Local writes can now be authorized before they become durable/materialized. Core exposes a prepared-local-write boundary, and each backend commits only after JS auth accepts the minted op.

- Adds `LocalWriteOptions` so apps can pass `authSession` directly to `client.local.*`.
- Adds `client.local.forReplica(replica, opts)` to bind repeated replica/auth options once.
- Uses core `prepare_local_*` + `commit_prepared_local` so local op construction and commit are separate.
- Wires sqlite-node, wa-sqlite, and Postgres through the same prepared-write semantics.
- Updates the playground to use the bound local writer and clearly hand committed ops to playground sync/debug code.
- Adds rollback/deferred-materialization coverage across core, SQLite, wa-sqlite, and Postgres.

## API Shape

Before, apps had to write first and authorize afterward:

```ts
const op = await client.local.payload(replica, nodeId, payload);
await authSession.authorizeLocalOps([op]);
```

After this PR, auth is part of the local write. If auth rejects, the write rolls back and no committed op is returned:

```ts
const op = await client.local.payload(replica, nodeId, payload, { authSession });
```

Apps that repeatedly write from the same replica/session can bind those options once:

```ts
const local = client.local.forReplica(replica, { authSession });

const op = await local.payload(nodeId, nextPayload);
await sync.pushLocalOps([op]);
```

The returned op is still available for immediate upload through the #130 sync API or for app-specific bookkeeping.

## Backend Notes

SQLite keeps a savepoint around the local UDF call because JS auth runs outside the extension. Postgres uses a prepared transaction path: native prepares the op, JS authorizes it, then native commits or rolls back.

The main tradeoff is that Postgres may hold a transaction open while `authorizeLocalOps` awaits. That is intentional to get correct rollback semantics.
