### PR TITLE
Add local write ids to materialization events

### DIFF
--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -137,6 +137,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioLocalInsertWithPayload,
     },
     {
+      name: 'local ops: materialization events include writeId',
+      run: scenarioLocalOpsMaterializationWriteId,
+    },
+    {
       name: 'append/appendMany: idempotent + headLamport monotonic',
       run: scenarioAppendIdempotentAndHeadLamportMonotonic,
     },
@@ -525,6 +529,69 @@ async function scenarioLocalInsertWithPayload(
   assertEqual(first.kind.type, 'insert', 'ops.all first kind');
   if (first.kind.type !== 'insert') throw new Error(`expected insert op, got ${first.kind.type}`);
   assertBytesEqual(first.kind.payload ?? null, payload, 'ops.all insert payload');
+}
+
+async function scenarioLocalOpsMaterializationWriteId(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parent = nodeIdFromInt(41);
+  const node = nodeIdFromInt(42);
+  const boundNode = nodeIdFromInt(43);
+  const payload = new TextEncoder().encode('payload-42');
+  const nextPayload = new TextEncoder().encode('payload-43');
+
+  await engine.local.insert(replica, root, parent, { type: 'last' }, null);
+
+  const assertWriteIdEvent = (
+    events: MaterializationEvent[],
+    writeId: string,
+    expectedRefs: string[],
+    label: string,
+  ) => {
+    assertEqual(events.length, 1, `${label} should emit one materialization event`);
+    assertArrayEqual(events[0]!.writeIds ?? [], [writeId], `${label} writeIds`);
+    assertEventNodeRefsContain(
+      materializationEventNodeRefs(events[0]!),
+      expectedRefs,
+      `${label} event refs`,
+    );
+  };
+
+  const insertEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.insert(replica, root, node, { type: 'last' }, null, {
+      writeId: 'local-insert-42',
+    });
+  });
+  assertWriteIdEvent(insertEvents, 'local-insert-42', [root, node], 'local insert');
+
+  const moveEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.move(replica, node, parent, { type: 'last' }, { writeId: 'local-move-42' });
+  });
+  assertWriteIdEvent(moveEvents, 'local-move-42', [root, parent, node], 'local move');
+
+  const payloadEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.payload(replica, node, payload, { writeId: 'local-payload-42' });
+  });
+  assertWriteIdEvent(payloadEvents, 'local-payload-42', [node], 'local payload');
+
+  const deleteEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.delete(replica, node, { writeId: 'local-delete-42' });
+  });
+  assertWriteIdEvent(deleteEvents, 'local-delete-42', [parent, node], 'local delete');
+
+  const boundLocal = engine.local.forReplica(replica, { writeId: 'bound-local-default-43' });
+  const boundInsertEvents = await captureMaterializationEvents(engine, async () => {
+    await boundLocal.insert(root, boundNode, { type: 'last' }, nextPayload);
+  });
+  assertWriteIdEvent(
+    boundInsertEvents,
+    'bound-local-default-43',
+    [root, boundNode],
+    'bound local insert',
+  );
 }
 
 async function scenarioAppendIdempotentAndHeadLamportMonotonic(

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -61,11 +61,11 @@ export async function createTreecrdtPostgresClient(
 
   const backend = factory.open(docId);
   const materialized = createMaterializationDispatcher();
-  const emitNativeOutcome = (nativeOutcome: NativeMaterializationOutcome) => {
-    materialized.emitOutcome(nativeToMaterializationOutcome(nativeOutcome));
+  const emitNativeOutcome = (nativeOutcome: NativeMaterializationOutcome, writeId?: string) => {
+    materialized.emitOutcome(nativeToMaterializationOutcome(nativeOutcome), writeId);
   };
-  const finishLocalOp = (result: NativeLocalOpResult): Operation => {
-    emitNativeOutcome(result.outcome);
+  const finishLocalOp = (result: NativeLocalOpResult, writeId?: string): Operation => {
+    emitNativeOutcome(result.outcome, writeId);
     return nativeToOperation(result.op);
   };
   const finishPreparedLocalOp = async (
@@ -85,7 +85,7 @@ export async function createTreecrdtPostgresClient(
         throw err;
       }
     }
-    return finishLocalOp(tx.commit());
+    return finishLocalOp(tx.commit(), writeOpts?.writeId);
   };
   const ensureMaterializedImpl = () => {
     emitNativeOutcome(backend.ensureMaterialized());

--- a/packages/treecrdt-postgres-napi/tests/conformance.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/conformance.test.ts
@@ -76,6 +76,7 @@ test('conformance registry includes materialization-event scenarios', () => {
   expect(names).toContain('materialization events: structural batch');
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
+  expect(names).toContain('local ops: materialization events include writeId');
 });
 
 maybeDescribe('engine conformance scenarios (postgres-napi engine)', () => {

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -37,6 +37,7 @@ test('conformance registry includes materialization-event scenarios', () => {
   expect(names).toContain('materialization events: structural batch');
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
+  expect(names).toContain('local ops: materialization events include writeId');
 });
 
 test('sqlite auth-aware local write rolls back on auth failure', async () => {

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -74,6 +74,9 @@ export type LocalWriteAuthSession = {
 };
 
 export type LocalWriteOptions = {
+  /** Echoed on the materialization event emitted by this local write. */
+  writeId?: string;
+
   /**
    * Authorizes the minted local op before it is exposed to callers as committed.
    *

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -74,8 +74,10 @@ function decodeLocalOpResult(
 function emitLocalOutcome(
   outcome: MaterializationOutcome,
   emit?: (event: MaterializationEvent) => void,
+  writeId?: string,
 ): void {
-  if (outcome.changes.length > 0) emit?.({ ...outcome });
+  if (outcome.changes.length > 0)
+    emit?.({ ...outcome, ...(writeId ? { writeIds: [writeId] } : {}) });
 }
 
 const ROOT_NODE_BYTES = nodeIdToBytes16(ROOT_NODE_ID_HEX);
@@ -617,7 +619,7 @@ export function createTreecrdtSqliteWriter(
         await sqliteGetJson<any>(runner, sql, params),
         sql,
       );
-      emitLocalOutcome(outcome, opts.onMaterialized);
+      emitLocalOutcome(outcome, opts.onMaterialized, writeOpts?.writeId);
       return op;
     }
 
@@ -632,7 +634,7 @@ export function createTreecrdtSqliteWriter(
       await authSession.authorizeLocalOps([op]);
       await sqliteExec(runner, `RELEASE ${savepoint}`);
       released = true;
-      emitLocalOutcome(outcome, opts.onMaterialized);
+      emitLocalOutcome(outcome, opts.onMaterialized, writeOpts?.writeId);
       return op;
     } catch (err) {
       if (!released) {


### PR DESCRIPTION
## Summary
- Allow `client.local.*` writes to carry a `writeId`.
- Echo that id on same-client materialization events across sqlite-node and postgres-napi.
- Add conformance coverage for local-write materialization metadata.