### PR TITLE
Document contributor changeset workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,36 @@
 # treecrdt
 
-Tree CRDT workspace targeting SQLite/wa-sqlite + WASM bindings with a shared TypeScript interface.
+TreeCRDT is a SQLite-backed tree CRDT workspace for browser clients, Node clients, sync protocol packages, and sync server packages.
 
-## Layout
-- `packages/treecrdt-core`: core CRDT library with traits for storage/indexing/access control.
-- `packages/treecrdt-sqlite-ext`: SQLite/wa-sqlite extension harness that will implement the core traits.
-- `packages/treecrdt-wasm`: bridge for wasm-bindgen and browser/node builds.
-- `packages/treecrdt-wasm-js`: TS/JS wrapper for the treecrdt-wasm build
-- `packages/treecrdt-ts`: TypeScript interface definitions shared by bindings and the sync layer.
-- `packages/treecrdt-sqlite-node`: TreeCRDT bundled for Node.js use
-- `packages/treecrdt-wa-sqlite`: TreeCRDT bunlded for browser use
-- `packages/treecrdt-benchmark`: Benchmark utilities
-- `packages/discovery`: bootstrap contract for resolving docs to attachment plans
-- `packages/treecrdt-sync`: high-level **client** sync for WebSocket + discovery + SQLite `SyncBackend` (npm: `@treecrdt/sync`). Builds on `@treecrdt/sync-protocol` and `@treecrdt/discovery`.
-- `packages/sync-protocol/protocol`: sync protocol/runtime core, transport-agnostic (npm: `@treecrdt/sync-protocol`)
-- `packages/sync-protocol/material/sqlite`: SQLite-backed sync adapters and proof-material stores
-- `packages/sync-protocol/material/postgres`: Postgres-backed sync proof-material stores
-- `packages/sync-protocol/server/core`: shared WebSocket sync server runtime
-- `packages/sync-protocol/server/postgres-node`: Node sync server wired to Postgres backend
+## Quick Start
 
-## Quick start
-```
+```sh
 pnpm install
 pnpm build
 pnpm test
 ```
 
-## Benchmarks
-For benchmark commands, product-facing note/sync scenarios, and the sync target matrix (`direct`, local Postgres sync server, remote sync server), see [docs/BENCHMARKS.md](docs/BENCHMARKS.md).
+## Main Packages
+
+- `@treecrdt/wa-sqlite`: browser SQLite client adapter.
+- `@treecrdt/sync`: client sync over discovery + WebSocket + SQLite backends.
+- `@treecrdt/interface`: shared TypeScript interfaces.
+- `@treecrdt/sync-protocol`: transport-agnostic sync protocol runtime.
+- `@treecrdt/discovery`: bootstrap contract for resolving docs to sync attachments.
+- `@treecrdt/sync-server-postgres-node`: Postgres-backed WebSocket sync server.
+
+See the package READMEs for package-specific setup and API details.
 
 ## Playground
-- Live demo (GitHub Pages): https://cybersemics.github.io/treecrdt/
 
-### Local playground with a real sync server
-If you want the most useful local setup, start the sync server first and then point the playground at it:
+- Live demo: https://cybersemics.github.io/treecrdt/
+- Local playground instructions: [examples/playground/README.md](examples/playground/README.md)
+- Local Postgres sync server instructions: [packages/sync-protocol/server/postgres-node/README.md](packages/sync-protocol/server/postgres-node/README.md)
 
-```sh
-# Build all workspace packages, including the Postgres sync-server path.
-pnpm build
-# Start a disposable local Postgres instance in Docker on localhost:5432.
-pnpm sync-server:postgres:db:start
-# Start the TreeCRDT sync server on ws://localhost:8787 using that Postgres DB.
-pnpm sync-server:postgres:local
-# Start the playground UI so you can connect it to the local sync server.
-pnpm playground
-```
+## Benchmarks
 
-Open the `Connections` panel in the playground and set the remote sync server URL to:
+For benchmark commands, product-facing note/sync scenarios, and the sync target matrix, see [docs/BENCHMARKS.md](docs/BENCHMARKS.md).
 
-```
-ws://localhost:8787
-```
+## Contributing
 
-The playground will normalize this to `/sync?docId=...`.
-
-`pnpm sync-server:postgres:db:start` starts a disposable local Postgres on the common URL:
-
-```
-postgres://postgres:postgres@127.0.0.1:5432/postgres
-```
-
-Stop that local database later with:
-
-```
-pnpm sync-server:postgres:db:stop
-```
-
-For full sync-server configuration and environment variables, see:
-
-- `packages/sync-protocol/server/postgres-node/README.md`
-- `examples/playground/README.md`
-
-## Contribute
-Contributions are welcome!
+For PR expectations, local checks, and changeset/release notes, see [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+## Pull Requests
+
+- Keep PRs focused. Split unrelated CI, docs, package, and behavior changes when practical.
+- Add or update tests for behavior changes.
+- Run the relevant local checks before requesting review.
+
+Common checks:
+
+```sh
+pnpm build
+pnpm test
+pnpm fmt:check:ts
+pnpm fmt:check:rust
+```
+
+## Changesets
+
+CI checks release metadata on pull requests. A changeset is required when a PR changes a release-tracked package and should be included in the next npm release.
+
+Add a changeset on the feature branch:
+
+```sh
+pnpm changeset
+```
+
+Choose the changed package, choose `patch`, `minor`, or `major`, and write a short package-level release note. The changeset text becomes the changelog entry, so it should describe the user-visible package change rather than every commit.
+
+No changeset is needed for docs-only, CI-only, example-only, or other non-package changes.
+
+If a PR changes package files but should not publish a release, add an empty changeset:
+
+```sh
+pnpm changeset --empty
+```
+
+## Releases
+
+Merged changesets are collected on `main`. The release workflow opens or updates a release PR that bumps package versions, updates changelogs, removes consumed changeset files, and refreshes the lockfile.
+
+Merging the release PR publishes the changed packages.


### PR DESCRIPTION
Simplifies the root README and moves contribution guidance into `docs/CONTRIBUTING.md`.

This is docs-only and does not require a changeset.