### PR TITLE
Add wa-sqlite runtime/storage API and OPFS tab events

### DIFF
--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -654,10 +654,12 @@ export default function App() {
       const baseUrl = resolvedBase.endsWith("/") ? resolvedBase : `${resolvedBase}/`;
       const filename = storageMode === "opfs" ? `/treecrdt-playground-${keyOverride ?? sessionKey}.db` : undefined;
       const c = await createTreecrdtClient({
-        storage: storageMode,
-        baseUrl,
-        preferWorker: storageMode === "opfs",
-        filename,
+        storage:
+          storageMode === "opfs"
+            ? { type: "opfs", filename, fallback: "throw" }
+            : { type: "memory" },
+        runtime: { type: "auto" },
+        assets: { baseUrl },
         docId: docIdOverride ?? docId,
       });
       if (disposedRef.current || initEpoch !== initEpochRef.current) {

--- a/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
+++ b/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
@@ -31,7 +31,7 @@ export default function App() {
 
     (async () => {
       try {
-        const c = await createTreecrdtClient({ storage: 'memory' });
+        const c = await createTreecrdtClient({ storage: { type: 'memory' } });
         setClient(c);
       } catch (err) {
         console.error('Failed to init wa-sqlite', err);

--- a/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
+++ b/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
@@ -16,13 +16,14 @@ export default function App() {
       (window as any).__createTreecrdtClient = async (
         storage: 'memory' | 'opfs',
         baseUrl?: string,
+        runtime: 'auto' | 'dedicated-worker' | 'shared-worker' = 'auto',
       ) => {
         const c = await createTreecrdtClient({
-          storage,
-          baseUrl,
-          preferWorker: storage === 'opfs',
+          storage: storage === 'opfs' ? { type: 'opfs' } : { type: 'memory' },
+          runtime: { type: runtime },
+          assets: { baseUrl },
         });
-        const summary = { mode: c.mode, storage: c.storage };
+        const summary = { mode: c.mode, runtime: c.runtime, storage: c.storage };
         if (c.close) await c.close();
         return summary;
       };

--- a/packages/treecrdt-wa-sqlite/e2e/src/closed-client.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/closed-client.ts
@@ -18,8 +18,9 @@ export async function runClosedClientE2E(): Promise<{ ok: true } | { ok: false; 
 
   // --- Direct client (memory)
   const directClient = await createTreecrdtClient({
-    storage: 'memory',
-    baseUrl,
+    storage: { type: 'memory' },
+    runtime: { type: 'direct' },
+    assets: { baseUrl },
   });
   await directClient.close();
 
@@ -36,7 +37,11 @@ export async function runClosedClientE2E(): Promise<{ ok: true } | { ok: false; 
   if (!directDoubleClose.ok) return directDoubleClose;
 
   // --- Direct client: drop then call
-  const directDrop = await createTreecrdtClient({ storage: 'memory', baseUrl });
+  const directDrop = await createTreecrdtClient({
+    storage: { type: 'memory' },
+    runtime: { type: 'direct' },
+    assets: { baseUrl },
+  });
   await directDrop.drop();
   const directAppendAfterDrop = await directDrop.ops.append(op).then(
     () => ({ ok: false as const, error: 'append after drop should have rejected' }),
@@ -55,10 +60,9 @@ export async function runClosedClientE2E(): Promise<{ ok: true } | { ok: false; 
   if (support.available) {
     const filename = `/closed-test-${crypto.randomUUID()}.db`;
     const workerClient = await createTreecrdtClient({
-      storage: 'opfs',
-      filename,
-      preferWorker: true,
-      baseUrl,
+      storage: { type: 'opfs', filename, fallback: 'throw' },
+      runtime: { type: 'dedicated-worker' },
+      assets: { baseUrl },
     });
     await workerClient.close();
 

--- a/packages/treecrdt-wa-sqlite/e2e/src/conformance.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/conformance.ts
@@ -16,8 +16,6 @@ export async function runTreecrdtEngineConformanceE2E(
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
-  const preferWorker = storage === 'opfs';
-
   for (const scenario of treecrdtEngineConformanceScenarios()) {
     const runKey = runId.replace(/[^a-z0-9]/gi, '').slice(0, 10) || 'run';
     const scenarioKey = conformanceHashKey(scenario.name);
@@ -28,7 +26,12 @@ export async function runTreecrdtEngineConformanceE2E(
     const openEngine = async (opts: { docId: string; name?: string }) => {
       const name = opts.name ?? 'main';
       const filename = storage === 'opfs' ? filenameFor(name) : undefined;
-      return await createTreecrdtClient({ storage, preferWorker, docId: opts.docId, filename });
+      return await createTreecrdtClient({
+        storage:
+          storage === 'opfs' ? { type: 'opfs', filename, fallback: 'throw' } : { type: 'memory' },
+        runtime: { type: storage === 'opfs' ? 'dedicated-worker' : 'direct' },
+        docId: opts.docId,
+      });
     };
 
     await runTreecrdtEngineConformanceScenario(scenario, {

--- a/packages/treecrdt-wa-sqlite/e2e/src/drop-opfs.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/drop-opfs.ts
@@ -14,10 +14,9 @@ export async function runDropStorageE2E(): Promise<{ ok: true } | { ok: false; e
 
   const filename = `/drop-test-${crypto.randomUUID()}.db`;
   const client = await createTreecrdtClient({
-    storage: 'opfs',
-    filename,
-    preferWorker: true,
-    baseUrl,
+    storage: { type: 'opfs', filename, fallback: 'throw' },
+    runtime: { type: 'dedicated-worker' },
+    assets: { baseUrl },
   });
 
   try {

--- a/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/opfs-worker.ts
@@ -49,9 +49,12 @@ async function createAdapter(
   try {
     console.info(`[opfs-worker] creating client storage=${clientStorage} base=${effectiveBase}`);
     client = await createTreecrdtClient({
-      storage: clientStorage,
-      baseUrl: effectiveBase,
-      filename,
+      storage:
+        clientStorage === 'opfs'
+          ? { type: 'opfs', filename, fallback: 'throw' }
+          : { type: 'memory' },
+      runtime: { type: clientStorage === 'opfs' ? 'dedicated-worker' : 'direct' },
+      assets: { baseUrl: effectiveBase },
       docId,
     });
     // sanity check to ensure DB is valid

--- a/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
@@ -37,6 +37,14 @@ export type SyncBenchResult = {
 
 type StorageKind = 'browser-memory' | 'browser-opfs-coop-sync';
 
+const memoryStorage = { type: 'memory' } as const;
+
+function storageOptionsForMode(mode: 'memory' | 'opfs', filename?: string) {
+  return mode === 'opfs'
+    ? { type: 'opfs' as const, filename, fallback: 'throw' as const }
+    : memoryStorage;
+}
+
 function hexToBytes(hex: string): Uint8Array {
   return nodeIdToBytes16(hex);
 }
@@ -76,8 +84,8 @@ function makeBackend(
 
 async function runAllE2e(): Promise<void> {
   const docId = `e2e-sync-all-${crypto.randomUUID()}`;
-  const a = await createTreecrdtClient({ storage: 'memory', docId });
-  const b = await createTreecrdtClient({ storage: 'memory', docId });
+  const a = await createTreecrdtClient({ storage: memoryStorage, docId });
+  const b = await createTreecrdtClient({ storage: memoryStorage, docId });
   try {
     const root = '0'.repeat(32);
     const aOps = [
@@ -143,8 +151,8 @@ async function runAllE2e(): Promise<void> {
 
 async function runChildrenE2e(): Promise<void> {
   const docId = `e2e-sync-children-${crypto.randomUUID()}`;
-  const a = await createTreecrdtClient({ storage: 'memory', docId });
-  const b = await createTreecrdtClient({ storage: 'memory', docId });
+  const a = await createTreecrdtClient({ storage: memoryStorage, docId });
+  const b = await createTreecrdtClient({ storage: memoryStorage, docId });
   try {
     const parentAHex = 'a0'.repeat(16);
     const parentBHex = 'b0'.repeat(16);
@@ -221,8 +229,8 @@ async function runLargeFanoutAllE2e(): Promise<void> {
   const codewordsPerMessage = 4096;
 
   const docId = `e2e-sync-large-fanout${fanout}-${crypto.randomUUID()}`;
-  const a = await createTreecrdtClient({ storage: 'memory', docId });
-  const b = await createTreecrdtClient({ storage: 'memory', docId });
+  const a = await createTreecrdtClient({ storage: memoryStorage, docId });
+  const b = await createTreecrdtClient({ storage: memoryStorage, docId });
 
   try {
     const root = '0'.repeat(32);
@@ -271,7 +279,7 @@ export async function runTreecrdtMaterializationEventE2E(): Promise<{
   children: string[];
 }> {
   const docId = `e2e-materialization-event-${crypto.randomUUID()}`;
-  const client = await createTreecrdtClient({ storage: 'memory', docId });
+  const client = await createTreecrdtClient({ storage: memoryStorage, docId });
   try {
     const root = '0'.repeat(32);
     const parent = nodeIdFromInt(101);
@@ -310,17 +318,16 @@ export async function runTreecrdtMaterializationEventE2E(): Promise<{
   }
 }
 
-async function runAuthLocalWriteCase(opts: {
-  storage: 'memory' | 'opfs';
-  preferWorker?: boolean;
-}): Promise<{
+async function runAuthLocalWriteCase(opts: { storage: 'memory' | 'opfs' }): Promise<{
   rollback: { exists: boolean; eventCount: number; opCount: number };
   success: { exists: boolean; eventCount: number; opCount: number; authorizedBeforeEvent: boolean };
 }> {
   const docId = `e2e-auth-local-write-${opts.storage}-${crypto.randomUUID()}`;
+  // Keep this OPFS test filename short; long generated names can fail before the auth path runs.
+  const filename = `/auth-${crypto.randomUUID().replace(/-/g, '').slice(0, 16)}.db`;
   const client = await createTreecrdtClient({
-    storage: opts.storage,
-    preferWorker: opts.preferWorker,
+    storage: storageOptionsForMode(opts.storage, filename),
+    runtime: { type: opts.storage === 'opfs' ? 'dedicated-worker' : 'direct' },
     docId,
   });
   const root = '0'.repeat(32);
@@ -383,7 +390,7 @@ export async function runTreecrdtAuthLocalWriteE2E(): Promise<{
   worker: Awaited<ReturnType<typeof runAuthLocalWriteCase>>;
 }> {
   const direct = await runAuthLocalWriteCase({ storage: 'memory' });
-  const worker = await runAuthLocalWriteCase({ storage: 'opfs', preferWorker: true });
+  const worker = await runAuthLocalWriteCase({ storage: 'opfs' });
   return { ok: true, direct, worker };
 }
 
@@ -550,8 +557,8 @@ export async function closeSharedOpfsCrossTabClient(): Promise<void> {
 
 export async function runTreecrdtSyncSubscribeE2E(): Promise<{ ok: true }> {
   const docId = `e2e-sync-subscribe-${crypto.randomUUID()}`;
-  const a = await createTreecrdtClient({ storage: 'memory', docId });
-  const b = await createTreecrdtClient({ storage: 'memory', docId });
+  const a = await createTreecrdtClient({ storage: memoryStorage, docId });
+  const b = await createTreecrdtClient({ storage: memoryStorage, docId });
 
   try {
     const root = '0'.repeat(32);
@@ -725,11 +732,19 @@ async function runBenchOnce(
 ): Promise<number> {
   const docId = `bench-sync-${workload}-${size}-${crypto.randomUUID()}`;
   const mode = storage === 'browser-opfs-coop-sync' ? 'opfs' : 'memory';
-  const preferWorker = mode === 'opfs';
   const filenameA = mode === 'opfs' ? `/bench-sync-a-${crypto.randomUUID()}.db` : undefined;
   const filenameB = mode === 'opfs' ? `/bench-sync-b-${crypto.randomUUID()}.db` : undefined;
-  const a = await createTreecrdtClient({ storage: mode, preferWorker, filename: filenameA, docId });
-  const b = await createTreecrdtClient({ storage: mode, preferWorker, filename: filenameB, docId });
+  const runtime = { type: mode === 'opfs' ? 'dedicated-worker' : 'direct' } as const;
+  const a = await createTreecrdtClient({
+    storage: storageOptionsForMode(mode, filenameA),
+    runtime,
+    docId,
+  });
+  const b = await createTreecrdtClient({
+    storage: storageOptionsForMode(mode, filenameB),
+    runtime,
+    docId,
+  });
 
   try {
     await Promise.all([a.ops.appendMany(bench.opsA), b.ops.appendMany(bench.opsB)]);

--- a/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/sync.ts
@@ -13,7 +13,7 @@ import {
   type SyncBenchWorkload,
 } from '@treecrdt/benchmark';
 import type { Operation } from '@treecrdt/interface';
-import type { LocalWriteOptions } from '@treecrdt/interface/engine';
+import type { LocalWriteOptions, MaterializationEvent } from '@treecrdt/interface/engine';
 import { bytesToHex, nodeIdToBytes16 } from '@treecrdt/interface/ids';
 import {
   createInMemoryConnectedPeers,
@@ -411,6 +411,143 @@ async function waitUntil(
   throw new Error(opts.message ?? `waitUntil timeout after ${timeoutMs}ms`);
 }
 
+type SharedOpfsCrossTabEvent = {
+  headSeq: number;
+  nodes: string[];
+};
+
+type SharedOpfsCrossTabState = {
+  mode: TreecrdtClient['mode'];
+  runtime: TreecrdtClient['runtime'];
+  storage: TreecrdtClient['storage'];
+  eventCount: number;
+  events: SharedOpfsCrossTabEvent[];
+  childrenByParent: Record<string, string[]>;
+  existsByNode: Record<string, boolean>;
+  parentByNode: Record<string, string | null>;
+  payloadByNode: Record<string, string | null>;
+};
+
+let sharedOpfsCrossTabClient: TreecrdtClient | null = null;
+let sharedOpfsCrossTabUnsubscribe: (() => void) | null = null;
+let sharedOpfsCrossTabEvents: MaterializationEvent[] = [];
+
+function summarizeMaterializationEvent(event: MaterializationEvent): SharedOpfsCrossTabEvent {
+  const nodes = new Set<string>();
+  for (const change of event.changes) {
+    nodes.add(change.node);
+    if ('parentAfter' in change && change.parentAfter) nodes.add(change.parentAfter);
+    if ('parentBefore' in change && change.parentBefore) nodes.add(change.parentBefore);
+  }
+  return { headSeq: event.headSeq, nodes: [...nodes].sort() };
+}
+
+export async function openSharedOpfsCrossTabClient(opts: {
+  docId: string;
+  filename: string;
+  runtime?: 'auto' | 'dedicated-worker' | 'shared-worker';
+}): Promise<{
+  mode: TreecrdtClient['mode'];
+  runtime: TreecrdtClient['runtime'];
+  storage: TreecrdtClient['storage'];
+}> {
+  await closeSharedOpfsCrossTabClient();
+  sharedOpfsCrossTabEvents = [];
+  sharedOpfsCrossTabClient = await createTreecrdtClient({
+    docId: opts.docId,
+    storage: { type: 'opfs', filename: opts.filename },
+    runtime: { type: opts.runtime ?? 'auto' },
+  });
+  sharedOpfsCrossTabUnsubscribe = sharedOpfsCrossTabClient.onMaterialized((event) => {
+    sharedOpfsCrossTabEvents.push(event);
+  });
+  return {
+    mode: sharedOpfsCrossTabClient.mode,
+    runtime: sharedOpfsCrossTabClient.runtime,
+    storage: sharedOpfsCrossTabClient.storage,
+  };
+}
+
+export async function mutateSharedOpfsCrossTabTree(opts: {
+  replicaLabel: string;
+  action: 'insert' | 'move' | 'payload' | 'delete';
+  nodeInt: number;
+  parent?: string;
+  newParent?: string;
+  payloadText?: string;
+}): Promise<{ node: string }> {
+  if (!sharedOpfsCrossTabClient) throw new Error('shared OPFS cross-tab client is not open');
+  const root = '0'.repeat(32);
+  const node = nodeIdFromInt(opts.nodeInt);
+  const replica = replicaFromLabel(opts.replicaLabel);
+
+  if (opts.action === 'insert') {
+    await sharedOpfsCrossTabClient.local.insert(
+      replica,
+      opts.parent ?? root,
+      node,
+      { type: 'last' },
+      opts.payloadText ? new TextEncoder().encode(opts.payloadText) : null,
+    );
+  } else if (opts.action === 'move') {
+    await sharedOpfsCrossTabClient.local.move(replica, node, opts.newParent ?? root, {
+      type: 'last',
+    });
+  } else if (opts.action === 'payload') {
+    await sharedOpfsCrossTabClient.local.payload(
+      replica,
+      node,
+      opts.payloadText ? new TextEncoder().encode(opts.payloadText) : null,
+    );
+  } else {
+    await sharedOpfsCrossTabClient.local.delete(replica, node);
+  }
+
+  return { node };
+}
+
+export async function sharedOpfsCrossTabState(
+  opts: { parents?: string[]; nodes?: string[] } = {},
+): Promise<SharedOpfsCrossTabState> {
+  if (!sharedOpfsCrossTabClient) throw new Error('shared OPFS cross-tab client is not open');
+  const root = '0'.repeat(32);
+  const parents = [...new Set([root, ...(opts.parents ?? [])])];
+  const childrenByParent: Record<string, string[]> = {};
+  for (const parent of parents) {
+    childrenByParent[parent] = await sharedOpfsCrossTabClient.tree.children(parent);
+  }
+
+  const existsByNode: Record<string, boolean> = {};
+  const parentByNode: Record<string, string | null> = {};
+  const payloadByNode: Record<string, string | null> = {};
+  for (const node of opts.nodes ?? []) {
+    existsByNode[node] = await sharedOpfsCrossTabClient.tree.exists(node);
+    parentByNode[node] = await sharedOpfsCrossTabClient.tree.parent(node);
+    const payload = await sharedOpfsCrossTabClient.tree.getPayload(node);
+    payloadByNode[node] = payload ? new TextDecoder().decode(payload) : null;
+  }
+
+  return {
+    mode: sharedOpfsCrossTabClient.mode,
+    runtime: sharedOpfsCrossTabClient.runtime,
+    storage: sharedOpfsCrossTabClient.storage,
+    eventCount: sharedOpfsCrossTabEvents.length,
+    events: sharedOpfsCrossTabEvents.map(summarizeMaterializationEvent),
+    childrenByParent,
+    existsByNode,
+    parentByNode,
+    payloadByNode,
+  };
+}
+
+export async function closeSharedOpfsCrossTabClient(): Promise<void> {
+  sharedOpfsCrossTabUnsubscribe?.();
+  sharedOpfsCrossTabUnsubscribe = null;
+  const client = sharedOpfsCrossTabClient;
+  sharedOpfsCrossTabClient = null;
+  if (client) await client.close();
+}
+
 export async function runTreecrdtSyncSubscribeE2E(): Promise<{ ok: true }> {
   const docId = `e2e-sync-subscribe-${crypto.randomUUID()}`;
   const a = await createTreecrdtClient({ storage: 'memory', docId });
@@ -704,6 +841,10 @@ declare global {
     runTreecrdtSyncLargeFanoutE2E?: typeof runTreecrdtSyncLargeFanoutE2E;
     runTreecrdtSyncSubscribeE2E?: typeof runTreecrdtSyncSubscribeE2E;
     runTreecrdtSyncBench?: typeof runTreecrdtSyncBench;
+    __openSharedOpfsCrossTabClient?: typeof openSharedOpfsCrossTabClient;
+    __mutateSharedOpfsCrossTabTree?: typeof mutateSharedOpfsCrossTabTree;
+    __sharedOpfsCrossTabState?: typeof sharedOpfsCrossTabState;
+    __closeSharedOpfsCrossTabClient?: typeof closeSharedOpfsCrossTabClient;
   }
 }
 
@@ -714,4 +855,8 @@ if (typeof window !== 'undefined') {
   window.runTreecrdtSyncLargeFanoutE2E = runTreecrdtSyncLargeFanoutE2E;
   window.runTreecrdtSyncSubscribeE2E = runTreecrdtSyncSubscribeE2E;
   window.runTreecrdtSyncBench = runTreecrdtSyncBench;
+  window.__openSharedOpfsCrossTabClient = openSharedOpfsCrossTabClient;
+  window.__mutateSharedOpfsCrossTabTree = mutateSharedOpfsCrossTabTree;
+  window.__sharedOpfsCrossTabState = sharedOpfsCrossTabState;
+  window.__closeSharedOpfsCrossTabClient = closeSharedOpfsCrossTabClient;
 }

--- a/packages/treecrdt-wa-sqlite/e2e/tests/basepath.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/basepath.spec.ts
@@ -17,7 +17,7 @@ test.describe.serial('non-root base path', () => {
     expect(summary.storage).toBe('memory');
   });
 
-  test('opfs client uses worker mode in preview build with base path', async ({
+  test('opfs client uses dedicated worker mode in preview build with base path', async ({
     page,
   }, testInfo) => {
     if (testInfo.project.name !== 'chromium-basepath-preview') test.skip();
@@ -30,21 +30,23 @@ test.describe.serial('non-root base path', () => {
     });
     expect(summary).not.toBeNull();
     expect(summary.mode).toBe('worker');
+    expect(summary.runtime).toBe('dedicated-worker');
     expect(summary.storage).toBe('opfs');
   });
 
   test("opfs init fails when OPFS VFS chunk can't load (and throws)", async ({
+    context,
     page,
   }, testInfo) => {
     if (testInfo.project.name !== 'chromium-basepath-preview') test.skip();
-    await page.route('**/OPFSCoopSyncVFS*.js', (route) => route.abort());
+    await context.route('**/OPFS*VFS*.js', (route) => route.abort());
     await page.goto('/base-path/');
     await page.waitForSelector('[data-testid="run-demo"]', { timeout: 30_000 });
     const result = await page.evaluate(async () => {
       const fn = (window as any).__createTreecrdtClient;
       if (!fn) return { ok: false, message: '__createTreecrdtClient missing' };
       try {
-        await fn('opfs');
+        await fn('opfs', undefined, 'dedicated-worker');
         return { ok: true, message: '' };
       } catch (err) {
         return { ok: false, message: err instanceof Error ? err.message : String(err) };

--- a/packages/treecrdt-wa-sqlite/e2e/tests/cross-tab.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/cross-tab.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function waitForCrossTabHarness(page: Page) {
+  await page.goto('/');
+  await page.waitForFunction(
+    () =>
+      typeof (window as any).__openSharedOpfsCrossTabClient === 'function' &&
+      typeof (window as any).__mutateSharedOpfsCrossTabTree === 'function' &&
+      typeof (window as any).__sharedOpfsCrossTabState === 'function',
+  );
+}
+
+type RuntimeChoice = 'auto' | 'dedicated-worker' | 'shared-worker';
+
+async function openClient(page: Page, docId: string, filename: string, runtime: RuntimeChoice) {
+  return page.evaluate(
+    async ({ docId, filename, runtime }) => {
+      const open = (window as any).__openSharedOpfsCrossTabClient;
+      if (!open) throw new Error('__openSharedOpfsCrossTabClient not available');
+      return await open({ docId, filename, runtime });
+    },
+    { docId, filename, runtime },
+  );
+}
+
+async function mutateTree(
+  page: Page,
+  opts: {
+    replicaLabel: string;
+    action: 'insert' | 'move' | 'payload' | 'delete';
+    nodeInt: number;
+    parent?: string;
+    newParent?: string;
+    payloadText?: string;
+  },
+) {
+  return page.evaluate(async (mutation) => {
+    const mutate = (window as any).__mutateSharedOpfsCrossTabTree;
+    if (!mutate) throw new Error('__mutateSharedOpfsCrossTabTree not available');
+    return await mutate(mutation);
+  }, opts);
+}
+
+async function state(page: Page, opts: { parents?: string[]; nodes?: string[] } = {}) {
+  return page.evaluate(async (stateOpts) => {
+    const getState = (window as any).__sharedOpfsCrossTabState;
+    if (!getState) throw new Error('__sharedOpfsCrossTabState not available');
+    return await getState(stateOpts);
+  }, opts);
+}
+
+async function closeClient(page: Page) {
+  await page.evaluate(async () => {
+    const close = (window as any).__closeSharedOpfsCrossTabClient;
+    if (close) await close();
+  });
+}
+
+const scenarios: Array<{
+  name: string;
+  filePrefix: string;
+  runtime: RuntimeChoice;
+  expectedRuntime: 'dedicated-worker' | 'shared-worker';
+}> = [
+  {
+    name: 'auto dedicated-worker',
+    filePrefix: 'dw',
+    runtime: 'auto',
+    expectedRuntime: 'dedicated-worker',
+  },
+  {
+    name: 'explicit shared-worker',
+    filePrefix: 'sw',
+    runtime: 'shared-worker',
+    expectedRuntime: 'shared-worker',
+  },
+];
+
+for (const scenario of scenarios) {
+  test(`shared OPFS clients propagate materialization events across tabs (${scenario.name})`, async ({
+    context,
+  }, testInfo) => {
+    if (testInfo.project.name !== 'chromium-dev') test.skip();
+    test.setTimeout(120_000);
+
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+    const docId = `e2e-cross-tab-${scenario.filePrefix}-${suffix}`;
+    const filename = `/e2e-ct-${scenario.filePrefix}-${suffix}.db`;
+    const pageA = await context.newPage();
+    const pageB = await context.newPage();
+    pageA.on('console', (msg) => console.log(`[pageA][${msg.type()}] ${msg.text()}`));
+    pageB.on('console', (msg) => console.log(`[pageB][${msg.type()}] ${msg.text()}`));
+
+    try {
+      await Promise.all([waitForCrossTabHarness(pageA), waitForCrossTabHarness(pageB)]);
+
+      const [summaryA, summaryB] = await Promise.all([
+        openClient(pageA, docId, filename, scenario.runtime),
+        openClient(pageB, docId, filename, scenario.runtime),
+      ]);
+      expect(summaryA).toEqual({
+        mode: 'worker',
+        runtime: scenario.expectedRuntime,
+        storage: 'opfs',
+      });
+      expect(summaryB).toEqual({
+        mode: 'worker',
+        runtime: scenario.expectedRuntime,
+        storage: 'opfs',
+      });
+
+      const root = '0'.repeat(32);
+      const parent = await mutateTree(pageA, {
+        replicaLabel: 'cross-tab-a',
+        action: 'insert',
+        nodeInt: 701,
+      });
+      const child = await mutateTree(pageA, {
+        replicaLabel: 'cross-tab-a',
+        action: 'insert',
+        nodeInt: 702,
+        parent: parent.node,
+        payloadText: 'child from A',
+      });
+
+      await expect
+        .poll(async () => (await state(pageB, { parents: [parent.node] })).eventCount, {
+          timeout: 15_000,
+        })
+        .toBeGreaterThanOrEqual(2);
+      const treeBuiltOnB = await state(pageB, {
+        parents: [parent.node],
+        nodes: [parent.node, child.node],
+      });
+      expect(treeBuiltOnB.childrenByParent[root]).toContain(parent.node);
+      expect(treeBuiltOnB.childrenByParent[parent.node]).toContain(child.node);
+      expect(treeBuiltOnB.parentByNode[child.node]).toBe(parent.node);
+      expect(treeBuiltOnB.payloadByNode[child.node]).toBe('child from A');
+      expect(treeBuiltOnB.events.some((event) => event.nodes.includes(child.node))).toBe(true);
+
+      const eventsBeforeBWriteOnA = (await state(pageA)).eventCount;
+      await mutateTree(pageB, {
+        replicaLabel: 'cross-tab-b',
+        action: 'move',
+        nodeInt: 702,
+        newParent: root,
+      });
+
+      await expect
+        .poll(async () => (await state(pageA)).eventCount, { timeout: 15_000 })
+        .toBeGreaterThan(eventsBeforeBWriteOnA);
+      const childMovedOnA = await state(pageA, { parents: [parent.node], nodes: [child.node] });
+      expect(childMovedOnA.childrenByParent[root]).toContain(child.node);
+      expect(childMovedOnA.childrenByParent[parent.node]).not.toContain(child.node);
+      expect(childMovedOnA.parentByNode[child.node]).toBe(root);
+
+      const eventsBeforePayloadOnB = (await state(pageB)).eventCount;
+      await mutateTree(pageA, {
+        replicaLabel: 'cross-tab-a',
+        action: 'payload',
+        nodeInt: 702,
+        payloadText: 'renamed from A',
+      });
+      await expect
+        .poll(async () => (await state(pageB)).eventCount, { timeout: 15_000 })
+        .toBeGreaterThan(eventsBeforePayloadOnB);
+      const payloadUpdatedOnB = await state(pageB, { nodes: [child.node] });
+      expect(payloadUpdatedOnB.payloadByNode[child.node]).toBe('renamed from A');
+
+      const eventsBeforeDeleteOnA = (await state(pageA)).eventCount;
+      await mutateTree(pageB, {
+        replicaLabel: 'cross-tab-b',
+        action: 'delete',
+        nodeInt: 701,
+      });
+      await expect
+        .poll(async () => (await state(pageA)).eventCount, { timeout: 15_000 })
+        .toBeGreaterThan(eventsBeforeDeleteOnA);
+      const parentDeletedOnA = await state(pageA, { nodes: [parent.node, child.node] });
+      expect(parentDeletedOnA.existsByNode[parent.node]).toBe(false);
+      expect(parentDeletedOnA.existsByNode[child.node]).toBe(true);
+      expect(parentDeletedOnA.childrenByParent[root]).not.toContain(parent.node);
+      expect(parentDeletedOnA.childrenByParent[root]).toContain(child.node);
+    } finally {
+      await Promise.allSettled([closeClient(pageA), closeClient(pageB)]);
+      await Promise.allSettled([pageA.close(), pageB.close()]);
+    }
+  });
+}

--- a/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
+++ b/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
@@ -1,62 +1,73 @@
 #!/usr/bin/env node
-import fs from "node:fs/promises";
-import { createRequire } from "node:module";
-import path from "node:path";
-import { repoRootFromImportMeta } from "../../../scripts/repo-root.mjs";
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { repoRootFromImportMeta } from '../../../scripts/repo-root.mjs';
 
 const repoRoot = repoRootFromImportMeta(import.meta.url, 3);
 
 const vendorRoot = (() => {
   try {
     const require = createRequire(import.meta.url);
-    const pkgJson = require.resolve("@treecrdt/wa-sqlite-vendor/package.json");
-    return path.join(path.dirname(pkgJson), "wa-sqlite");
+    const pkgJson = require.resolve('@treecrdt/wa-sqlite-vendor/package.json');
+    return path.join(path.dirname(pkgJson), 'wa-sqlite');
   } catch {
-    return path.join(repoRoot, "packages/treecrdt-wa-sqlite-vendor/wa-sqlite");
+    return path.join(repoRoot, 'packages/treecrdt-wa-sqlite-vendor/wa-sqlite');
   }
 })();
 
 const sources = [
   {
-    src: path.join(vendorRoot, "src/examples/OPFSCoopSyncVFS.js"),
-    name: "OPFSCoopSyncVFS.js",
+    src: path.join(vendorRoot, 'src/examples/OPFSCoopSyncVFS.js'),
+    name: 'OPFSCoopSyncVFS.js',
+    transform: (content) =>
+      content.replace('../FacadeVFS.js', './FacadeVFS.js').replace('../VFS.js', './VFS.js'),
+  },
+  {
+    src: path.join(vendorRoot, 'src/examples/OPFSAnyContextVFS.js'),
+    name: 'OPFSAnyContextVFS.js',
     transform: (content) =>
       content
-        .replace("../FacadeVFS.js", "./FacadeVFS.js")
-        .replace("../VFS.js", "./VFS.js"),
+        .replace('../FacadeVFS.js', './FacadeVFS.js')
+        .replace('../VFS.js', './VFS.js')
+        .replace('../WebLocksMixin.js', './WebLocksMixin.js'),
   },
   {
-    src: path.join(vendorRoot, "src/FacadeVFS.js"),
-    name: "FacadeVFS.js",
+    src: path.join(vendorRoot, 'src/FacadeVFS.js'),
+    name: 'FacadeVFS.js',
   },
   {
-    src: path.join(vendorRoot, "src/VFS.js"),
-    name: "VFS.js",
+    src: path.join(vendorRoot, 'src/VFS.js'),
+    name: 'VFS.js',
   },
   {
-    src: path.join(vendorRoot, "src/sqlite-constants.js"),
-    name: "sqlite-constants.js",
+    src: path.join(vendorRoot, 'src/WebLocksMixin.js'),
+    name: 'WebLocksMixin.js',
+  },
+  {
+    src: path.join(vendorRoot, 'src/sqlite-constants.js'),
+    name: 'sqlite-constants.js',
   },
 ];
 
 const targetDirs = [
-  path.join(repoRoot, "packages/treecrdt-wa-sqlite/src/vendor"),
-  path.join(repoRoot, "packages/treecrdt-wa-sqlite/dist/vendor"),
+  path.join(repoRoot, 'packages/treecrdt-wa-sqlite/src/vendor'),
+  path.join(repoRoot, 'packages/treecrdt-wa-sqlite/dist/vendor'),
 ];
 
 async function copyFile(from, to, transform) {
-  const content = await fs.readFile(from, "utf8");
+  const content = await fs.readFile(from, 'utf8');
   const data = transform ? transform(content) : content;
 
   try {
-    const existing = await fs.readFile(to, "utf8");
+    const existing = await fs.readFile(to, 'utf8');
     if (existing === data) return false;
   } catch {
     // fall through: file doesn't exist or isn't readable
   }
 
   await fs.mkdir(path.dirname(to), { recursive: true });
-  await fs.writeFile(to, data, "utf8");
+  await fs.writeFile(to, data, 'utf8');
   return true;
 }
 
@@ -65,9 +76,7 @@ async function main() {
     let changed = 0;
     for (const { src, name, transform } of sources) {
       const results = await Promise.all(
-        targetDirs.map((dir) =>
-          copyFile(src, path.join(dir, name), transform),
-        ),
+        targetDirs.map((dir) => copyFile(src, path.join(dir, name), transform)),
       );
       changed += results.filter(Boolean).length;
     }
@@ -75,7 +84,7 @@ async function main() {
       `[copy-opfs-vfs] synced ${sources.length} files to ${targetDirs.length} dirs (${changed} changed)`,
     );
   } catch (err) {
-    console.error("[copy-opfs-vfs] failed to copy OPFS VFS artifacts", err);
+    console.error('[copy-opfs-vfs] failed to copy OPFS VFS artifacts', err);
     process.exit(1);
   }
 }

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -18,7 +18,12 @@ import {
   nodeIdToBytes16,
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
-import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import type {
+  LocalWriteOptions,
+  MaterializationEvent,
+  TreecrdtEngine,
+  WriteOptions,
+} from '@treecrdt/interface/engine';
 import {
   createMaterializationDispatcher,
   createTreecrdtEngineLocal,
@@ -40,9 +45,23 @@ export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
 
 export type StorageMode = 'memory' | 'opfs';
 export type ClientMode = 'direct' | 'worker';
+export type RuntimeMode = 'direct' | 'dedicated-worker' | 'shared-worker';
+export type TreecrdtStorage =
+  | { type: 'memory' }
+  | { type: 'opfs'; filename?: string; fallback?: 'throw' | 'memory' }
+  | { type: 'auto'; filename?: string; fallback?: 'memory' | 'throw' };
+export type TreecrdtRuntime =
+  | { type: 'auto' }
+  | { type: 'direct' }
+  | { type: 'dedicated-worker'; workerUrl?: string | URL }
+  | { type: 'shared-worker'; workerUrl?: string | URL; name?: string };
+export type TreecrdtAssets = {
+  baseUrl?: string;
+};
 
 export type TreecrdtClient = TreecrdtEngine & {
   mode: ClientMode;
+  runtime: RuntimeMode;
   storage: StorageMode;
   runner: SqliteRunner;
   auth: TreecrdtClientAuthApi;
@@ -62,18 +81,73 @@ export type TreecrdtClientAuthApi = {
 };
 
 export type ClientOptions = {
-  storage?: StorageMode | 'auto';
+  storage?: StorageMode | 'auto' | TreecrdtStorage;
+  runtime?: TreecrdtRuntime;
+  assets?: TreecrdtAssets;
+  /** @deprecated Use assets.baseUrl. */
   baseUrl?: string; // where wa-sqlite assets live; defaults to import.meta.env.BASE_URL + wa-sqlite/
-  filename?: string; // only for opfs; defaults to /treecrdt-playground.db
+  /** @deprecated Use storage: { type: 'opfs', filename }. */
+  filename?: string; // only for opfs; defaults to /treecrdt.db
+  /** @deprecated Use runtime: { type: 'dedicated-worker' } or runtime: { type: 'direct' }. */
   preferWorker?: boolean; // when true (default for opfs), use a worker instead of main-thread SQLite
   docId?: string; // used for v0 sync opRef derivation inside the extension
 };
 
+type NormalizedStorageOptions = {
+  type: StorageMode | 'auto';
+  filename?: string;
+  requireOpfs: boolean;
+  fallback: 'memory' | 'throw';
+};
+
+type NormalizedRuntimeOptions = TreecrdtRuntime;
+
+function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
+  const raw = opts.storage;
+  if (raw && typeof raw === 'object') {
+    if (raw.type === 'memory') {
+      return { type: 'memory', requireOpfs: false, fallback: 'memory' };
+    }
+    if (raw.type === 'opfs') {
+      const fallback = raw.fallback ?? 'throw';
+      return {
+        type: 'opfs',
+        filename: raw.filename ?? opts.filename,
+        requireOpfs: fallback === 'throw',
+        fallback,
+      };
+    }
+    const fallback = raw.fallback ?? 'memory';
+    return {
+      type: 'auto',
+      filename: raw.filename ?? opts.filename,
+      requireOpfs: fallback === 'throw',
+      fallback,
+    };
+  }
+
+  if (raw === 'memory') {
+    return { type: 'memory', requireOpfs: false, fallback: 'memory' };
+  }
+  if (raw === 'opfs') {
+    return { type: 'opfs', filename: opts.filename, requireOpfs: true, fallback: 'throw' };
+  }
+  return { type: 'auto', filename: opts.filename, requireOpfs: false, fallback: 'memory' };
+}
+
+function normalizeRuntimeOptions(opts: ClientOptions): NormalizedRuntimeOptions {
+  if (opts.runtime) return opts.runtime;
+  if (opts.preferWorker === true) return { type: 'dedicated-worker' };
+  if (opts.preferWorker === false) return { type: 'direct' };
+  return { type: 'auto' };
+}
+
 export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<TreecrdtClient> {
-  const storage = opts.storage === 'memory' ? 'memory' : opts.storage === 'opfs' ? 'opfs' : 'auto';
-  const requireOpfs = opts.storage === 'opfs';
+  const storage = normalizeStorageOptions(opts);
+  const runtime = normalizeRuntimeOptions(opts);
   const docId = opts.docId ?? 'treecrdt';
   const rawBase =
+    opts.assets?.baseUrl ??
     opts.baseUrl ??
     (typeof import.meta !== 'undefined' && (import.meta as any).env?.BASE_URL
       ? (import.meta as any).env.BASE_URL
@@ -81,35 +155,68 @@ export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<Tr
   const baseUrl = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
   const support = detectOpfsSupport();
 
-  const shouldUseOpfs = storage === 'opfs' || (storage === 'auto' && support.available);
-  const preferWorker = opts.preferWorker ?? shouldUseOpfs; // default to worker when targeting OPFS
+  const shouldUseOpfs = storage.type === 'opfs' || (storage.type === 'auto' && support.available);
+  if (storage.type === 'auto' && !support.available && storage.fallback === 'throw') {
+    throw new Error(`OPFS unavailable in this environment: ${support.reason ?? 'unknown reason'}`);
+  }
+  const resolvedRuntime = resolveRuntimeMode(runtime, shouldUseOpfs);
 
-  // If OPFS requested, default to worker path to avoid main-thread sync handles.
-  if (shouldUseOpfs) {
-    if (preferWorker) {
-      return createWorkerClient({
-        baseUrl,
-        filename: opts.filename,
-        storage: 'opfs',
-        requireOpfs,
-        docId,
-      });
-    }
-    if (!support.available) {
-      throw new Error(
-        `OPFS unavailable in this environment: ${support.reason ?? 'unknown reason'}`,
-      );
-    }
+  // If OPFS is requested, default runtime:auto to a worker path to avoid main-thread sync handles.
+  if (shouldUseOpfs && resolvedRuntime === 'direct' && !support.available && storage.requireOpfs) {
+    throw new Error(`OPFS unavailable in this environment: ${support.reason ?? 'unknown reason'}`);
   }
 
-  // Direct path.
+  if (resolvedRuntime === 'shared-worker') {
+    return createSharedWorkerClient({
+      baseUrl,
+      filename: storage.filename,
+      storage: shouldUseOpfs ? 'opfs' : 'memory',
+      requireOpfs: storage.requireOpfs,
+      docId,
+      workerUrl: runtime.type === 'shared-worker' ? runtime.workerUrl : undefined,
+      name:
+        runtime.type === 'shared-worker'
+          ? (runtime.name ??
+            defaultSharedWorkerName(docId, shouldUseOpfs ? storage.filename : ':memory:'))
+          : defaultSharedWorkerName(docId, shouldUseOpfs ? storage.filename : ':memory:'),
+    });
+  }
+
+  if (resolvedRuntime === 'dedicated-worker') {
+    return createWorkerClient({
+      baseUrl,
+      filename: storage.filename,
+      storage: shouldUseOpfs ? 'opfs' : 'memory',
+      requireOpfs: storage.requireOpfs,
+      docId,
+      workerUrl: runtime.type === 'dedicated-worker' ? runtime.workerUrl : undefined,
+    });
+  }
+
   return createDirectClient({
     baseUrl,
-    filename: opts.filename,
+    filename: storage.filename,
     storage: shouldUseOpfs ? 'opfs' : 'memory',
-    requireOpfs,
+    requireOpfs: storage.requireOpfs,
     docId,
   });
+}
+
+function resolveRuntimeMode(runtime: TreecrdtRuntime, shouldUseOpfs: boolean): RuntimeMode {
+  if (runtime.type === 'direct') return 'direct';
+  if (runtime.type === 'dedicated-worker') return 'dedicated-worker';
+  if (runtime.type === 'shared-worker') {
+    if (typeof SharedWorker === 'undefined') {
+      throw new Error('TreeCRDT shared-worker runtime is unavailable in this environment');
+    }
+    return 'shared-worker';
+  }
+  if (shouldUseOpfs) return 'dedicated-worker';
+  return 'direct';
+}
+
+function defaultSharedWorkerName(docId: string, filename?: string): string {
+  return `treecrdt:${docId}:${filename ?? '/treecrdt.db'}`;
 }
 
 // --- Worker client
@@ -121,7 +228,37 @@ type WorkerProxy = {
   removeEventListener: (type: 'message' | 'error', fn: (ev: any) => void) => void;
 };
 
+type MessagePortProxy = {
+  postMessage(msg: RpcRequest, transfer?: Transferable[]): void;
+  start: () => void;
+  close: () => void;
+  addEventListener: (type: 'message' | 'messageerror', fn: (ev: any) => void) => void;
+  removeEventListener: (type: 'message' | 'messageerror', fn: (ev: any) => void) => void;
+};
+
 type RpcCall = <M extends RpcMethod>(method: M, params: RpcParams<M>) => Promise<RpcResult<M>>;
+type SharedWorkerFactory = (options?: WorkerOptions & { name?: string }) => SharedWorker;
+type ClientMaterializationDispatcher = ReturnType<typeof createMaterializationDispatcher> & {
+  enableCrossTab: (scope: CrossTabMaterializationScope) => void;
+  emitIncomingEvent: (event: MaterializationEvent) => void;
+  close: () => void;
+};
+type ClientMaterializationDispatcherOptions = {
+  broadcast?: (event: MaterializationEvent) => void;
+};
+type CrossTabMaterializationScope = {
+  docId: string;
+  filename: string;
+};
+type CrossTabMaterializationMessage = {
+  type: 'treecrdt-materialized-v1';
+  sourceId: string;
+  docId: string;
+  filename: string;
+  event: MaterializationEvent;
+};
+
+const CROSS_TAB_MATERIALIZED_MESSAGE = 'treecrdt-materialized-v1';
 
 let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
 
@@ -149,18 +286,101 @@ function createLazyAuthApi(opts: { runner: SqliteRunner; docId: string }): Treec
   };
 }
 
+function createClientMaterializationDispatcher(
+  opts: ClientMaterializationDispatcherOptions = {},
+): ClientMaterializationDispatcher {
+  const dispatcher = createMaterializationDispatcher();
+  const clientId = randomClientId();
+  let channel: BroadcastChannel | null = null;
+  let scope: CrossTabMaterializationScope | null = null;
+
+  const close = () => {
+    channel?.close();
+    channel = null;
+    scope = null;
+  };
+
+  const eventForPeers = (event: MaterializationEvent): MaterializationEvent => {
+    const { writeIds: _writeIds, ...nextEvent } = event;
+    return nextEvent;
+  };
+
+  const broadcast = (event: MaterializationEvent) => {
+    if (!channel || !scope || event.changes.length === 0) return;
+    channel.postMessage({
+      type: CROSS_TAB_MATERIALIZED_MESSAGE,
+      sourceId: clientId,
+      docId: scope.docId,
+      filename: scope.filename,
+      event: eventForPeers(event),
+    } satisfies CrossTabMaterializationMessage);
+  };
+
+  const emitEvent = (event: MaterializationEvent) => {
+    if (event.changes.length === 0) return;
+    dispatcher.emitEvent(event);
+    opts.broadcast?.(eventForPeers(event));
+    broadcast(event);
+  };
+
+  const emitOutcome: ClientMaterializationDispatcher['emitOutcome'] = (outcome, writeId) => {
+    if (outcome.changes.length === 0) return;
+    emitEvent({
+      ...outcome,
+      ...(writeId ? { writeIds: [writeId] } : {}),
+    });
+  };
+
+  const enableCrossTab = (nextScope: CrossTabMaterializationScope) => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    close();
+    scope = nextScope;
+    channel = new BroadcastChannel(materializationChannelName(nextScope));
+    channel.onmessage = (ev: MessageEvent<CrossTabMaterializationMessage>) => {
+      const msg = ev.data;
+      if (!msg || msg.type !== CROSS_TAB_MATERIALIZED_MESSAGE) return;
+      if (msg.sourceId === clientId) return;
+      if (msg.docId !== nextScope.docId || msg.filename !== nextScope.filename) return;
+      dispatcher.emitEvent(msg.event);
+    };
+  };
+
+  return {
+    emitEvent,
+    emitOutcome,
+    emitIncomingEvent: dispatcher.emitEvent,
+    onMaterialized: dispatcher.onMaterialized,
+    enableCrossTab,
+    close,
+  };
+}
+
+function materializationChannelName(scope: CrossTabMaterializationScope): string {
+  return `${CROSS_TAB_MATERIALIZED_MESSAGE}:${scope.docId}:${scope.filename}`;
+}
+
+function randomClientId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 async function createWorkerClient(opts: {
   baseUrl: string;
   filename?: string;
   storage: StorageMode;
   docId: string;
   requireOpfs?: boolean;
+  workerUrl?: string | URL;
 }): Promise<TreecrdtClient> {
-  const materialized = createMaterializationDispatcher();
+  const materialized = createClientMaterializationDispatcher();
   // Keep the URL inline so Vite detects and bundles the worker properly.
-  const worker = new Worker(new URL('./worker.js', import.meta.url), {
-    type: 'module',
-  }) as unknown as WorkerProxy;
+  const worker = (opts.workerUrl
+    ? new Worker(opts.workerUrl, { type: 'module' })
+    : new Worker(new URL('./worker.js', import.meta.url), {
+        type: 'module',
+      })) as unknown as WorkerProxy;
   let nextId = 1;
   const pending = new Map<
     number,
@@ -220,10 +440,17 @@ async function createWorkerClient(opts: {
     opts.filename,
     opts.storage,
     opts.docId,
-  ])) as { storage?: StorageMode; opfsError?: string } | undefined;
+  ])) as { storage?: StorageMode; filename?: string; opfsError?: string } | undefined;
   const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
+  const effectiveFilename =
+    initResult?.filename ??
+    (effectiveStorage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:');
+  if (effectiveStorage === 'opfs') {
+    materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
+  }
   const cleanup = () => {
     closed = true;
+    materialized.close();
     for (const { reject } of pending.values()) reject(closedError);
     pending.clear();
     worker.removeEventListener('error', onError);
@@ -265,6 +492,7 @@ async function createWorkerClient(opts: {
 
   return makeTreecrdtClientFromCall({
     mode: 'worker',
+    runtime: 'dedicated-worker',
     storage: effectiveStorage,
     docId: opts.docId,
     call,
@@ -272,6 +500,153 @@ async function createWorkerClient(opts: {
     close: closeImpl,
     drop: dropImpl,
   });
+}
+
+// --- Shared worker client (one SQLite backend shared by same-origin tabs)
+
+async function createSharedWorkerClient(opts: {
+  baseUrl: string;
+  filename?: string;
+  storage: StorageMode;
+  docId: string;
+  name: string;
+  requireOpfs?: boolean;
+  workerUrl?: string | URL;
+}): Promise<TreecrdtClient> {
+  const sharedWorker = opts.workerUrl
+    ? new SharedWorker(opts.workerUrl, { name: opts.name, type: 'module' } as WorkerOptions & {
+        name: string;
+      })
+    : await createDefaultSharedWorker(opts.name);
+  const port = sharedWorker.port as unknown as MessagePortProxy;
+  let nextId = 1;
+  const pending = new Map<
+    number,
+    { resolve: (value: any) => void; reject: (err: Error) => void }
+  >();
+  let terminalError: Error | null = null;
+  let closed = false;
+  let callQueue: Promise<void> = Promise.resolve();
+
+  const closedError = new Error(CLIENT_CLOSED_ERROR);
+  const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
+    promise.then(
+      () => undefined,
+      () => undefined,
+    );
+
+  const callRaw = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+    if (closed) return Promise.reject(closedError);
+    const id = nextId++;
+    if (terminalError) return Promise.reject(terminalError);
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      port.postMessage({ id, method, params } satisfies RpcRequest<M>);
+    });
+  };
+  const call = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+    const run = callQueue.then(() => callRaw(method, params));
+    callQueue = settleQueue(run);
+    return run;
+  };
+  const materialized = createClientMaterializationDispatcher({
+    broadcast: (event) => {
+      void call('broadcastMaterialized', [event]).catch(() => {
+        // Closing tabs can race a final materialization notification.
+      });
+    },
+  });
+
+  const onMessage = (ev: MessageEvent<RpcResponse | RpcPushMessage>) => {
+    const data = ev.data;
+    if ('type' in data && data.type === 'materialized') {
+      materialized.emitIncomingEvent(data.event);
+      return;
+    }
+    const response = data as RpcResponse;
+    const handler = pending.get(response.id as number);
+    if (!handler) return;
+    pending.delete(response.id as number);
+    if (response.ok) handler.resolve(response.result);
+    else handler.reject(new Error(response.error || 'shared worker error'));
+  };
+  const onMessageError = () => {
+    const err = new Error('shared worker message error');
+    terminalError = err;
+    for (const { reject } of pending.values()) reject(err);
+    pending.clear();
+  };
+  port.addEventListener('message', onMessage);
+  port.addEventListener('messageerror', onMessageError);
+  port.start();
+
+  const initResult = (await call('init', [
+    opts.baseUrl,
+    opts.filename,
+    opts.storage,
+    opts.docId,
+  ])) as { storage?: StorageMode; filename?: string; opfsError?: string } | undefined;
+  const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
+  const cleanup = () => {
+    closed = true;
+    materialized.close();
+    for (const { reject } of pending.values()) reject(closedError);
+    pending.clear();
+    port.removeEventListener('message', onMessage);
+    port.removeEventListener('messageerror', onMessageError);
+    port.close();
+  };
+
+  if (opts.requireOpfs && effectiveStorage !== 'opfs') {
+    const reason = initResult?.opfsError ? `: ${initResult.opfsError}` : '';
+    try {
+      if (!terminalError) await call('close', [] as RpcParams<'close'>);
+    } catch {
+      // ignore close errors on init failure
+    } finally {
+      cleanup();
+    }
+    throw new Error(`OPFS requested but could not be initialized${reason}`);
+  }
+
+  const closeImpl = async () => {
+    if (closed) return;
+    try {
+      if (!terminalError) await call('close', [] as RpcParams<'close'>);
+      cleanup();
+    } finally {
+      // noop
+    }
+  };
+
+  const dropImpl = async () => {
+    if (closed) return;
+    try {
+      if (!terminalError) await call('drop', [] as RpcParams<'drop'>);
+      cleanup();
+    } finally {
+      // noop
+    }
+  };
+
+  return makeTreecrdtClientFromCall({
+    mode: 'worker',
+    runtime: 'shared-worker',
+    storage: effectiveStorage,
+    docId: opts.docId,
+    call,
+    materialized,
+    close: closeImpl,
+    drop: dropImpl,
+  });
+}
+
+async function createDefaultSharedWorker(name: string): Promise<SharedWorker> {
+  // Vite's ?sharedworker wrapper bundles the module and still lets us pass a runtime name.
+  const { default: createWorker } = (await import('./shared-worker.js?sharedworker')) as {
+    default: SharedWorkerFactory;
+  };
+  return createWorker({ name });
 }
 
 // --- Direct client (main-thread, used for memory or opt-in opfs)
@@ -283,7 +658,7 @@ async function createDirectClient(opts: {
   docId: string;
   requireOpfs?: boolean;
 }): Promise<TreecrdtClient> {
-  const materialized = createMaterializationDispatcher();
+  const materialized = createClientMaterializationDispatcher();
   const { baseUrl, storage, requireOpfs } = opts;
   const opened = await openTreecrdtDb({
     baseUrl,
@@ -296,6 +671,9 @@ async function createDirectClient(opts: {
   const db = opened.db;
   const finalStorage: StorageMode = opened.storage;
   const filename = opened.filename;
+  if (finalStorage === 'opfs') {
+    materialized.enableCrossTab({ docId: opts.docId, filename });
+  }
   const adapter = opened.api;
   const runner: SqliteRunner = {
     exec: (sql) => db.exec(sql),
@@ -423,6 +801,7 @@ async function createDirectClient(opts: {
 
   return makeTreecrdtClientFromCall({
     mode: 'direct',
+    runtime: 'direct',
     storage: finalStorage,
     docId: opts.docId,
     call,
@@ -447,10 +826,11 @@ async function createDirectClient(opts: {
 
 function makeTreecrdtClientFromCall(opts: {
   mode: ClientMode;
+  runtime: RuntimeMode;
   storage: StorageMode;
   docId: string;
   call: RpcCall;
-  materialized: ReturnType<typeof createMaterializationDispatcher>;
+  materialized: ClientMaterializationDispatcher;
   close: () => Promise<void>;
   drop: () => Promise<void>;
 }): TreecrdtClient {
@@ -555,13 +935,28 @@ function makeTreecrdtClientFromCall(opts: {
       } catch {
         // Client teardown is best-effort. Fast refresh and overlapping resets can race a prior
         // close, and the underlying sqlite handle may already be gone by the time this runs.
+      } finally {
+        materialized.close();
       }
     })();
     await closePromise;
   };
+  let dropPromise: Promise<void> | null = null;
+  const dropImpl = async () => {
+    if (dropPromise) return await dropPromise;
+    dropPromise = (async () => {
+      try {
+        await opts.drop();
+      } finally {
+        materialized.close();
+      }
+    })();
+    await dropPromise;
+  };
 
   return {
     mode: opts.mode,
+    runtime: opts.runtime,
     storage: opts.storage,
     docId: opts.docId,
     runner,
@@ -594,7 +989,7 @@ function makeTreecrdtClientFromCall(opts: {
     local,
     onMaterialized: materialized.onMaterialized,
     close: closeImpl,
-    drop: opts.drop,
+    drop: dropImpl,
   };
 }
 

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -81,15 +81,9 @@ export type TreecrdtClientAuthApi = {
 };
 
 export type ClientOptions = {
-  storage?: StorageMode | 'auto' | TreecrdtStorage;
+  storage?: TreecrdtStorage;
   runtime?: TreecrdtRuntime;
   assets?: TreecrdtAssets;
-  /** @deprecated Use assets.baseUrl. */
-  baseUrl?: string; // where wa-sqlite assets live; defaults to import.meta.env.BASE_URL + wa-sqlite/
-  /** @deprecated Use storage: { type: 'opfs', filename }. */
-  filename?: string; // only for opfs; defaults to /treecrdt.db
-  /** @deprecated Use runtime: { type: 'dedicated-worker' } or runtime: { type: 'direct' }. */
-  preferWorker?: boolean; // when true (default for opfs), use a worker instead of main-thread SQLite
   docId?: string; // used for v0 sync opRef derivation inside the extension
 };
 
@@ -103,43 +97,39 @@ type NormalizedStorageOptions = {
 type NormalizedRuntimeOptions = TreecrdtRuntime;
 
 function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
-  const raw = opts.storage;
-  if (raw && typeof raw === 'object') {
-    if (raw.type === 'memory') {
-      return { type: 'memory', requireOpfs: false, fallback: 'memory' };
-    }
-    if (raw.type === 'opfs') {
-      const fallback = raw.fallback ?? 'throw';
-      return {
-        type: 'opfs',
-        filename: raw.filename ?? opts.filename,
-        requireOpfs: fallback === 'throw',
-        fallback,
-      };
-    }
-    const fallback = raw.fallback ?? 'memory';
+  const raw = opts.storage ?? { type: 'auto' };
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(
+      'createTreecrdtClient storage must use object options, e.g. { type: "memory" } or { type: "opfs" }',
+    );
+  }
+
+  if (raw.type === 'memory') {
+    return { type: 'memory', requireOpfs: false, fallback: 'memory' };
+  }
+  if (raw.type === 'opfs') {
+    const fallback = raw.fallback ?? 'throw';
     return {
-      type: 'auto',
-      filename: raw.filename ?? opts.filename,
+      type: 'opfs',
+      filename: raw.filename,
       requireOpfs: fallback === 'throw',
       fallback,
     };
   }
-
-  if (raw === 'memory') {
-    return { type: 'memory', requireOpfs: false, fallback: 'memory' };
+  if (raw.type !== 'auto') {
+    throw new Error('createTreecrdtClient storage.type must be "memory", "opfs", or "auto"');
   }
-  if (raw === 'opfs') {
-    return { type: 'opfs', filename: opts.filename, requireOpfs: true, fallback: 'throw' };
-  }
-  return { type: 'auto', filename: opts.filename, requireOpfs: false, fallback: 'memory' };
+  const fallback = raw.fallback ?? 'memory';
+  return {
+    type: 'auto',
+    filename: raw.filename,
+    requireOpfs: fallback === 'throw',
+    fallback,
+  };
 }
 
 function normalizeRuntimeOptions(opts: ClientOptions): NormalizedRuntimeOptions {
-  if (opts.runtime) return opts.runtime;
-  if (opts.preferWorker === true) return { type: 'dedicated-worker' };
-  if (opts.preferWorker === false) return { type: 'direct' };
-  return { type: 'auto' };
+  return opts.runtime ?? { type: 'auto' };
 }
 
 export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<TreecrdtClient> {
@@ -148,7 +138,6 @@ export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<Tr
   const docId = opts.docId ?? 'treecrdt';
   const rawBase =
     opts.assets?.baseUrl ??
-    opts.baseUrl ??
     (typeof import.meta !== 'undefined' && (import.meta as any).env?.BASE_URL
       ? (import.meta as any).env.BASE_URL
       : '/');

--- a/packages/treecrdt-wa-sqlite/src/open.ts
+++ b/packages/treecrdt-wa-sqlite/src/open.ts
@@ -1,4 +1,4 @@
-import { createOpfsVfs } from './opfs.js';
+import { createOpfsVfs, type OpfsVfsKind } from './opfs.js';
 import { createWaSqliteApi } from './index.js';
 import type { Database } from './index.js';
 import { makeDbAdapter } from './db.js';
@@ -12,6 +12,7 @@ export type OpenTreecrdtDbOptions = {
   docId: string;
   requireOpfs?: boolean;
   onMaterialized?: (event: MaterializationEvent) => void;
+  opfsVfs?: OpfsVfsKind;
 };
 
 export type OpenTreecrdtDbResult = {
@@ -36,7 +37,7 @@ export async function openTreecrdtDb(opts: OpenTreecrdtDbOptions): Promise<OpenT
   let opfsError: string | undefined;
   if (storage === 'opfs') {
     try {
-      const vfs = await createOpfsVfs(module, { name: 'opfs' });
+      const vfs = await createOpfsVfs(module, { name: 'opfs', kind: opts.opfsVfs });
       sqlite3.vfs_register(vfs, true);
     } catch (err) {
       opfsError = err instanceof Error ? err.message : String(err);

--- a/packages/treecrdt-wa-sqlite/src/opfs.ts
+++ b/packages/treecrdt-wa-sqlite/src/opfs.ts
@@ -113,16 +113,25 @@ export async function opfsStorageExists(filename: string): Promise<boolean> {
   return false;
 }
 
+export type OpfsVfsKind = 'coop-sync' | 'any-context';
+
 export type OpfsVfsOptions = {
   name?: string;
+  kind?: OpfsVfsKind;
 };
 
 /**
- * Create the OPFS cooperative sync VFS bound to the provided wa-sqlite Module.
- * Uses a local copy of wa-sqlite's OPFSCoopSyncVFS example to avoid reaching into vendor paths.
+ * Create an OPFS VFS bound to the provided wa-sqlite Module.
+ * Uses local copies of wa-sqlite's example VFS implementations to avoid reaching into vendor paths.
  */
 export async function createOpfsVfs(module: any, opts: OpfsVfsOptions = {}): Promise<any> {
   const name = opts.name ?? 'opfs';
+  if (opts.kind === 'any-context') {
+    // @ts-ignore vendored module lacks type declarations
+    const { OPFSAnyContextVFS } = await import('./vendor/OPFSAnyContextVFS.js');
+    return OPFSAnyContextVFS.create(name, module, { lockPolicy: 'exclusive' });
+  }
+
   // @ts-ignore vendored module lacks type declarations
   const { OPFSCoopSyncVFS } = await import('./vendor/OPFSCoopSyncVFS.js');
   return OPFSCoopSyncVFS.create(name, module);
@@ -133,6 +142,7 @@ export type OpenOptions = {
   filename?: string;
   storage: 'memory' | 'opfs';
   sqliteApi: { Factory: (module: any) => any };
+  opfsVfs?: OpfsVfsKind;
 };
 
 /**
@@ -151,7 +161,7 @@ export async function openWithStorage(
     if (!support.available) {
       throw new Error(`OPFS unsupported: ${support.reason ?? 'unknown reason'}`);
     }
-    const vfs = await createOpfsVfs(module, { name: 'opfs' });
+    const vfs = await createOpfsVfs(module, { name: 'opfs', kind: opts.opfsVfs });
     sqlite3.vfs_register(vfs, true);
     file = filename === ':memory:' ? '/treecrdt.db' : filename;
   }

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -13,7 +13,7 @@ export type RpcInitParams = {
   docId: string;
 };
 
-export type RpcInitResult = { storage: RpcStorageMode; opfsError?: string };
+export type RpcInitResult = { storage: RpcStorageMode; filename: string; opfsError?: string };
 
 export type RpcSchema = {
   init: {
@@ -27,6 +27,7 @@ export type RpcSchema = {
     params: [ops: Operation[]];
     result: MaterializationOutcome;
   };
+  broadcastMaterialized: { params: [event: MaterializationEvent]; result: void };
   opsSince: { params: [lamport: number, root?: string]; result: unknown[] };
   opRefsAll: { params: []; result: unknown[] };
   opRefsChildren: { params: [parent: string]; result: unknown[] };

--- a/packages/treecrdt-wa-sqlite/src/shared-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/shared-worker.ts
@@ -1,0 +1,276 @@
+/// <reference lib="webworker" />
+import { dbGetText } from './sql.js';
+import type { Database } from './index.js';
+import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
+import type { Operation, TreecrdtAdapter } from '@treecrdt/interface';
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
+import type {
+  RpcInitResult,
+  RpcMethod,
+  RpcParams,
+  RpcRequest,
+  RpcResult,
+  RpcSqlParams,
+} from './rpc.js';
+import { openTreecrdtDb } from './open.js';
+import { clearOpfsStorage } from './opfs.js';
+
+type SharedWorkerGlobal = typeof globalThis & {
+  onconnect: ((ev: MessageEvent) => void) | null;
+};
+
+type StoredConfig = {
+  baseUrl: string;
+  requestedFilename: string;
+  requestedStorage: 'memory' | 'opfs';
+  docId: string;
+};
+
+const ports = new Set<MessagePort>();
+let db: Database | null = null;
+let api: TreecrdtAdapter | null = null;
+let storedFilename: string | undefined;
+let storedStorage: 'memory' | 'opfs' = 'memory';
+let storedConfig: StoredConfig | null = null;
+let initResult: RpcInitResult | null = null;
+let callQueue: Promise<void> = Promise.resolve();
+
+const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
+  promise.then(
+    () => undefined,
+    () => undefined,
+  );
+
+function broadcastMaterialized(event: MaterializationEvent, exclude?: MessagePort) {
+  if (event.changes.length === 0) return;
+  for (const port of ports) {
+    if (port === exclude) continue;
+    port.postMessage({ type: 'materialized', event });
+  }
+}
+
+(self as unknown as SharedWorkerGlobal).onconnect = (ev: MessageEvent) => {
+  const port = ev.ports[0];
+  if (!port) return;
+  ports.add(port);
+  port.onmessage = (message: MessageEvent<RpcRequest>) => {
+    const request = message.data;
+    const respond = (ok: boolean, result?: any, error?: string) => {
+      port.postMessage({ id: request.id, ok, result, error });
+    };
+    const run = callQueue.then(() => handleRequest(port, request));
+    callQueue = settleQueue(run);
+    run.then(
+      (result) => respond(true, result),
+      (err) => respond(false, null, err instanceof Error ? err.message : String(err)),
+    );
+  };
+  port.start();
+};
+
+async function handleRequest<M extends RpcMethod>(
+  sourcePort: MessagePort,
+  request: RpcRequest<M>,
+): Promise<RpcResult<M> | void> {
+  if (request.method === 'init') {
+    const [baseUrl, filename, storage, docId] = request.params as RpcParams<'init'>;
+    return (await init(baseUrl, filename, storage, docId)) as RpcResult<M>;
+  }
+
+  if (request.method === 'broadcastMaterialized') {
+    const [event] = request.params as RpcParams<'broadcastMaterialized'>;
+    broadcastMaterialized(event, sourcePort);
+    return undefined;
+  }
+
+  if (request.method === 'close') {
+    await close(sourcePort);
+    return undefined;
+  }
+
+  if (request.method === 'drop') {
+    await drop();
+    return undefined;
+  }
+
+  const methodFn = methods[request.method as keyof typeof methods] as
+    | ((...args: any[]) => Promise<unknown>)
+    | undefined;
+  if (!methodFn) throw new Error(`unknown method: ${request.method}`);
+  return (await methodFn(...((request.params ?? []) as any[]))) as RpcResult<M>;
+}
+
+async function init(
+  baseUrl: string,
+  filename: string | undefined,
+  storageParam: 'memory' | 'opfs',
+  docId: string,
+): Promise<RpcInitResult> {
+  const requestedFilename = storageParam === 'opfs' ? (filename ?? '/treecrdt.db') : ':memory:';
+  if (storedConfig && initResult) {
+    if (
+      storedConfig.baseUrl !== baseUrl ||
+      storedConfig.requestedFilename !== requestedFilename ||
+      storedConfig.requestedStorage !== storageParam ||
+      storedConfig.docId !== docId
+    ) {
+      throw new Error('shared worker already initialized with a different TreeCRDT database');
+    }
+    return initResult;
+  }
+
+  const opened = await openTreecrdtDb({
+    baseUrl,
+    filename,
+    storage: storageParam,
+    docId,
+    requireOpfs: false,
+    opfsVfs: storageParam === 'opfs' ? 'any-context' : undefined,
+    onMaterialized: (event) => broadcastMaterialized(event),
+  });
+  db = opened.db;
+  api = opened.api;
+  storedFilename = opened.filename;
+  storedStorage = opened.storage;
+  storedConfig = { baseUrl, requestedFilename, requestedStorage: storageParam, docId };
+  initResult = opened.opfsError
+    ? { storage: opened.storage, filename: opened.filename, opfsError: opened.opfsError }
+    : { storage: opened.storage, filename: opened.filename };
+  return initResult;
+}
+
+const methods = {
+  sqlExec,
+  sqlGetText,
+  append,
+  appendMany,
+  opsSince,
+  opRefsAll,
+  opRefsChildren,
+  opsByOpRefs,
+  treeChildren,
+  treeChildrenPage,
+  treeDump,
+  treeNodeCount,
+  treeParent,
+  treeExists,
+  treePayload,
+  headLamport,
+  replicaMaxCounter,
+} as const;
+
+async function sqlExec(sql: string) {
+  await ensureDb().exec(sql);
+  return null;
+}
+
+async function sqlGetText(sql: string, params?: RpcSqlParams): Promise<string | null> {
+  return dbGetText(ensureDb(), sql, params ?? []);
+}
+
+async function append(op: Operation) {
+  return await ensureApi().appendOp(op, nodeIdToBytes16, replicaIdToBytes);
+}
+
+async function appendMany(ops: Operation[]) {
+  return await ensureApi().appendOps!(ops, nodeIdToBytes16, replicaIdToBytes);
+}
+
+async function opsSince(lamport: number, root: string | undefined) {
+  return await ensureApi().opsSince(lamport, root);
+}
+
+async function opRefsAll() {
+  return await ensureApi().opRefsAll();
+}
+
+async function opRefsChildren(parent: string) {
+  return await ensureApi().opRefsChildren(nodeIdToBytes16(parent));
+}
+
+async function opsByOpRefs(opRefs: number[][]) {
+  return await ensureApi().opsByOpRefs(opRefs.map((r) => Uint8Array.from(r)));
+}
+
+async function treeChildren(parent: string) {
+  return await ensureApi().treeChildren(nodeIdToBytes16(parent));
+}
+
+async function treeChildrenPage(
+  parent: string,
+  cursor: { orderKey: number[]; node: number[] } | null,
+  limit: number,
+) {
+  const cursorBytes = cursor
+    ? {
+        orderKey: Uint8Array.from(cursor.orderKey),
+        node: Uint8Array.from(cursor.node),
+      }
+    : null;
+  return await ensureApi().treeChildrenPage!(nodeIdToBytes16(parent), cursorBytes, limit);
+}
+
+async function treeDump() {
+  return await ensureApi().treeDump();
+}
+
+async function treeNodeCount() {
+  return await ensureApi().treeNodeCount();
+}
+
+async function treeParent(node: string) {
+  const result = await ensureApi().treeParent(nodeIdToBytes16(node));
+  return result === null ? null : Array.from(result);
+}
+
+async function treeExists(node: string) {
+  return await ensureApi().treeExists(nodeIdToBytes16(node));
+}
+
+async function treePayload(node: string) {
+  const payload = await ensureApi().treePayload(nodeIdToBytes16(node));
+  return payload === null ? null : Array.from(payload);
+}
+
+async function headLamport() {
+  return await ensureApi().headLamport();
+}
+
+async function replicaMaxCounter(replica: number[]) {
+  return await ensureApi().replicaMaxCounter(Uint8Array.from(replica));
+}
+
+async function close(port: MessagePort) {
+  ports.delete(port);
+  if (ports.size > 0) return;
+  await closeDbAndReset();
+}
+
+async function drop() {
+  const filename = storedFilename;
+  const storage = storedStorage;
+  await closeDbAndReset();
+  if (storage === 'opfs' && filename) {
+    await clearOpfsStorage(filename);
+  }
+}
+
+async function closeDbAndReset() {
+  if (db?.close) await db.close();
+  db = null;
+  api = null;
+  storedFilename = undefined;
+  storedStorage = 'memory';
+  storedConfig = null;
+  initResult = null;
+}
+
+function ensureApi(): TreecrdtAdapter {
+  if (!db || !api) throw new Error('db not initialized');
+  return api;
+}
+
+function ensureDb(): Database {
+  if (!db) throw new Error('db not initialized');
+  return db;
+}

--- a/packages/treecrdt-wa-sqlite/src/types/vite-worker.d.ts
+++ b/packages/treecrdt-wa-sqlite/src/types/vite-worker.d.ts
@@ -1,0 +1,4 @@
+declare module '*?sharedworker' {
+  const WorkerWrapper: (options?: WorkerOptions & { name?: string }) => SharedWorker;
+  export default WorkerWrapper;
+}

--- a/packages/treecrdt-wa-sqlite/src/worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/worker.ts
@@ -5,7 +5,7 @@ import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { Operation } from '@treecrdt/interface';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
-import type { RpcMethod, RpcRequest, RpcSqlParams } from './rpc.js';
+import type { RpcInitResult, RpcMethod, RpcRequest, RpcSqlParams } from './rpc.js';
 import { openTreecrdtDb } from './open.js';
 import { clearOpfsStorage } from './opfs.js';
 
@@ -65,7 +65,7 @@ async function init(
   filename: string | undefined,
   storageParam: 'memory' | 'opfs',
   docId: string,
-): Promise<{ storage: 'memory' | 'opfs'; opfsError?: string }> {
+): Promise<RpcInitResult> {
   if (db) {
     if (db.close) await db.close();
     db = null;
@@ -84,8 +84,8 @@ async function init(
   storedFilename = opened.filename;
   storedStorage = opened.storage;
   return opened.opfsError
-    ? { storage: opened.storage, opfsError: opened.opfsError }
-    : { storage: opened.storage };
+    ? { storage: opened.storage, filename: opened.filename, opfsError: opened.opfsError }
+    : { storage: opened.storage, filename: opened.filename };
 }
 
 async function sqlExec(sql: string) {


### PR DESCRIPTION
## Summary
- Replaces the old wa-sqlite client options with object-shaped `storage`, `runtime`, and `assets` options.
- Removes the legacy top-level `storage: 'opfs'`, `filename`, `baseUrl`, and `preferWorker` compatibility path.
- Makes OPFS `runtime: { type: 'auto' }` resolve to the dedicated-worker + `OPFSCoopSyncVFS` path by default.
- Adds OPFS cross-tab materialization notifications for clients sharing the same `docId` and OPFS filename.

## API Change

Old API, removed in this PR:

```ts
const client = await createTreecrdtClient({
  storage: 'opfs',
  filename: '/treecrdt-playground.db',
  preferWorker: true,
  baseUrl: '/',
  docId,
})
```

New API:

```ts
const client = await createTreecrdtClient({
  storage: { type: 'opfs', filename: '/treecrdt-playground.db', fallback: 'throw' },
  runtime: { type: 'auto' },
  assets: { baseUrl: '/' },
  docId,
})
```

Memory stays explicit and simple:

```ts
const client = await createTreecrdtClient({
  storage: { type: 'memory' },
  runtime: { type: 'auto' },
  docId,
})
```

Explicit SharedWorker remains available when the app wants a single same-origin worker backend:

```ts
const client = await createTreecrdtClient({
  storage: { type: 'opfs', filename: '/treecrdt-playground.db' },
  runtime: { type: 'shared-worker' },
  docId,
})
```

## Runtime Notes

| Runtime | OPFS behavior | Cross-tab behavior |
| --- | --- | --- |
| `auto` | dedicated Worker per tab; each client opens the configured OPFS filename | BroadcastChannel materialization notifications between matching clients |
| `dedicated-worker` | dedicated Worker per tab; each client opens the configured OPFS filename | BroadcastChannel materialization notifications between matching clients |
| `shared-worker` | one same-origin SharedWorker SQLite backend opens the configured OPFS filename | SharedWorker relays materialization notifications |
| `direct` | main-thread SQLite per tab; each client opens the configured OPFS filename | BroadcastChannel materialization notifications between matching clients |
| memory | per-client memory DB | isolated state |

“Configured OPFS filename” means the browser OPFS path passed as `storage.filename`, scoped to the same origin and browser profile. Tabs only observe each other when they use the same origin, same profile, same `docId`, same OPFS filename, and either BroadcastChannel or explicit SharedWorker support.

Cross-tab updates are local notifications over shared OPFS storage, not remote sync.

Local benchmarking still favors the dedicated-worker OPFS path over SharedWorker for writes, so `runtime: { type: 'auto' }` keeps dedicated-worker as the default.
