### PR TITLE
Document SQLite client import surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 Tree CRDT workspace targeting SQLite/wa-sqlite + WASM bindings with a shared TypeScript interface.
 
 ## Layout
+
 - `packages/treecrdt-core`: core CRDT library with traits for storage/indexing/access control.
 - `packages/treecrdt-sqlite-ext`: SQLite/wa-sqlite extension harness that will implement the core traits.
 - `packages/treecrdt-wasm`: bridge for wasm-bindgen and browser/node builds.
 - `packages/treecrdt-wasm-js`: TS/JS wrapper for the treecrdt-wasm build
 - `packages/treecrdt-ts`: TypeScript interface definitions shared by bindings and the sync layer.
-- `packages/treecrdt-sqlite-node`: TreeCRDT bundled for Node.js use
-- `packages/treecrdt-wa-sqlite`: TreeCRDT bunlded for browser use
+- `packages/treecrdt-sqlite-node`: TreeCRDT SQLite client for Node.js use
+- `packages/treecrdt-wa-sqlite`: TreeCRDT SQLite client for browser use
 - `packages/treecrdt-benchmark`: Benchmark utilities
 - `packages/discovery`: bootstrap contract for resolving docs to attachment plans
 - `packages/treecrdt-sync`: high-level **client** sync for WebSocket + discovery + SQLite `SyncBackend` (npm: `@treecrdt/sync`). Builds on `@treecrdt/sync-protocol` and `@treecrdt/discovery`.
@@ -20,6 +21,7 @@ Tree CRDT workspace targeting SQLite/wa-sqlite + WASM bindings with a shared Typ
 - `packages/sync-protocol/server/postgres-node`: Node sync server wired to Postgres backend
 
 ## Quick start
+
 ```
 pnpm install
 pnpm build
@@ -27,12 +29,22 @@ pnpm test
 ```
 
 ## Benchmarks
+
 For benchmark commands, product-facing note/sync scenarios, and the sync target matrix (`direct`, local Postgres sync server, remote sync server), see [docs/BENCHMARKS.md](docs/BENCHMARKS.md).
 
+## SQLite Clients
+
+TreeCRDT intentionally keeps separate SQLite app entrypoints for Node and browser runtimes:
+`@treecrdt/sqlite-node` for `better-sqlite3`/native extension usage, and
+`@treecrdt/wa-sqlite` for browser wa-sqlite/WASM usage. See
+[docs/SQLITE_CLIENTS.md](docs/SQLITE_CLIENTS.md) for the import-surface decision and examples.
+
 ## Playground
+
 - Live demo (GitHub Pages): https://cybersemics.github.io/treecrdt/
 
 ### Local playground with a real sync server
+
 If you want the most useful local setup, start the sync server first and then point the playground at it:
 
 ```sh
@@ -72,4 +84,5 @@ For full sync-server configuration and environment variables, see:
 - `examples/playground/README.md`
 
 ## Contribute
+
 Contributions are welcome!

--- a/docs/SQLITE_CLIENTS.md
+++ b/docs/SQLITE_CLIENTS.md
@@ -1,0 +1,76 @@
+# SQLite Client Import Surface
+
+TreeCRDT intentionally keeps separate SQLite client packages for Node and browser runtimes:
+
+- `@treecrdt/sqlite-node` for Node.js apps using `better-sqlite3` and the native SQLite extension.
+- `@treecrdt/wa-sqlite` for browser apps using wa-sqlite, WASM assets, and optional worker/OPFS runtime support.
+
+There is no `@treecrdt/sqlite` meta-package today. Keeping the runtime packages explicit avoids
+accidentally pulling Node native dependencies into browser bundles or wa-sqlite/WASM assets into Node
+apps.
+
+## Shared Engine Surface
+
+Both packages expose the common `TreecrdtEngine` shape from `@treecrdt/interface/engine`, so app code
+can usually depend on the shared engine type after startup.
+
+```ts
+import type { TreecrdtEngine } from '@treecrdt/interface/engine';
+
+async function readRootChildren(client: TreecrdtEngine) {
+  return client.tree.children('0'.repeat(32));
+}
+```
+
+## Node
+
+Use `@treecrdt/sqlite-node` when the app owns a `better-sqlite3` database.
+
+```ts
+import Database from 'better-sqlite3';
+import { createTreecrdtClient, loadTreecrdtExtension } from '@treecrdt/sqlite-node';
+
+const db = new Database('treecrdt.db');
+loadTreecrdtExtension(db);
+
+const client = await createTreecrdtClient(db, { docId });
+```
+
+The Node package owns the native extension lookup/loading helpers and should not be imported from
+browser code.
+
+## Browser
+
+Use `@treecrdt/wa-sqlite/client` for the high-level browser client and
+`@treecrdt/wa-sqlite/vite-plugin` when a Vite app needs wa-sqlite assets copied into its public
+directory.
+
+```ts
+import { createTreecrdtClient } from '@treecrdt/wa-sqlite/client';
+
+const client = await createTreecrdtClient({ docId });
+```
+
+```ts
+// vite.config.ts
+import { treecrdt } from '@treecrdt/wa-sqlite/vite-plugin';
+
+export default {
+  plugins: [treecrdt()],
+};
+```
+
+The browser package owns wa-sqlite asset loading, worker support, and OPFS helpers. Node apps should
+use `@treecrdt/sqlite-node` instead.
+
+## Lower-Level SQLite Helpers
+
+Runtime-neutral SQLite material helpers live in `@treecrdt/interface/sqlite` and
+`@treecrdt/sync-sqlite`. Those packages are for adapter/auth/sync plumbing, not the recommended app
+startup import path.
+
+## Decision
+
+This repository is choosing explicit runtime packages over a unified conditional-export package for
+now. Revisit a meta-package only if we have a concrete app integration that benefits from one import
+enough to justify the bundler and dependency-separation risks.

--- a/packages/treecrdt-sqlite-node/README.md
+++ b/packages/treecrdt-sqlite-node/README.md
@@ -1,0 +1,27 @@
+# @treecrdt/sqlite-node
+
+Node.js TreeCRDT SQLite client built on `better-sqlite3` and the native TreeCRDT SQLite extension.
+
+Use this package for Node processes. Browser apps should use `@treecrdt/wa-sqlite/client` instead;
+there is intentionally no shared `@treecrdt/sqlite` app import today.
+
+## Usage
+
+```ts
+import Database from 'better-sqlite3';
+import { createTreecrdtClient, loadTreecrdtExtension } from '@treecrdt/sqlite-node';
+
+const db = new Database('treecrdt.db');
+loadTreecrdtExtension(db);
+
+const client = await createTreecrdtClient(db, { docId });
+```
+
+`createTreecrdtClient` returns the common `TreecrdtEngine` surface from
+`@treecrdt/interface/engine`, plus Node-specific `runner` and auth helpers.
+
+## Import Decision
+
+The Node and browser SQLite packages stay separate to keep native `better-sqlite3` dependencies out
+of browser bundles and wa-sqlite/WASM assets out of Node apps. See
+[`docs/SQLITE_CLIENTS.md`](../../docs/SQLITE_CLIENTS.md) for the full import-surface decision.

--- a/packages/treecrdt-wa-sqlite/README.md
+++ b/packages/treecrdt-wa-sqlite/README.md
@@ -1,26 +1,43 @@
-# @treecrdt/wa-sqlite (scaffold)
+# @treecrdt/wa-sqlite
 
-Loader + thin helpers to use the TreeCRDT SQLite extension with wa-sqlite in browser/Node.
+Browser TreeCRDT SQLite client built on wa-sqlite, the TreeCRDT SQLite extension, and optional
+worker/OPFS helpers.
 
-## Build wa-sqlite (extension baked in)
-The vendor package builds upstream wa-sqlite with TreeCRDT baked in via Makefile overrides.
-```
-pnpm --filter @treecrdt/wa-sqlite-vendor build
-# builds packages/treecrdt-wa-sqlite-vendor/dist (example apps copy these into public/wa-sqlite/)
-```
+Use this package for browser apps. Node apps should use `@treecrdt/sqlite-node` instead; there is
+intentionally no shared `@treecrdt/sqlite` app import today.
 
-## Use in the demo
-The demo imports the local wa-sqlite build and uses the auto-registered TreeCRDT extension:
+## Usage
+
 ```ts
-import * as SQLite from "wa-sqlite";
-import sqliteWasm from "/wa-sqlite/wa-sqlite.wasm?url";
-import { createWaSqliteApi } from "@treecrdt/wa-sqlite";
+import { createTreecrdtClient } from '@treecrdt/wa-sqlite/client';
 
-const module = await SQLite.Factory({ wasm: sqliteWasm });
-const db = await module.open(":memory:");
-const api = createWaSqliteApi(db);
+const client = await createTreecrdtClient({ docId });
 ```
-See `src/index.ts` and `src/ui/App.tsx` for helpers and a simple insert+move demo.
 
-## Playwright
-`pnpm --filter @treecrdt/wa-sqlite test:e2e` runs Vite dev + Playwright and asserts the demo can append/fetch ops via the extension.
+`createTreecrdtClient` returns the common `TreecrdtEngine` surface from
+`@treecrdt/interface/engine`, plus browser-specific runtime helpers.
+
+## Vite Assets
+
+Vite apps can use the package plugin to copy wa-sqlite assets from `@treecrdt/wa-sqlite-vendor` into
+the app public directory.
+
+```ts
+// vite.config.ts
+import { treecrdt } from '@treecrdt/wa-sqlite/vite-plugin';
+
+export default {
+  plugins: [treecrdt()],
+};
+```
+
+## Low-Level Adapter
+
+The package root exports `createWaSqliteApi` for lower-level adapter integrations that already own a
+wa-sqlite database handle. App code should prefer `@treecrdt/wa-sqlite/client`.
+
+## Import Decision
+
+The Node and browser SQLite packages stay separate to keep native `better-sqlite3` dependencies out
+of browser bundles and wa-sqlite/WASM assets out of Node apps. See
+[`docs/SQLITE_CLIENTS.md`](../../docs/SQLITE_CLIENTS.md) for the full import-surface decision.


### PR DESCRIPTION
## Summary
- Documents the SQLite client import decision: keep explicit runtime packages instead of adding a `@treecrdt/sqlite` meta-package.
- Adds a central `docs/SQLITE_CLIENTS.md` guide with Node, browser, and shared-engine import examples.
- Adds/updates package READMEs for `@treecrdt/sqlite-node` and `@treecrdt/wa-sqlite`.
- Links the decision from the root README.

Fixes #48.
