### PR TITLE
docs(sync): define applyOps read-after-write visibility

### DIFF
--- a/.changeset/sync-apply-visibility.md
+++ b/.changeset/sync-apply-visibility.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/sync-protocol': patch
+---
+
+Define `applyOps` as a read-after-write visibility boundary for sync backends.

--- a/packages/sync-protocol/protocol/src/in-memory.ts
+++ b/packages/sync-protocol/protocol/src/in-memory.ts
@@ -4,6 +4,12 @@ import type { DuplexTransport, WireCodec } from './transport/index.js';
 import { createInMemoryDuplex, wrapDuplexTransportWithCodec } from './transport/index.js';
 import type { Filter, OpRef, SyncBackend, SyncMessage } from './types.js';
 
+/**
+ * Test/benchmark utility for helpers that intentionally queue backend work.
+ *
+ * `flush` is not part of the public `SyncBackend` contract. Awaiting
+ * `applyOps` must still be enough for read-after-write visibility.
+ */
 export type FlushableSyncBackend<Op> = SyncBackend<Op> & { flush: () => Promise<void> };
 
 export function makeQueuedSyncBackend<Op>(opts: {

--- a/packages/sync-protocol/protocol/src/types.ts
+++ b/packages/sync-protocol/protocol/src/types.ts
@@ -127,11 +127,24 @@ export type SyncMessage<Op> = {
   payload: SyncMessagePayload<Op>;
 };
 
+/**
+ * Storage contract used by the sync protocol.
+ *
+ * `applyOps` is a read-after-write boundary: once it resolves, the newly applied
+ * ops must be observable through this backend's read methods for the same doc.
+ * The protocol relies on that when resolving `syncOnce` and live subscription
+ * delivery; callers should not need a separate public flush/settle step to read
+ * their own completed write.
+ */
 export interface SyncBackend<Op> {
   docId: string;
   maxLamport(): Promise<bigint>;
   listOpRefs(filter: Filter): Promise<OpRef[]>;
   getOpsByOpRefs(opRefs: OpRef[]): Promise<Op[]>;
+  /**
+   * Persist/apply ops and resolve only after those ops are visible to
+   * `maxLamport`, `listOpRefs`, and `getOpsByOpRefs`.
+   */
   applyOps(ops: Op[]): Promise<void>;
 
   /**

--- a/packages/sync-protocol/protocol/tests/helpers/sync-backend-contract.ts
+++ b/packages/sync-protocol/protocol/tests/helpers/sync-backend-contract.ts
@@ -36,6 +36,30 @@ export function defineSyncBackendContract(
   label: string,
   createHarness: () => Promise<SyncBackendHarness> | SyncBackendHarness,
 ): void {
+  test(`${label}: applyOps is read-after-write visible after resolve`, async () => {
+    const harness = await createHarness();
+    try {
+      const docId = `doc-apply-visible-${randomUUID()}`;
+      const backend = await harness.openBackend(docId);
+      const replica = replicaFromLabel('v');
+      const op = makeOp(replica, 1, 7, {
+        type: 'insert',
+        parent: root,
+        node: nodeIdFromInt(7),
+        orderKey: orderKeyFromPosition(0),
+      });
+
+      await backend.applyOps([op]);
+
+      const refs = await backend.listOpRefs({ all: {} });
+      expect(refs.map(bytesToHex)).toEqual([bytesToHex(deriveOpRefV0(docId, op.meta.id))]);
+      expect(await backend.getOpsByOpRefs(refs)).toEqual([op]);
+      expect(await backend.maxLamport()).toBe(7n);
+    } finally {
+      await harness.close?.();
+    }
+  });
+
   test(`${label}: getOpsByOpRefs preserves request order and errors on missing`, async () => {
     const harness = await createHarness();
     try {

--- a/packages/sync-protocol/protocol/tests/helpers/sync-backend-contract.ts
+++ b/packages/sync-protocol/protocol/tests/helpers/sync-backend-contract.ts
@@ -53,7 +53,16 @@ export function defineSyncBackendContract(
 
       const refs = await backend.listOpRefs({ all: {} });
       expect(refs.map(bytesToHex)).toEqual([bytesToHex(deriveOpRefV0(docId, op.meta.id))]);
-      expect(await backend.getOpsByOpRefs(refs)).toEqual([op]);
+      const [stored] = await backend.getOpsByOpRefs(refs);
+      if (!stored) throw new Error('expected stored op');
+      expect(stored.meta.id.counter).toBe(op.meta.id.counter);
+      expect(bytesToHex(stored.meta.id.replica)).toBe(bytesToHex(op.meta.id.replica));
+      expect(stored.meta.lamport).toBe(op.meta.lamport);
+      expect(stored.kind.type).toBe('insert');
+      if (stored.kind.type !== 'insert') throw new Error('expected insert op');
+      expect(stored.kind.parent).toBe(root);
+      expect(stored.kind.node).toBe(nodeIdFromInt(7));
+      expect(bytesToHex(stored.kind.orderKey)).toBe(bytesToHex(orderKeyFromPosition(0)));
       expect(await backend.maxLamport()).toBe(7n);
     } finally {
       await harness.close?.();

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -2048,23 +2048,9 @@ async function scenarioSyncAuthExcludedRootNotSynced(
       { maxCodewords: 10_000, codewordsPerMessage: 256 },
     );
 
-    // `syncOnce` does not guarantee the responder has fully applied the initiator's ops when using async backends
-    // (e.g. wa-sqlite worker/OPFS). Poll briefly for the update to become visible.
-    const expectedHex = bytesToHex(updated);
-    const deadline = Date.now() + 2_000;
-    while (true) {
-      const ops = await a.ops.all();
-      const latest = latestPayloadForNode(ops, publicNode);
-      if (latest && bytesToHex(latest) === expectedHex) break;
-      if (Date.now() > deadline) {
-        assertBytesEqual(
-          latest ?? null,
-          updated,
-          'expected payload update to propagate to full peer',
-        );
-      }
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-    }
+    const ops = await a.ops.all();
+    const latest = latestPayloadForNode(ops, publicNode);
+    assertBytesEqual(latest ?? null, updated, 'expected payload update to propagate to full peer');
   } finally {
     detach();
   }

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -2152,23 +2152,9 @@ async function scenarioSyncAuthExcludedRootNotSynced(
       { maxCodewords: 10_000, codewordsPerMessage: 256 },
     );
 
-    // `syncOnce` does not guarantee the responder has fully applied the initiator's ops when using async backends
-    // (e.g. wa-sqlite worker/OPFS). Poll briefly for the update to become visible.
-    const expectedHex = bytesToHex(updated);
-    const deadline = Date.now() + 2_000;
-    while (true) {
-      const ops = await a.ops.all();
-      const latest = latestPayloadForNode(ops, publicNode);
-      if (latest && bytesToHex(latest) === expectedHex) break;
-      if (Date.now() > deadline) {
-        assertBytesEqual(
-          latest ?? null,
-          updated,
-          'expected payload update to propagate to full peer',
-        );
-      }
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
-    }
+    const ops = await a.ops.all();
+    const latest = latestPayloadForNode(ops, publicNode);
+    assertBytesEqual(latest ?? null, updated, 'expected payload update to propagate to full peer');
   } finally {
     detach();
   }


### PR DESCRIPTION
## Summary
- Documents `SyncBackend.applyOps` as a read-after-write boundary.
- Adds an explicit backend contract assertion that `applyOps` results are visible through `listOpRefs`, `getOpsByOpRefs`, and `maxLamport` after resolve.
- Removes a stale conformance polling path that implied async backends could resolve sync before `applyOps` was visible.
- Clarifies that `FlushableSyncBackend` is only a test/benchmark utility, not part of the normative sync backend contract.

Fixes #112.
