### PR TITLE
Simplify auth session options

### DIFF
--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -68,16 +68,15 @@ export type TreecrdtAuthSessionOptions = Omit<
   | 'localPublicKey'
   | 'localCapabilityTokens'
   | 'localRevocationRecords'
-> &
-  {
-    /** Doc used to warm local auth material before the session is handed to sync. */
-    docId: string;
-    /** Backend-owned auth dependencies, e.g. subtree scope checks and proof-material stores. */
-    backend?: TreecrdtAuthSessionBackend;
-    identity?: TreecrdtAuthSessionIdentity;
-    trust: TreecrdtAuthSessionTrust;
-    local: TreecrdtAuthSessionLocal;
-  };
+> & {
+  /** Doc used to warm local auth material before the session is handed to sync. */
+  docId: string;
+  /** Backend-owned auth dependencies, e.g. subtree scope checks and proof-material stores. */
+  backend?: TreecrdtAuthSessionBackend;
+  identity?: TreecrdtAuthSessionIdentity;
+  trust: TreecrdtAuthSessionTrust;
+  local: TreecrdtAuthSessionLocal;
+};
 
 export type TreecrdtAuthSession = {
   syncAuth: SyncAuth<Operation>;
@@ -97,14 +96,7 @@ export type TreecrdtAuthSession = {
  * awaiting `ready` before passing it into sync startup, avoiding per-app warmup wrappers.
  */
 export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): TreecrdtAuthSession {
-  const {
-    docId,
-    backend,
-    identity,
-    trust,
-    local,
-    ...authOptsBase
-  } = opts;
+  const { docId, backend, identity, trust, local, ...authOptsBase } = opts;
   if (!trust?.issuerPublicKeys) throw new Error('auth session requires trust.issuerPublicKeys');
   if (!local?.privateKey) throw new Error('auth session requires local.privateKey');
   if (!local?.publicKey) throw new Error('auth session requires local.publicKey');

--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -56,28 +56,6 @@ export type TreecrdtAuthSessionLocal = {
 
 export type TreecrdtAuthSessionLocalAuthorizeOptions = Partial<SyncAuthOpsContext>;
 
-type LegacyTreecrdtAuthSessionOptions = Pick<
-  TreecrdtCoseCwtAuthOptions,
-  'scopeEvaluator' | 'capabilityStore' | 'opAuthStore' | 'onPeerIdentityChain'
-> &
-  Partial<
-    Pick<
-      TreecrdtCoseCwtAuthOptions,
-      | 'issuerPublicKeys'
-      | 'localPrivateKey'
-      | 'localPublicKey'
-      | 'localCapabilityTokens'
-      | 'localRevocationRecords'
-    >
-  > & {
-    /** Prefer `identity.local`; kept so existing callers do not need to migrate immediately. */
-    localIdentityChain?:
-      | TreecrdtIdentityChainV1
-      | (() => MaybePromise<TreecrdtIdentityChainV1 | null | undefined>);
-    /** Prefer `identity.onLocalError`; kept so existing callers do not need to migrate immediately. */
-    onIdentityChainError?: (error: unknown) => void;
-  };
-
 export type TreecrdtAuthSessionOptions = Omit<
   TreecrdtCoseCwtAuthOptions,
   | 'localIdentityChain'
@@ -91,14 +69,14 @@ export type TreecrdtAuthSessionOptions = Omit<
   | 'localCapabilityTokens'
   | 'localRevocationRecords'
 > &
-  LegacyTreecrdtAuthSessionOptions & {
+  {
     /** Doc used to warm local auth material before the session is handed to sync. */
     docId: string;
     /** Backend-owned auth dependencies, e.g. subtree scope checks and proof-material stores. */
     backend?: TreecrdtAuthSessionBackend;
     identity?: TreecrdtAuthSessionIdentity;
-    trust?: TreecrdtAuthSessionTrust;
-    local?: TreecrdtAuthSessionLocal;
+    trust: TreecrdtAuthSessionTrust;
+    local: TreecrdtAuthSessionLocal;
   };
 
 export type TreecrdtAuthSession = {
@@ -125,40 +103,26 @@ export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): Tre
     identity,
     trust,
     local,
-    localIdentityChain,
-    onIdentityChainError,
-    scopeEvaluator,
-    capabilityStore,
-    opAuthStore,
-    onPeerIdentityChain,
-    issuerPublicKeys,
-    localPrivateKey,
-    localPublicKey,
-    localCapabilityTokens,
-    localRevocationRecords,
     ...authOptsBase
   } = opts;
-  const resolvedIssuerPublicKeys = trust?.issuerPublicKeys ?? issuerPublicKeys;
-  const resolvedLocalPrivateKey = local?.privateKey ?? localPrivateKey;
-  const resolvedLocalPublicKey = local?.publicKey ?? localPublicKey;
-  if (!resolvedIssuerPublicKeys) throw new Error('auth session requires trust.issuerPublicKeys');
-  if (!resolvedLocalPrivateKey) throw new Error('auth session requires local.privateKey');
-  if (!resolvedLocalPublicKey) throw new Error('auth session requires local.publicKey');
+  if (!trust?.issuerPublicKeys) throw new Error('auth session requires trust.issuerPublicKeys');
+  if (!local?.privateKey) throw new Error('auth session requires local.privateKey');
+  if (!local?.publicKey) throw new Error('auth session requires local.publicKey');
 
   const authOpts: TreecrdtCoseCwtAuthOptions = {
     ...authOptsBase,
-    issuerPublicKeys: resolvedIssuerPublicKeys,
-    localPrivateKey: resolvedLocalPrivateKey,
-    localPublicKey: resolvedLocalPublicKey,
-    localCapabilityTokens: local?.capabilityTokens ?? localCapabilityTokens,
-    localRevocationRecords: local?.revocationRecords ?? localRevocationRecords,
-    scopeEvaluator: backend?.scopeEvaluator ?? scopeEvaluator,
-    capabilityStore: backend?.capabilityStore ?? capabilityStore,
-    opAuthStore: backend?.opAuthStore ?? opAuthStore,
-    onPeerIdentityChain: identity?.onPeer ?? onPeerIdentityChain,
+    issuerPublicKeys: trust.issuerPublicKeys,
+    localPrivateKey: local.privateKey,
+    localPublicKey: local.publicKey,
+    localCapabilityTokens: local.capabilityTokens,
+    localRevocationRecords: local.revocationRecords,
+    scopeEvaluator: backend?.scopeEvaluator,
+    capabilityStore: backend?.capabilityStore,
+    opAuthStore: backend?.opAuthStore,
+    onPeerIdentityChain: identity?.onPeer,
   };
-  const resolvedLocalIdentityChain = identity?.local ?? localIdentityChain;
-  const resolvedOnIdentityChainError = identity?.onLocalError ?? onIdentityChainError;
+  const resolvedLocalIdentityChain = identity?.local;
+  const resolvedOnIdentityChainError = identity?.onLocalError;
   const baseAuth = createTreecrdtCoseCwtAuth(authOpts);
   let state: TreecrdtAuthSessionState = { status: 'loading' };
 

--- a/packages/treecrdt-auth/tests/session.test.ts
+++ b/packages/treecrdt-auth/tests/session.test.ts
@@ -18,13 +18,21 @@ function testIdentityChain(): TreecrdtIdentityChainV1 {
   };
 }
 
+function baseSessionOptions(docId: string) {
+  return {
+    docId,
+    trust: { issuerPublicKeys: [] },
+    local: {
+      privateKey: testKey(4),
+      publicKey: testKey(5),
+    },
+    allowUnsigned: true,
+  };
+}
+
 test('auth session warms sync auth and exposes ready state', async () => {
   const session = createTreecrdtAuthSession({
-    docId: 'doc-auth-session-ready',
-    issuerPublicKeys: [],
-    localPrivateKey: testKey(4),
-    localPublicKey: testKey(5),
-    allowUnsigned: true,
+    ...baseSessionOptions('doc-auth-session-ready'),
   });
 
   expect(session.getState().status).toBe('loading');
@@ -34,12 +42,10 @@ test('auth session warms sync auth and exposes ready state', async () => {
 
 test('auth session advertises async local identity chain without app-side wrappers', async () => {
   const session = createTreecrdtAuthSession({
-    docId: 'doc-auth-session-identity',
-    issuerPublicKeys: [],
-    localPrivateKey: testKey(4),
-    localPublicKey: testKey(5),
-    allowUnsigned: true,
-    localIdentityChain: async () => testIdentityChain(),
+    ...baseSessionOptions('doc-auth-session-identity'),
+    identity: {
+      local: async () => testIdentityChain(),
+    },
   });
 
   await session.ready;
@@ -54,13 +60,7 @@ test('auth session advertises async local identity chain without app-side wrappe
 test('auth session accepts grouped backend and identity options', async () => {
   let listedCapabilities = 0;
   const session = createTreecrdtAuthSession({
-    docId: 'doc-auth-session-grouped',
-    trust: { issuerPublicKeys: [] },
-    local: {
-      privateKey: testKey(4),
-      publicKey: testKey(5),
-    },
-    allowUnsigned: true,
+    ...baseSessionOptions('doc-auth-session-grouped'),
     backend: {
       scopeEvaluator: async () => 'deny',
       capabilityStore: {
@@ -95,15 +95,13 @@ test('auth session accepts grouped backend and identity options', async () => {
 test('auth session treats identity chain provider failures as best-effort', async () => {
   const errors: unknown[] = [];
   const session = createTreecrdtAuthSession({
-    docId: 'doc-auth-session-identity-error',
-    issuerPublicKeys: [],
-    localPrivateKey: testKey(4),
-    localPublicKey: testKey(5),
-    allowUnsigned: true,
-    localIdentityChain: async () => {
-      throw new Error('identity unavailable');
+    ...baseSessionOptions('doc-auth-session-identity-error'),
+    identity: {
+      local: async () => {
+        throw new Error('identity unavailable');
+      },
+      onLocalError: (err) => errors.push(err),
     },
-    onIdentityChainError: (err) => errors.push(err),
   });
 
   await session.ready;


### PR DESCRIPTION
## Summary
Removes the legacy flat `createTreecrdtAuthSession(...)` option aliases before this API is released broadly.

Auth sessions now accept one grouped shape: `trust`, `local`, optional `identity`, and optional `backend`. The lower-level `createTreecrdtCoseCwtAuth(...)` API is unchanged for internal/expert callers.

## Before
```ts
createTreecrdtAuthSession({
  docId,
  issuerPublicKeys,
  localPrivateKey,
  localPublicKey,
  localCapabilityTokens,
  localIdentityChain,
  onPeerIdentityChain,
})
```

## After
```ts
createTreecrdtAuthSession({
  docId,
  trust: { issuerPublicKeys },
  local: {
    privateKey,
    publicKey,
    capabilityTokens,
  },
  identity: {
    local,
    onPeer,
  },
})
```

This keeps the app-facing auth setup closer to the `client.auth.createSession(...)` usage already used by the playground, and removes duplicated compatibility resolution from the session wrapper.