### PR TITLE
Remove wa-sqlite client auth surface

### DIFF
--- a/.changeset/separate-wa-sqlite-auth.md
+++ b/.changeset/separate-wa-sqlite-auth.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': minor
+---
+
+Remove auth helpers from the wa-sqlite client surface so apps compose sqlite auth explicitly through `@treecrdt/sync-sqlite/auth`.

--- a/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuth.ts
@@ -12,6 +12,7 @@ import {
   type TreecrdtCapabilityTokenV1,
 } from "@treecrdt/auth";
 import { createTreecrdtSqliteSyncDiagnostics } from "@treecrdt/sync-sqlite";
+import { createTreecrdtSqliteAuthApi } from "@treecrdt/sync-sqlite/auth";
 import type { SyncAuth } from "@treecrdt/sync-protocol";
 import type { TreecrdtClient } from "@treecrdt/wa-sqlite";
 
@@ -290,6 +291,11 @@ type UsePlaygroundAuthOptions = {
 
 export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAuthApi {
   const { docId, joinMode, client, syncServerUrl, syncTransportMode, onPeerIdentityChain, refreshDocPayloadKey } = opts;
+  const authApi = useMemo(
+    () =>
+      client ? createTreecrdtSqliteAuthApi({ runner: client.runner, docId: client.docId }) : null,
+    [client],
+  );
 
   const [authEnabled, setAuthEnabled] = useState(() => initialAuthEnabled());
   const [revealIdentity, setRevealIdentity] = useState(() => initialRevealIdentity());
@@ -486,7 +492,7 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
     resetLocalIdentityChain,
   } = usePlaygroundAuthSession({
     authEnabled,
-    client,
+    authApi,
     docId,
     authMaterial,
     hardRevokedTokenIds,
@@ -873,8 +879,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
       const issuerPk = base64urlDecode(issuerPkB64);
       const proofTokenBytes = base64urlDecode(proofTokenB64);
-      const proofDesc = client
-        ? await client.auth.describeCapabilityToken({
+      const proofDesc = authApi
+        ? await authApi.describeCapabilityToken({
             tokenBytes: proofTokenBytes,
             trust: { issuerPublicKeys: [issuerPk] },
             docId,
@@ -900,10 +906,10 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
         if (proofScope?.maxDepth !== undefined) {
           throw new Error("This tab can only mint delegated invites for its current subtree scope (maxDepth).");
         }
-        if (!client) {
+        if (!authApi) {
           throw new Error("This tab can only mint delegated invites for its current subtree scope.");
         }
-        const tri = await client.auth.evaluateScope({
+        const tri = await authApi.evaluateScope({
           node: hexToBytes16(rootNodeId),
           scope: {
             root: hexToBytes16(proofRootId),
@@ -1175,8 +1181,8 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
 
         const issuerPk = base64urlDecode(issuerPkB64);
         const proofTokenBytes = base64urlDecode(proofTokenB64);
-        const proofDesc = client
-          ? await client.auth.describeCapabilityToken({
+        const proofDesc = authApi
+          ? await authApi.describeCapabilityToken({
               tokenBytes: proofTokenBytes,
               trust: { issuerPublicKeys: [issuerPk] },
               docId,
@@ -1199,10 +1205,10 @@ export function usePlaygroundAuth(opts: UsePlaygroundAuthOptions): PlaygroundAut
           if (proofScope?.maxDepth !== undefined) {
             throw new Error("this tab can only delegate grants for its current subtree scope (maxDepth)");
           }
-          if (!client) {
+          if (!authApi) {
             throw new Error("this tab can only delegate grants for its current subtree scope");
           }
-          const tri = await client.auth.evaluateScope({
+          const tri = await authApi.evaluateScope({
             node: hexToBytes16(rootNodeId),
             scope: {
               root: hexToBytes16(proofRootId),

--- a/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundAuthSession.ts
@@ -4,14 +4,14 @@ import type { LocalWriteOptions } from "@treecrdt/interface/engine";
 import { bytesToHex } from "@treecrdt/interface/ids";
 import { base64urlDecode, type TreecrdtAuthSession } from "@treecrdt/auth";
 import type { SyncAuth } from "@treecrdt/sync-protocol";
-import type { TreecrdtClient } from "@treecrdt/wa-sqlite";
+import type { TreecrdtSqliteAuthApi } from "@treecrdt/sync-sqlite/auth";
 
 import { createLocalIdentityChainV1, type StoredAuthMaterial } from "../../auth";
 import { hexToBytes16 } from "../../sync-v0";
 
 type UsePlaygroundAuthSessionOptions = {
   authEnabled: boolean;
-  client: TreecrdtClient | null;
+  authApi: TreecrdtSqliteAuthApi | null;
   docId: string;
   authMaterial: StoredAuthMaterial;
   hardRevokedTokenIds: string[];
@@ -38,7 +38,7 @@ export function usePlaygroundAuthSession(
 ): PlaygroundAuthSessionState {
   const {
     authEnabled,
-    client,
+    authApi,
     docId,
     authMaterial,
     hardRevokedTokenIds,
@@ -94,7 +94,7 @@ export function usePlaygroundAuthSession(
     let cancelled = false;
     setSyncAuth(null);
 
-    if (!authEnabled || !client) {
+    if (!authEnabled || !authApi) {
       localAuthSessionRef.current = null;
       return () => {
         cancelled = true;
@@ -118,7 +118,7 @@ export function usePlaygroundAuthSession(
         const localPk = base64urlDecode(localPkB64);
         const localTokens = localTokensB64.map((t) => base64urlDecode(t));
 
-        const authSession = await client.auth.createSession({
+        const authSession = await authApi.createSession({
           docId,
           trust: { issuerPublicKeys: [issuerPk] },
           local: {
@@ -155,7 +155,7 @@ export function usePlaygroundAuthSession(
     };
   }, [
     authEnabled,
-    client,
+    authApi,
     docId,
     authMaterial.issuerPkB64,
     authMaterial.localSkB64,

--- a/packages/treecrdt-wa-sqlite/package.json
+++ b/packages/treecrdt-wa-sqlite/package.json
@@ -36,8 +36,7 @@
     "benchmark": "pnpm run build && tsx ./scripts/bench.ts"
   },
   "dependencies": {
-    "@treecrdt/interface": "workspace:*",
-    "@treecrdt/sync-sqlite": "workspace:*"
+    "@treecrdt/interface": "workspace:*"
   },
   "devDependencies": {
     "@treecrdt/wa-sqlite-vendor": "workspace:*",

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -27,7 +27,6 @@ import {
   createMaterializationDispatcher,
   createTreecrdtEngineLocal,
 } from '@treecrdt/interface/engine';
-import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import { dbGetText } from './sql.js';
 import type {
   RpcMethod,
@@ -54,9 +53,7 @@ import type {
   SharedWorkerFactory,
   StorageMode,
   TreecrdtClient,
-  TreecrdtClientAuthApi,
   TreecrdtRuntime,
-  TreecrdtSqliteAuthModule,
   WorkerProxy,
 } from './types.js';
 
@@ -177,32 +174,6 @@ function defaultSharedWorkerName(docId: string, filename?: string): string {
 // --- Worker client
 
 const CROSS_TAB_MATERIALIZED_MESSAGE = 'treecrdt-materialized-v1';
-
-let sqliteAuthModulePromise: Promise<TreecrdtSqliteAuthModule> | null = null;
-
-function loadSqliteAuthModule(): Promise<TreecrdtSqliteAuthModule> {
-  // Auth is an opt-in capability path for browser clients. Apps that only open
-  // local trees do not need auth sessions or proof material until they call client.auth.*.
-  sqliteAuthModulePromise ??= import('@treecrdt/sync-sqlite/auth');
-  return sqliteAuthModulePromise;
-}
-
-function createLazyAuthApi(opts: { runner: SqliteRunner; docId: string }): TreecrdtClientAuthApi {
-  let authApiPromise: Promise<TreecrdtSqliteAuthApi> | null = null;
-  const getAuthApi = () => {
-    authApiPromise ??= loadSqliteAuthModule().then(({ createTreecrdtSqliteAuthApi }) =>
-      createTreecrdtSqliteAuthApi(opts),
-    );
-    return authApiPromise;
-  };
-
-  return {
-    createSession: async (...args) => (await getAuthApi()).createSession(...args),
-    describeCapabilityToken: async (...args) =>
-      (await getAuthApi()).describeCapabilityToken(...args),
-    evaluateScope: async (...args) => await (await getAuthApi()).evaluateScope(...args),
-  };
-}
 
 function createClientMaterializationDispatcher(
   opts: ClientMaterializationDispatcherOptions = {},
@@ -906,7 +877,6 @@ function makeTreecrdtClientFromCall(opts: {
       getPayload: treeGetPayloadImpl,
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
-    auth: createLazyAuthApi({ runner, docId: opts.docId }),
     local,
     onMaterialized: materialized.onMaterialized,
     close: closeImpl,

--- a/packages/treecrdt-wa-sqlite/src/index.ts
+++ b/packages/treecrdt-wa-sqlite/src/index.ts
@@ -6,7 +6,6 @@ export type {
   StorageMode,
   TreecrdtAssets,
   TreecrdtClient,
-  TreecrdtClientAuthApi,
   TreecrdtRuntime,
   TreecrdtStorage,
 } from './types.js';

--- a/packages/treecrdt-wa-sqlite/src/types.ts
+++ b/packages/treecrdt-wa-sqlite/src/types.ts
@@ -1,7 +1,6 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
-import type { TreecrdtSqliteAuthApi } from '@treecrdt/sync-sqlite/auth';
 import type { RpcMethod, RpcParams, RpcRequest, RpcResult } from './rpc.js';
 
 // Minimal wa-sqlite surface needed by the adapter. Exported so consumers
@@ -37,20 +36,7 @@ export type TreecrdtClient = TreecrdtEngine & {
   runtime: RuntimeMode;
   storage: StorageMode;
   runner: SqliteRunner;
-  auth: TreecrdtClientAuthApi;
   drop: () => Promise<void>;
-};
-
-export type TreecrdtSqliteAuthModule = typeof import('@treecrdt/sync-sqlite/auth');
-
-export type TreecrdtClientAuthApi = {
-  createSession: (
-    ...args: Parameters<TreecrdtSqliteAuthApi['createSession']>
-  ) => Promise<ReturnType<TreecrdtSqliteAuthApi['createSession']>>;
-  describeCapabilityToken: TreecrdtSqliteAuthApi['describeCapabilityToken'];
-  evaluateScope: (
-    ...args: Parameters<TreecrdtSqliteAuthApi['evaluateScope']>
-  ) => Promise<Awaited<ReturnType<TreecrdtSqliteAuthApi['evaluateScope']>>>;
 };
 
 export type ClientOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,9 +490,6 @@ importers:
       '@treecrdt/interface':
         specifier: workspace:*
         version: link:../treecrdt-ts
-      '@treecrdt/sync-sqlite':
-        specifier: workspace:*
-        version: link:../sync-protocol/material/sqlite
     devDependencies:
       '@treecrdt/benchmark':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Remove auth from the `@treecrdt/wa-sqlite` client surface.

Apps now compose sqlite auth explicitly from `@treecrdt/sync-sqlite/auth` using the wa-sqlite client runner and `docId`. This keeps wa-sqlite focused on browser sqlite storage/runtime and leaves auth in the sqlite sync/auth layer.