### PR TITLE
Split playground auth session hook

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -207,7 +207,7 @@ export default function App() {
     authMaterial,
     syncAuth,
     refreshAuthMaterial,
-    localIdentityChainPromiseRef,
+    resetLocalIdentityChain,
     replica,
     selfPeerId,
     viewRootId,
@@ -1117,7 +1117,7 @@ export default function App() {
               setIdentityKeyBlobImportText,
               deviceSigningKeyBlobImportText,
               setDeviceSigningKeyBlobImportText,
-              localIdentityChainPromiseRef,
+              resetLocalIdentityChain,
             }}
             treeParentRef={treeParentRef}
             treeVirtualizer={treeVirtualizer}

--- a/examples/playground/src/playground/components/SharingAuthPanel.tsx
+++ b/examples/playground/src/playground/components/SharingAuthPanel.tsx
@@ -52,7 +52,7 @@ type SharingAuthPanelProps = {
   deviceSigningKeyBlobImportText: string;
   setDeviceSigningKeyBlobImportText: React.Dispatch<React.SetStateAction<string>>;
 
-  localIdentityChainPromiseRef: PlaygroundAuthApi["localIdentityChainPromiseRef"];
+  resetLocalIdentityChain: PlaygroundAuthApi["resetLocalIdentityChain"];
 
   client: unknown | null;
   pendingOps: PlaygroundAuthApi["pendingOps"];
@@ -189,7 +189,7 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
     setIdentityKeyBlobImportText,
     deviceSigningKeyBlobImportText,
     setDeviceSigningKeyBlobImportText,
-    localIdentityChainPromiseRef,
+    resetLocalIdentityChain,
   } = props;
 
   const deviceWrapKeyB64 = getDeviceWrapKeyB64();
@@ -467,7 +467,7 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
               setAuthError={setAuthError}
               onImport={(value) => {
                 setSealedIdentityKeyB64(value);
-                localIdentityChainPromiseRef.current = null;
+                resetLocalIdentityChain();
               }}
             />
 
@@ -485,7 +485,7 @@ export function SharingAuthPanel(props: SharingAuthPanelProps) {
               setAuthError={setAuthError}
               onImport={(value) => {
                 setSealedDeviceSigningKeyB64(value);
-                localIdentityChainPromiseRef.current = null;
+                resetLocalIdentityChain();
               }}
             />
           </div>

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -17,7 +17,6 @@ import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 
 import {
   clearAuthMaterial,
-  createLocalIdentityChainV1,
   createCapabilityTokenV1,
   decodeInvitePayload,
   encodeInvitePayload,
@@ -216,9 +215,7 @@ export type PlaygroundAuthApi = {
   authMaterial: StoredAuthMaterial;
   syncAuth: SyncAuth<Operation> | null;
   refreshAuthMaterial: () => Promise<StoredAuthMaterial>;
-  localIdentityChainPromiseRef: React.MutableRefObject<
-    Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
-  >;
+  resetLocalIdentityChain: () => void;
 
   replica: Uint8Array | null;
   selfPeerId: string | null;
@@ -482,11 +479,11 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
   const {
     syncAuth,
-    localIdentityChainPromiseRef,
     replica,
     selfPeerId,
     getLocalWriteOptions,
     clearAuthSession,
+    resetLocalIdentityChain,
   } = usePlaygroundAuthSession({
     authEnabled,
     client,
@@ -1334,7 +1331,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     authMaterial,
     syncAuth,
     refreshAuthMaterial,
-    localIdentityChainPromiseRef,
+    resetLocalIdentityChain,
     replica,
     selfPeerId,
     viewRootId,

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { bytesToHex } from "@treecrdt/interface/ids";
 import type { Operation } from "@treecrdt/interface";
 import type { LocalWriteOptions } from "@treecrdt/interface/engine";
+import { bytesToHex } from "@treecrdt/interface/ids";
 import {
   base64urlDecode,
   base64urlEncode,
@@ -10,11 +10,8 @@ import {
   deriveTokenIdV1,
   issueTreecrdtDelegatedCapabilityTokenV1,
   type TreecrdtCapabilityTokenV1,
-  type TreecrdtAuthSession,
 } from "@treecrdt/auth";
-import {
-  createTreecrdtSqliteSyncDiagnostics,
-} from "@treecrdt/sync-sqlite";
+import { createTreecrdtSqliteSyncDiagnostics } from "@treecrdt/sync-sqlite";
 import type { SyncAuth } from "@treecrdt/sync-protocol";
 import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
 
@@ -45,6 +42,7 @@ import { prefixPlaygroundStorageKey } from "../storage";
 import type { InviteActions } from "../invite";
 import type { ToastState } from "../components/PlaygroundToast";
 import type { SyncTransportMode } from "../types";
+import { usePlaygroundAuthSession } from "./usePlaygroundAuthSession";
 
 function computeInviteExcludeNodeIds(privateRoots: Set<string>, inviteRoot: string): string[] {
   return Array.from(privateRoots).filter((id) => id !== inviteRoot && id !== ROOT_ID && /^[0-9a-f]{32}$/i.test(id));
@@ -323,12 +321,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     localTokensB64: [],
   }));
 
-  const [syncAuth, setSyncAuth] = useState<SyncAuth<Operation> | null>(null);
-  const localAuthSessionRef = useRef<TreecrdtAuthSession | null>(null);
-  const localIdentityChainPromiseRef = useRef<
-    Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
-  >(null);
-
   const [authToken, setAuthToken] = useState<TreecrdtCapabilityTokenV1 | null>(null);
   const [hardRevokedTokenIds, setHardRevokedTokenIds] = useState<string[]>([]);
 
@@ -396,11 +388,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     },
     [docId]
   );
-
-  useEffect(() => {
-    // Local identity chains are doc-bound (replica cert includes `docId`) and depend on the current replica key.
-    localIdentityChainPromiseRef.current = null;
-  }, [docId, authMaterial.localPkB64, revealIdentity]);
 
   const togglePrivateRoot = (id: string) => {
     if (id === ROOT_ID) return;
@@ -476,24 +463,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     void refreshAuthMaterial().catch((err) => setAuthError(err instanceof Error ? err.message : String(err)));
   }, [docId, refreshAuthMaterial]);
 
-  const getLocalIdentityChain = React.useCallback(async () => {
-    if (!revealIdentity) return null;
-    const pkB64 = authMaterial.localPkB64;
-    if (!pkB64) return null;
-
-    if (!localIdentityChainPromiseRef.current) {
-      const replicaPk = base64urlDecode(pkB64);
-      localIdentityChainPromiseRef.current = createLocalIdentityChainV1({ docId, replicaPublicKey: replicaPk }).catch(
-        (err) => {
-          console.error("Failed to create identity chain", err);
-          return null;
-        }
-      );
-    }
-
-    return await localIdentityChainPromiseRef.current;
-  }, [authMaterial.localPkB64, docId, revealIdentity]);
-
   useEffect(() => {
     let cancelled = false;
     void (async () => {
@@ -511,97 +480,23 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     };
   }, [docId]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setSyncAuth(null);
-
-    if (!authEnabled || !client) {
-      localAuthSessionRef.current = null;
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const { issuerPkB64, localSkB64, localPkB64 } = authMaterial;
-    const localTokensB64 = authMaterial.localTokensB64;
-
-    if (!issuerPkB64 || !localSkB64 || !localPkB64 || localTokensB64.length === 0) {
-      localAuthSessionRef.current = null;
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    void (async () => {
-      try {
-        const issuerPk = base64urlDecode(issuerPkB64);
-        const localSk = base64urlDecode(localSkB64);
-        const localPk = base64urlDecode(localPkB64);
-        const localTokens = localTokensB64.map((t) => base64urlDecode(t));
-
-        const authSession = await client.auth.createSession({
-          docId,
-          trust: { issuerPublicKeys: [issuerPk] },
-          local: {
-            privateKey: localSk,
-            publicKey: localPk,
-            capabilityTokens: localTokens,
-          },
-          revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
-          requireProofRef: true,
-          identity: {
-            onPeer: onPeerIdentityChain,
-            local: getLocalIdentityChain,
-          },
-        });
-        if (cancelled) return;
-
-        const preparedAuth = authSession.syncAuth;
-        localAuthSessionRef.current = authSession;
-
-        await authSession.ready;
-        if (cancelled) return;
-        setSyncAuth(preparedAuth);
-      } catch (err) {
-        if (cancelled) return;
-        localAuthSessionRef.current = null;
-        setSyncAuth(null);
-        setAuthError(err instanceof Error ? err.message : String(err));
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      if (localAuthSessionRef.current) localAuthSessionRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
+  const {
+    syncAuth,
+    localIdentityChainPromiseRef,
+    replica,
+    selfPeerId,
+    getLocalWriteOptions,
+    clearAuthSession,
+  } = usePlaygroundAuthSession({
     authEnabled,
     client,
     docId,
-    authMaterial.issuerPkB64,
-    authMaterial.localSkB64,
-    authMaterial.localPkB64,
-    authMaterial.localTokensB64.join(","),
-    hardRevokedTokenIds.join(","),
-    getLocalIdentityChain,
+    authMaterial,
+    hardRevokedTokenIds,
+    revealIdentity,
     onPeerIdentityChain,
-  ]);
-
-  const replica = useMemo(() => (authMaterial.localPkB64 ? base64urlDecode(authMaterial.localPkB64) : null), [
-    authMaterial.localPkB64,
-  ]);
-  const selfPeerId = useMemo(() => (replica ? bytesToHex(replica) : null), [replica]);
-
-  const getLocalWriteOptions = React.useCallback(
-    (): LocalWriteOptions | undefined => {
-      if (!authEnabled) return;
-      const session = localAuthSessionRef.current;
-      if (!session) throw new Error("auth is enabled but not configured");
-      return { authSession: session };
-    },
-    [authEnabled]
-  );
+    setAuthError,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -700,8 +595,6 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
       return [...prev, normalized];
     });
   }, []);
-
-  const hardRevokedTokenIdBytes = useMemo(() => hardRevokedTokenIds.map((hex) => hexToBytes16(hex)), [hardRevokedTokenIds]);
 
   const importInvitePayload = React.useCallback(
     async (inviteB64: string, opts2: { clearHash?: boolean } = {}) => {
@@ -893,7 +786,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         setAuthError(null);
       } catch (err) {
         if (cancelled) return;
-        localAuthSessionRef.current = null;
+        clearAuthSession();
         setAuthError(authEnabled ? (err instanceof Error ? err.message : String(err)) : null);
       }
     })();
@@ -901,7 +794,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     return () => {
       cancelled = true;
     };
-  }, [authEnabled, docId, joinMode]);
+  }, [authEnabled, clearAuthSession, docId, joinMode]);
 
   const resetAuth = () => {
     clearAuthMaterial(docId);

--- a/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
@@ -1,0 +1,189 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import type { Operation } from "@treecrdt/interface";
+import type { LocalWriteOptions } from "@treecrdt/interface/engine";
+import { bytesToHex } from "@treecrdt/interface/ids";
+import { base64urlDecode, type TreecrdtAuthSession } from "@treecrdt/auth";
+import type { SyncAuth } from "@treecrdt/sync-protocol";
+import type { TreecrdtClient } from "@treecrdt/wa-sqlite/client";
+
+import { createLocalIdentityChainV1, type StoredAuthMaterial } from "../../auth";
+import { hexToBytes16 } from "../../sync-v0";
+
+type UsePlaygroundAuthSessionOptions = {
+  authEnabled: boolean;
+  client: TreecrdtClient | null;
+  docId: string;
+  authMaterial: StoredAuthMaterial;
+  hardRevokedTokenIds: string[];
+  revealIdentity: boolean;
+  onPeerIdentityChain: (chain: {
+    identityPublicKey: Uint8Array;
+    devicePublicKey: Uint8Array;
+    replicaPublicKey: Uint8Array;
+  }) => void;
+  setAuthError: React.Dispatch<React.SetStateAction<string | null>>;
+};
+
+export type PlaygroundAuthSessionState = {
+  syncAuth: SyncAuth<Operation> | null;
+  localIdentityChainPromiseRef: React.MutableRefObject<
+    Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
+  >;
+  replica: Uint8Array | null;
+  selfPeerId: string | null;
+  getLocalWriteOptions: () => LocalWriteOptions | undefined;
+  clearAuthSession: () => void;
+};
+
+export function usePlaygroundAuthSession(
+  opts: UsePlaygroundAuthSessionOptions,
+): PlaygroundAuthSessionState {
+  const {
+    authEnabled,
+    client,
+    docId,
+    authMaterial,
+    hardRevokedTokenIds,
+    revealIdentity,
+    onPeerIdentityChain,
+    setAuthError,
+  } = opts;
+  const [syncAuth, setSyncAuth] = useState<SyncAuth<Operation> | null>(null);
+  const localAuthSessionRef = useRef<TreecrdtAuthSession | null>(null);
+  const localIdentityChainPromiseRef = useRef<
+    Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
+  >(null);
+
+  useEffect(() => {
+    // Local identity chains are doc-bound (replica cert includes `docId`) and depend on the current replica key.
+    localIdentityChainPromiseRef.current = null;
+  }, [docId, authMaterial.localPkB64, revealIdentity]);
+
+  const getLocalIdentityChain = React.useCallback(async () => {
+    if (!revealIdentity) return null;
+    const pkB64 = authMaterial.localPkB64;
+    if (!pkB64) return null;
+
+    if (!localIdentityChainPromiseRef.current) {
+      const replicaPk = base64urlDecode(pkB64);
+      localIdentityChainPromiseRef.current = createLocalIdentityChainV1({
+        docId,
+        replicaPublicKey: replicaPk,
+      }).catch((err) => {
+        console.error("Failed to create identity chain", err);
+        return null;
+      });
+    }
+
+    return await localIdentityChainPromiseRef.current;
+  }, [authMaterial.localPkB64, docId, revealIdentity]);
+
+  const hardRevokedTokenIdBytes = useMemo(
+    () => hardRevokedTokenIds.map((hex) => hexToBytes16(hex)),
+    [hardRevokedTokenIds],
+  );
+
+  const clearAuthSession = React.useCallback(() => {
+    localAuthSessionRef.current = null;
+    setSyncAuth(null);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setSyncAuth(null);
+
+    if (!authEnabled || !client) {
+      localAuthSessionRef.current = null;
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const { issuerPkB64, localSkB64, localPkB64 } = authMaterial;
+    const localTokensB64 = authMaterial.localTokensB64;
+
+    if (!issuerPkB64 || !localSkB64 || !localPkB64 || localTokensB64.length === 0) {
+      localAuthSessionRef.current = null;
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    void (async () => {
+      try {
+        const issuerPk = base64urlDecode(issuerPkB64);
+        const localSk = base64urlDecode(localSkB64);
+        const localPk = base64urlDecode(localPkB64);
+        const localTokens = localTokensB64.map((t) => base64urlDecode(t));
+
+        const authSession = await client.auth.createSession({
+          docId,
+          trust: { issuerPublicKeys: [issuerPk] },
+          local: {
+            privateKey: localSk,
+            publicKey: localPk,
+            capabilityTokens: localTokens,
+          },
+          revokedCapabilityTokenIds: hardRevokedTokenIdBytes,
+          requireProofRef: true,
+          identity: {
+            onPeer: onPeerIdentityChain,
+            local: getLocalIdentityChain,
+          },
+        });
+        if (cancelled) return;
+
+        const preparedAuth = authSession.syncAuth;
+        localAuthSessionRef.current = authSession;
+
+        await authSession.ready;
+        if (cancelled) return;
+        setSyncAuth(preparedAuth);
+      } catch (err) {
+        if (cancelled) return;
+        localAuthSessionRef.current = null;
+        setSyncAuth(null);
+        setAuthError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (localAuthSessionRef.current) localAuthSessionRef.current = null;
+    };
+  }, [
+    authEnabled,
+    client,
+    docId,
+    authMaterial.issuerPkB64,
+    authMaterial.localSkB64,
+    authMaterial.localPkB64,
+    authMaterial.localTokensB64,
+    hardRevokedTokenIdBytes,
+    getLocalIdentityChain,
+    onPeerIdentityChain,
+    setAuthError,
+  ]);
+
+  const replica = useMemo(
+    () => (authMaterial.localPkB64 ? base64urlDecode(authMaterial.localPkB64) : null),
+    [authMaterial.localPkB64],
+  );
+  const selfPeerId = useMemo(() => (replica ? bytesToHex(replica) : null), [replica]);
+
+  const getLocalWriteOptions = React.useCallback((): LocalWriteOptions | undefined => {
+    if (!authEnabled) return;
+    const session = localAuthSessionRef.current;
+    if (!session) throw new Error("auth is enabled but not configured");
+    return { authSession: session };
+  }, [authEnabled]);
+
+  return {
+    syncAuth,
+    localIdentityChainPromiseRef,
+    replica,
+    selfPeerId,
+    getLocalWriteOptions,
+    clearAuthSession,
+  };
+}

--- a/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
@@ -26,13 +26,11 @@ type UsePlaygroundAuthSessionOptions = {
 
 export type PlaygroundAuthSessionState = {
   syncAuth: SyncAuth<Operation> | null;
-  localIdentityChainPromiseRef: React.MutableRefObject<
-    Promise<Awaited<ReturnType<typeof createLocalIdentityChainV1>> | null> | null
-  >;
   replica: Uint8Array | null;
   selfPeerId: string | null;
   getLocalWriteOptions: () => LocalWriteOptions | undefined;
   clearAuthSession: () => void;
+  resetLocalIdentityChain: () => void;
 };
 
 export function usePlaygroundAuthSession(
@@ -82,6 +80,10 @@ export function usePlaygroundAuthSession(
     () => hardRevokedTokenIds.map((hex) => hexToBytes16(hex)),
     [hardRevokedTokenIds],
   );
+
+  const resetLocalIdentityChain = React.useCallback(() => {
+    localIdentityChainPromiseRef.current = null;
+  }, []);
 
   const clearAuthSession = React.useCallback(() => {
     localAuthSessionRef.current = null;
@@ -180,10 +182,10 @@ export function usePlaygroundAuthSession(
 
   return {
     syncAuth,
-    localIdentityChainPromiseRef,
     replica,
     selfPeerId,
     getLocalWriteOptions,
     clearAuthSession,
+    resetLocalIdentityChain,
   };
 }


### PR DESCRIPTION
## Summary

Extracts the playground auth session lifecycle from the large `usePlaygroundAuth` UI/grant hook. This is stacked on #131 and is a small follow-up toward #107.

## What changed

- Adds `usePlaygroundAuthSession` for prepared `client.auth.createSession` lifecycle, identity-chain warmup, `syncAuth`, replica/self peer identity, and auth-aware local write options.
- Leaves invite/grant UI policy in `usePlaygroundAuth`, but removes the lower-level session plumbing from that hook.
- Keeps the existing authenticated local writes, sync auth handoff, identity reveal, revocation, invite, and delegated grant behavior unchanged.

## Notes

This does not close #107 by itself; it is a playground-facing extraction that makes the remaining reusable auth orchestration boundary easier to see.

Refs #107.