### PR TITLE
Expose materialization source metadata

### DIFF
--- a/.changeset/wise-plants-change.md
+++ b/.changeset/wise-plants-change.md
@@ -1,0 +1,7 @@
+---
+'@treecrdt/interface': minor
+'@treecrdt/wa-sqlite': minor
+'@treecrdt/sync': patch
+---
+
+Add optional per-change source metadata to materialization events so apps can derive local projections like update metadata from the operation that caused a visible tree change.

--- a/packages/treecrdt-core/src/affected.rs
+++ b/packages/treecrdt-core/src/affected.rs
@@ -1,6 +1,6 @@
 use crate::ids::NodeId;
-use crate::ops::OperationKind;
-use crate::types::MaterializationChange;
+use crate::ops::{Operation, OperationKind};
+use crate::types::{MaterializationChange, MaterializationSource};
 
 #[derive(Clone, Debug)]
 pub(crate) struct TombstoneDelta {
@@ -37,8 +37,10 @@ pub(crate) fn parent_hints_from(parent: Option<NodeId>) -> Vec<NodeId> {
 
 pub(crate) fn direct_materialization_changes(
     snapshot_parent: Option<NodeId>,
-    kind: &OperationKind,
+    op: &Operation,
 ) -> Vec<MaterializationChange> {
+    let source = Some(MaterializationSource::from_op(op));
+    let kind = &op.kind;
     match kind {
         OperationKind::Insert {
             parent,
@@ -50,6 +52,7 @@ pub(crate) fn direct_materialization_changes(
                 node: *node,
                 parent_after: *parent,
                 payload: payload.clone(),
+                source,
             }]
         }
         OperationKind::Move {
@@ -58,10 +61,12 @@ pub(crate) fn direct_materialization_changes(
             node: *node,
             parent_before: snapshot_parent.filter(|parent| *parent != NodeId::TRASH),
             parent_after: *new_parent,
+            source,
         }],
         OperationKind::Payload { node, payload } => vec![MaterializationChange::Payload {
             node: *node,
             payload: payload.clone(),
+            source,
         }],
         OperationKind::Delete { .. } | OperationKind::Tombstone { .. } => Vec::new(),
     }
@@ -69,6 +74,7 @@ pub(crate) fn direct_materialization_changes(
 
 pub(crate) fn materialization_change_from_tombstone_delta(
     delta: TombstoneDelta,
+    source: Option<MaterializationSource>,
 ) -> Option<MaterializationChange> {
     if delta.node == NodeId::TRASH {
         return None;
@@ -80,10 +86,12 @@ pub(crate) fn materialization_change_from_tombstone_delta(
             node: delta.node,
             parent_after: parent,
             payload: delta.payload_after,
+            source,
         }),
         (false, true) => Some(MaterializationChange::Delete {
             node: delta.node,
             parent_before: parent,
+            source,
         }),
         _ => None,
     }
@@ -95,6 +103,7 @@ struct StructuralChange {
     final_parent: NodeId,
     inserted: bool,
     payload_after: Option<Vec<u8>>,
+    source: Option<MaterializationSource>,
 }
 
 #[derive(Clone, Debug)]
@@ -103,6 +112,38 @@ struct TombstoneChange {
     last_parent: Option<NodeId>,
     payload_after: Option<Vec<u8>>,
     count: usize,
+    source: Option<MaterializationSource>,
+}
+
+#[derive(Clone, Debug)]
+struct PayloadChange {
+    payload_after: Option<Vec<u8>>,
+    source: Option<MaterializationSource>,
+}
+
+fn source_key(source: &MaterializationSource) -> (u64, &[u8], u64) {
+    (
+        source.operation.lamport,
+        source.operation.id.replica.as_bytes(),
+        source.operation.id.counter,
+    )
+}
+
+fn latest_source(
+    left: Option<MaterializationSource>,
+    right: Option<MaterializationSource>,
+) -> Option<MaterializationSource> {
+    match (left, right) {
+        (None, None) => None,
+        (Some(source), None) | (None, Some(source)) => Some(source),
+        (Some(left), Some(right)) => {
+            if source_key(&right) >= source_key(&left) {
+                Some(right)
+            } else {
+                Some(left)
+            }
+        }
+    }
 }
 
 pub(crate) fn coalesce_materialization_changes(
@@ -112,7 +153,7 @@ pub(crate) fn coalesce_materialization_changes(
 
     let mut structural: BTreeMap<NodeId, StructuralChange> = BTreeMap::new();
     let mut tombstone: BTreeMap<NodeId, TombstoneChange> = BTreeMap::new();
-    let mut payload: BTreeMap<NodeId, Option<Vec<u8>>> = BTreeMap::new();
+    let mut payload: BTreeMap<NodeId, PayloadChange> = BTreeMap::new();
 
     for change in changes {
         match change {
@@ -120,6 +161,7 @@ pub(crate) fn coalesce_materialization_changes(
                 node,
                 parent_after,
                 payload,
+                source,
             } => {
                 structural
                     .entry(node)
@@ -127,50 +169,61 @@ pub(crate) fn coalesce_materialization_changes(
                         existing.final_parent = parent_after;
                         existing.inserted = true;
                         existing.payload_after = payload.clone();
+                        existing.source = latest_source(existing.source.clone(), source.clone());
                     })
                     .or_insert(StructuralChange {
                         first_parent: None,
                         final_parent: parent_after,
                         inserted: true,
                         payload_after: payload,
+                        source,
                     });
             }
             MaterializationChange::Move {
                 node,
                 parent_before,
                 parent_after,
+                source,
             } => {
                 structural
                     .entry(node)
-                    .and_modify(|existing| existing.final_parent = parent_after)
+                    .and_modify(|existing| {
+                        existing.final_parent = parent_after;
+                        existing.source = latest_source(existing.source.clone(), source.clone());
+                    })
                     .or_insert(StructuralChange {
                         first_parent: parent_before,
                         final_parent: parent_after,
                         inserted: false,
                         payload_after: None,
+                        source,
                     });
             }
             MaterializationChange::Delete {
                 node,
                 parent_before,
+                source,
             } => {
                 tombstone
                     .entry(node)
                     .and_modify(|existing| {
                         existing.last_parent = parent_before;
                         existing.count += 1;
+                        existing.source = latest_source(existing.source.clone(), source.clone());
                     })
                     .or_insert(TombstoneChange {
                         first_is_restore: false,
                         last_parent: parent_before,
                         payload_after: None,
                         count: 1,
+                        source,
                     });
             }
             MaterializationChange::Restore {
                 node,
                 parent_after,
                 payload,
+                source,
             } => {
                 tombstone
                     .entry(node)
@@ -178,19 +231,31 @@ pub(crate) fn coalesce_materialization_changes(
                         existing.last_parent = parent_after;
                         existing.payload_after = payload.clone();
                         existing.count += 1;
+                        existing.source = latest_source(existing.source.clone(), source.clone());
                     })
                     .or_insert(TombstoneChange {
                         first_is_restore: true,
                         last_parent: parent_after,
                         payload_after: payload,
                         count: 1,
+                        source,
                     });
             }
             MaterializationChange::Payload {
                 node,
                 payload: payload_after,
+                source,
             } => {
-                payload.insert(node, payload_after);
+                payload
+                    .entry(node)
+                    .and_modify(|existing| {
+                        existing.payload_after = payload_after.clone();
+                        existing.source = latest_source(existing.source.clone(), source.clone());
+                    })
+                    .or_insert(PayloadChange {
+                        payload_after,
+                        source,
+                    });
             }
         }
     }
@@ -209,17 +274,27 @@ pub(crate) fn coalesce_materialization_changes(
     let mut coalesced = Vec::new();
     for (node, change) in structural {
         if change.inserted {
-            let payload_after = payload.remove(&node).unwrap_or(change.payload_after);
+            let payload_change = payload.remove(&node);
+            let payload_after = payload_change
+                .as_ref()
+                .map(|change| change.payload_after.clone())
+                .unwrap_or(change.payload_after);
+            let source = latest_source(
+                change.source,
+                payload_change.and_then(|change| change.source),
+            );
             coalesced.push(MaterializationChange::Insert {
                 node,
                 parent_after: change.final_parent,
                 payload: payload_after,
+                source,
             });
         } else {
             coalesced.push(MaterializationChange::Move {
                 node,
                 parent_before: change.first_parent,
                 parent_after: change.final_parent,
+                source: change.source,
             });
         }
     }
@@ -229,25 +304,36 @@ pub(crate) fn coalesce_materialization_changes(
             continue;
         }
         if change.first_is_restore {
-            let payload_after = payload.remove(&node).unwrap_or(change.payload_after);
+            let payload_change = payload.remove(&node);
+            let payload_after = payload_change
+                .as_ref()
+                .map(|change| change.payload_after.clone())
+                .unwrap_or(change.payload_after);
+            let source = latest_source(
+                change.source,
+                payload_change.and_then(|change| change.source),
+            );
             coalesced.push(MaterializationChange::Restore {
                 node,
                 parent_after: change.last_parent,
                 payload: payload_after,
+                source,
             });
         } else {
             coalesced.push(MaterializationChange::Delete {
                 node,
                 parent_before: change.last_parent,
+                source: change.source,
             });
         }
     }
 
-    for (node, payload_after) in payload {
+    for (node, payload_change) in payload {
         if !deleted_nodes.contains(&node) {
             coalesced.push(MaterializationChange::Payload {
                 node,
-                payload: payload_after,
+                payload: payload_change.payload_after,
+                source: payload_change.source,
             });
         }
     }

--- a/packages/treecrdt-core/src/lib.rs
+++ b/packages/treecrdt-core/src/lib.rs
@@ -36,6 +36,7 @@ pub use traits::{
 pub use tree::TreeCrdt;
 pub use types::{
     ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
-    NodeExport, NodeSnapshotExport, PreparedLocalOp,
+    MaterializationSource, MaterializationSourceOperation, NodeExport, NodeSnapshotExport,
+    PreparedLocalOp,
 };
 pub use version_vector::VersionVector;

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -1007,10 +1007,12 @@ where
                     node: *node,
                     parent_after: final_parent.filter(|parent| *parent != NodeId::TRASH),
                     payload: rebuilt.crdt.payload(*node)?,
+                    source: None,
                 }),
                 (false, true) => patch_changes.push(MaterializationChange::Delete {
                     node: *node,
                     parent_before: previous_parent.filter(|parent| *parent != NodeId::TRASH),
+                    source: None,
                 }),
                 _ => {}
             }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -12,7 +12,7 @@ use crate::traits::{
 };
 use crate::types::{
     ApplyDelta, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationOutcome,
-    NodeExport, NodeSnapshotExport, PreparedLocalOp,
+    MaterializationSource, NodeExport, NodeSnapshotExport, PreparedLocalOp,
 };
 use crate::version_vector::VersionVector;
 
@@ -20,6 +20,23 @@ use crate::version_vector::VersionVector;
 struct NodeSnapshot {
     parent: Option<NodeId>,
     order_key: Option<Vec<u8>>,
+}
+
+fn attach_source_if_missing(
+    change: &mut MaterializationChange,
+    next_source: Option<MaterializationSource>,
+) {
+    match change {
+        MaterializationChange::Insert { source, .. }
+        | MaterializationChange::Move { source, .. }
+        | MaterializationChange::Delete { source, .. }
+        | MaterializationChange::Restore { source, .. }
+        | MaterializationChange::Payload { source, .. } => {
+            if source.is_none() {
+                *source = next_source;
+            }
+        }
+    }
 }
 
 /// Generic Tree CRDT facade that wires clock and storage together.
@@ -170,6 +187,7 @@ where
                     node,
                     parent_after: parent,
                     payload: payload_after,
+                    source: None,
                 }],
             },
         })
@@ -218,6 +236,7 @@ where
                     node,
                     parent_before: old_parent,
                     parent_after: new_parent,
+                    source: None,
                 }],
             },
         })
@@ -241,6 +260,7 @@ where
                 changes: vec![MaterializationChange::Delete {
                     node,
                     parent_before: old_parent.filter(|parent| *parent != NodeId::TRASH),
+                    source: None,
                 }],
             },
         })
@@ -276,6 +296,7 @@ where
                 changes: vec![MaterializationChange::Payload {
                     node,
                     payload: payload_after,
+                    source: None,
                 }],
             },
         })
@@ -315,7 +336,7 @@ where
             self.op_count += 1;
             self.head = Some(op.clone());
 
-            let changes = direct_materialization_changes(snapshot.parent, &op.kind);
+            let changes = direct_materialization_changes(snapshot.parent, &op);
             return Ok(Some(ApplyDelta {
                 snapshot: NodeSnapshotExport {
                     parent: snapshot.parent,
@@ -343,17 +364,21 @@ where
         seq: &mut u64,
     ) -> Result<Option<ApplyDelta>> {
         *seq = (*seq).saturating_add(1);
-        let snapshot = self.apply_remote_with_delta(op.clone())?.map(|delta| NodeSnapshot {
-            parent: delta.snapshot.parent,
-            order_key: delta.snapshot.order_key,
-        });
-        let Some(snapshot) = snapshot else {
+        let delta = self.apply_remote_with_delta(op.clone())?;
+        let Some(delta) = delta else {
             *seq = (*seq).saturating_sub(1);
             return Ok(None);
         };
-        let changes = direct_materialization_changes(snapshot.parent, &op.kind);
+        let snapshot = NodeSnapshot {
+            parent: delta.snapshot.parent,
+            order_key: delta.snapshot.order_key,
+        };
         Ok(Some(self.finalize_materialized_apply(
-            snapshot, &op, index, *seq, changes,
+            snapshot,
+            &op,
+            index,
+            *seq,
+            delta.changes,
         )?))
     }
 
@@ -378,7 +403,7 @@ where
         self.op_count = seq;
         self.head = Some(op.clone());
 
-        let changes = direct_materialization_changes(snapshot.parent, &op.kind);
+        let changes = direct_materialization_changes(snapshot.parent, &op);
         self.finalize_materialized_apply(snapshot, &op, index, seq, changes)
     }
 
@@ -422,11 +447,14 @@ where
         let mut starts = parents;
         starts.push(op_node);
         let tombstone_changed = self.refresh_tombstones_upward_with_delta(starts)?;
-        changes.extend(
-            tombstone_changed
-                .into_iter()
-                .filter_map(materialization_change_from_tombstone_delta),
-        );
+        let source = Some(MaterializationSource::from_op(op));
+        for change in &mut changes {
+            attach_source_if_missing(change, source.clone());
+        }
+
+        changes.extend(tombstone_changed.into_iter().filter_map(|delta| {
+            materialization_change_from_tombstone_delta(delta, source.clone())
+        }));
 
         Ok(ApplyDelta {
             snapshot: NodeSnapshotExport {
@@ -465,12 +493,14 @@ where
             index.record(*parent, op_id, seq)?;
         }
 
+        let source = Some(MaterializationSource::from_op(op));
         let mut changes = plan.changes.clone();
-        changes.extend(
-            tombstone_changed
-                .into_iter()
-                .filter_map(materialization_change_from_tombstone_delta),
-        );
+        for change in &mut changes {
+            attach_source_if_missing(change, source.clone());
+        }
+        changes.extend(tombstone_changed.into_iter().filter_map(|delta| {
+            materialization_change_from_tombstone_delta(delta, source.clone())
+        }));
 
         Ok(MaterializationOutcome {
             head_seq: seq,

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::ids::{NodeId, OperationId};
+use crate::ids::{Lamport, NodeId, OperationId};
 use crate::ops::Operation;
 use crate::version_vector::VersionVector;
 
@@ -21,6 +21,37 @@ pub struct NodeSnapshotExport {
     pub order_key: Option<Vec<u8>>,
 }
 
+/// Operation source metadata for a materialized visible change.
+///
+/// Materialization changes are coalesced, so this identifies the latest operation that contributed
+/// to the final visible change when core can determine that exactly. Conservative catch-up paths
+/// may omit it when a change is derived from rebuilt state rather than a single operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct MaterializationSource {
+    pub operation: MaterializationSourceOperation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
+pub struct MaterializationSourceOperation {
+    pub id: OperationId,
+    pub lamport: Lamport,
+}
+
+impl MaterializationSource {
+    pub fn from_op(op: &Operation) -> Self {
+        Self {
+            operation: MaterializationSourceOperation {
+                id: op.meta.id.clone(),
+                lamport: op.meta.lamport,
+            },
+        }
+    }
+}
+
 /// A coalesced visible change produced while advancing materialized state.
 ///
 /// This is intentionally higher-level than raw operations: a replay pass may collapse multiple
@@ -33,24 +64,49 @@ pub enum MaterializationChange {
         node: NodeId,
         parent_after: NodeId,
         payload: Option<Vec<u8>>,
+        #[cfg_attr(
+            feature = "serde",
+            serde(default, skip_serializing_if = "Option::is_none")
+        )]
+        source: Option<MaterializationSource>,
     },
     Move {
         node: NodeId,
         parent_before: Option<NodeId>,
         parent_after: NodeId,
+        #[cfg_attr(
+            feature = "serde",
+            serde(default, skip_serializing_if = "Option::is_none")
+        )]
+        source: Option<MaterializationSource>,
     },
     Delete {
         node: NodeId,
         parent_before: Option<NodeId>,
+        #[cfg_attr(
+            feature = "serde",
+            serde(default, skip_serializing_if = "Option::is_none")
+        )]
+        source: Option<MaterializationSource>,
     },
     Restore {
         node: NodeId,
         parent_after: Option<NodeId>,
         payload: Option<Vec<u8>>,
+        #[cfg_attr(
+            feature = "serde",
+            serde(default, skip_serializing_if = "Option::is_none")
+        )]
+        source: Option<MaterializationSource>,
     },
     Payload {
         node: NodeId,
         payload: Option<Vec<u8>>,
+        #[cfg_attr(
+            feature = "serde",
+            serde(default, skip_serializing_if = "Option::is_none")
+        )]
+        source: Option<MaterializationSource>,
     },
 }
 

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -348,6 +348,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
                     changes: vec![MaterializationChange::Payload {
                         node: NodeId(2),
                         payload: Some(vec![9]),
+                        source: None,
                     }],
                 },
             })
@@ -436,10 +437,12 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
                         MaterializationChange::Payload {
                             node: NodeId(1),
                             payload: None,
+                            source: None,
                         },
                         MaterializationChange::Payload {
                             node: NodeId(2),
                             payload: None,
+                            source: None,
                         },
                     ],
                 },
@@ -874,6 +877,7 @@ fn catch_up_materialized_state_reports_rows_restored_by_replay_patch() {
             node: parent,
             parent_after: Some(NodeId::ROOT),
             payload: None,
+            source: None,
         }),
         "catch-up must report rows restored by patching stale backend state"
     );

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -331,6 +331,24 @@ async function captureMaterializationEvents(
   return events;
 }
 
+function assertChangeSource(
+  event: MaterializationEvent,
+  node: string,
+  op: Operation,
+  label: string,
+): void {
+  const change = event.changes.find((change) => change.node === node);
+  assert(change, `${label} change for node`);
+  assert(change.source, `${label} source`);
+  assertEqual(change.source.operation.id.counter, op.meta.id.counter, `${label} source counter`);
+  assertEqual(change.source.operation.lamport, op.meta.lamport, `${label} source lamport`);
+  assertBytesEqual(
+    change.source.operation.id.replica,
+    replicaIdToBytes(op.meta.id.replica),
+    `${label} source replica`,
+  );
+}
+
 function assertBytesEqual(
   actual: Uint8Array | null,
   expected: Uint8Array | null,
@@ -560,31 +578,46 @@ async function scenarioLocalOpsMaterializationWriteId(
     );
   };
 
+  let insertOp: Operation | undefined;
   const insertEvents = await captureMaterializationEvents(engine, async () => {
-    await engine.local.insert(replica, root, node, { type: 'last' }, null, {
+    insertOp = await engine.local.insert(replica, root, node, { type: 'last' }, null, {
       writeId: 'local-insert-42',
     });
   });
   assertWriteIdEvent(insertEvents, 'local-insert-42', [root, node], 'local insert');
+  assertChangeSource(insertEvents[0]!, node, insertOp!, 'local insert');
 
+  let moveOp: Operation | undefined;
   const moveEvents = await captureMaterializationEvents(engine, async () => {
-    await engine.local.move(replica, node, parent, { type: 'last' }, { writeId: 'local-move-42' });
+    moveOp = await engine.local.move(
+      replica,
+      node,
+      parent,
+      { type: 'last' },
+      { writeId: 'local-move-42' },
+    );
   });
   assertWriteIdEvent(moveEvents, 'local-move-42', [root, parent, node], 'local move');
+  assertChangeSource(moveEvents[0]!, node, moveOp!, 'local move');
 
+  let payloadOp: Operation | undefined;
   const payloadEvents = await captureMaterializationEvents(engine, async () => {
-    await engine.local.payload(replica, node, payload, { writeId: 'local-payload-42' });
+    payloadOp = await engine.local.payload(replica, node, payload, { writeId: 'local-payload-42' });
   });
   assertWriteIdEvent(payloadEvents, 'local-payload-42', [node], 'local payload');
+  assertChangeSource(payloadEvents[0]!, node, payloadOp!, 'local payload');
 
+  let deleteOp: Operation | undefined;
   const deleteEvents = await captureMaterializationEvents(engine, async () => {
-    await engine.local.delete(replica, node, { writeId: 'local-delete-42' });
+    deleteOp = await engine.local.delete(replica, node, { writeId: 'local-delete-42' });
   });
   assertWriteIdEvent(deleteEvents, 'local-delete-42', [parent, node], 'local delete');
+  assertChangeSource(deleteEvents[0]!, node, deleteOp!, 'local delete');
 
   const boundLocal = engine.local.forReplica(replica, { writeId: 'bound-local-default-43' });
+  let boundInsertOp: Operation | undefined;
   const boundInsertEvents = await captureMaterializationEvents(engine, async () => {
-    await boundLocal.insert(root, boundNode, { type: 'last' }, nextPayload);
+    boundInsertOp = await boundLocal.insert(root, boundNode, { type: 'last' }, nextPayload);
   });
   assertWriteIdEvent(
     boundInsertEvents,
@@ -592,6 +625,7 @@ async function scenarioLocalOpsMaterializationWriteId(
     [root, boundNode],
     'bound local insert',
   );
+  assertChangeSource(boundInsertEvents[0]!, boundNode, boundInsertOp!, 'bound local insert');
 }
 
 async function scenarioAppendIdempotentAndHeadLamportMonotonic(

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -4,8 +4,9 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use postgres::{Client, NoTls};
 use treecrdt_core::{
-    Error as CoreError, Lamport, MaterializationChange, MaterializationOutcome, NodeId, Operation,
-    OperationId, OperationKind, ReplicaId, Result as CoreResult, VersionVector,
+    Error as CoreError, Lamport, MaterializationChange, MaterializationOutcome,
+    MaterializationSource, NodeId, Operation, OperationId, OperationKind, ReplicaId,
+    Result as CoreResult, VersionVector,
 };
 
 fn map_err(e: impl std::fmt::Display) -> napi::Error {
@@ -80,6 +81,24 @@ pub struct NativeMaterializationChange {
     pub parent_before: Option<Buffer>,
     pub parent_after: Option<Buffer>,
     pub payload: Option<Buffer>,
+    pub source: Option<NativeMaterializationSource>,
+}
+
+#[napi(object)]
+pub struct NativeMaterializationSource {
+    pub operation: NativeMaterializationSourceOperation,
+}
+
+#[napi(object)]
+pub struct NativeMaterializationSourceOperation {
+    pub id: NativeOperationId,
+    pub lamport: BigInt,
+}
+
+#[napi(object)]
+pub struct NativeOperationId {
+    pub replica: Buffer,
+    pub counter: BigInt,
 }
 
 #[napi(object)]
@@ -133,6 +152,20 @@ impl NativePreparedLocalOpTx {
 }
 
 fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOutcome {
+    fn source_to_native(
+        source: Option<MaterializationSource>,
+    ) -> Option<NativeMaterializationSource> {
+        source.map(|source| NativeMaterializationSource {
+            operation: NativeMaterializationSourceOperation {
+                id: NativeOperationId {
+                    replica: Buffer::from(source.operation.id.replica.as_bytes().to_vec()),
+                    counter: BigInt::from(source.operation.id.counter),
+                },
+                lamport: BigInt::from(source.operation.lamport),
+            },
+        })
+    }
+
     let changes = outcome
         .changes
         .into_iter()
@@ -141,51 +174,64 @@ fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOu
                 node,
                 parent_after,
                 payload,
+                source,
             } => NativeMaterializationChange {
                 kind: "insert".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: Some(node_buffer(parent_after)),
                 payload: payload.map(Buffer::from),
+                source: source_to_native(source),
             },
             MaterializationChange::Move {
                 node,
                 parent_before,
                 parent_after,
+                source,
             } => NativeMaterializationChange {
                 kind: "move".to_string(),
                 node: node_buffer(node),
                 parent_before: parent_before.map(node_buffer),
                 parent_after: Some(node_buffer(parent_after)),
                 payload: None,
+                source: source_to_native(source),
             },
             MaterializationChange::Delete {
                 node,
                 parent_before,
+                source,
             } => NativeMaterializationChange {
                 kind: "delete".to_string(),
                 node: node_buffer(node),
                 parent_before: parent_before.map(node_buffer),
                 parent_after: None,
                 payload: None,
+                source: source_to_native(source),
             },
             MaterializationChange::Restore {
                 node,
                 parent_after,
                 payload,
+                source,
             } => NativeMaterializationChange {
                 kind: "restore".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: parent_after.map(node_buffer),
                 payload: payload.map(Buffer::from),
+                source: source_to_native(source),
             },
-            MaterializationChange::Payload { node, payload } => NativeMaterializationChange {
+            MaterializationChange::Payload {
+                node,
+                payload,
+                source,
+            } => NativeMaterializationChange {
                 kind: "payload".to_string(),
                 node: node_buffer(node),
                 parent_before: None,
                 parent_after: None,
                 payload: payload.map(Buffer::from),
+                source: source_to_native(source),
             },
         })
         .collect();

--- a/packages/treecrdt-postgres-napi/src/codec.ts
+++ b/packages/treecrdt-postgres-napi/src/codec.ts
@@ -5,7 +5,7 @@ import {
   nodeIdToBytes16,
   replicaIdToBytes,
 } from '@treecrdt/interface/ids';
-import type { MaterializationOutcome } from '@treecrdt/interface/engine';
+import type { MaterializationOutcome, MaterializationSource } from '@treecrdt/interface/engine';
 
 import type { NativeMaterializationOutcome, NativeOp } from './native.js';
 
@@ -181,10 +181,26 @@ export function nativeToMaterializationOutcome(
   outcome: NativeMaterializationOutcome,
 ): MaterializationOutcome {
   const payloadOrNull = (payload: Uint8Array | null | undefined) => payload ?? null;
+  const decodeSource = (
+    source: NativeMaterializationOutcome['changes'][number]['source'],
+  ): MaterializationSource | undefined =>
+    source
+      ? {
+          operation: {
+            id: {
+              replica: source.operation.id.replica,
+              counter: parseSafeInteger('source.operation.id.counter', source.operation.id.counter),
+            },
+            lamport: parseSafeInteger('source.operation.lamport', source.operation.lamport),
+          },
+        }
+      : undefined;
+
   return {
     headSeq: parseSafeInteger('headSeq', outcome.headSeq),
     changes: outcome.changes.map((change) => {
       const kind = String(change.kind);
+      const source = decodeSource(change.source);
       if (kind === 'insert') {
         if (!change.parentAfter) throw new Error('native insert change missing parentAfter');
         return {
@@ -192,6 +208,7 @@ export function nativeToMaterializationOutcome(
           node: nodeIdFromBytes16(change.node),
           parentAfter: nodeIdFromBytes16(change.parentAfter),
           payload: payloadOrNull(change.payload),
+          ...(source ? { source } : {}),
         };
       }
       if (kind === 'move') {
@@ -201,6 +218,7 @@ export function nativeToMaterializationOutcome(
           node: nodeIdFromBytes16(change.node),
           parentBefore: change.parentBefore ? nodeIdFromBytes16(change.parentBefore) : null,
           parentAfter: nodeIdFromBytes16(change.parentAfter),
+          ...(source ? { source } : {}),
         };
       }
       if (kind === 'delete') {
@@ -208,6 +226,7 @@ export function nativeToMaterializationOutcome(
           kind,
           node: nodeIdFromBytes16(change.node),
           parentBefore: change.parentBefore ? nodeIdFromBytes16(change.parentBefore) : null,
+          ...(source ? { source } : {}),
         };
       }
       if (kind === 'restore') {
@@ -216,6 +235,7 @@ export function nativeToMaterializationOutcome(
           node: nodeIdFromBytes16(change.node),
           parentAfter: change.parentAfter ? nodeIdFromBytes16(change.parentAfter) : null,
           payload: payloadOrNull(change.payload),
+          ...(source ? { source } : {}),
         };
       }
       if (kind === 'payload') {
@@ -223,6 +243,7 @@ export function nativeToMaterializationOutcome(
           kind,
           node: nodeIdFromBytes16(change.node),
           payload: payloadOrNull(change.payload),
+          ...(source ? { source } : {}),
         };
       }
       throw new Error(`unknown native materialization change kind: ${kind}`);

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -24,6 +24,17 @@ export type NativeMaterializationChange = {
   parentBefore?: Uint8Array | null;
   parentAfter?: Uint8Array | null;
   payload?: Uint8Array | null;
+  source?: NativeMaterializationSource | null;
+};
+
+export type NativeMaterializationSource = {
+  operation: {
+    id: {
+      replica: Uint8Array;
+      counter: bigint | number;
+    };
+    lamport: bigint | number;
+  };
 };
 
 export type NativeMaterializationOutcome = {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -9,7 +9,8 @@ use treecrdt_core::PayloadStore;
 use treecrdt_core::Storage;
 use treecrdt_core::{
     orchestrate_persisted_remote_append, try_direct_rewind_catch_up_materialized_state,
-    LamportClock, MaterializationChange, MaterializationCursor, MaterializationOutcome, ReplicaId,
+    LamportClock, MaterializationChange, MaterializationCursor, MaterializationOutcome,
+    MaterializationSource, OperationId, ReplicaId,
 };
 
 #[derive(serde::Serialize)]
@@ -30,29 +31,75 @@ enum JsonMaterializationChange {
         node: String,
         parent_after: String,
         payload: Option<Vec<u8>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<JsonMaterializationSource>,
     },
     Move {
         node: String,
         parent_before: Option<String>,
         parent_after: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<JsonMaterializationSource>,
     },
     Delete {
         node: String,
         parent_before: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<JsonMaterializationSource>,
     },
     Restore {
         node: String,
         parent_after: Option<String>,
         payload: Option<Vec<u8>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<JsonMaterializationSource>,
     },
     Payload {
         node: String,
         payload: Option<Vec<u8>>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<JsonMaterializationSource>,
     },
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonMaterializationSource {
+    operation: JsonMaterializationSourceOperation,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonMaterializationSourceOperation {
+    id: JsonOperationId,
+    lamport: u64,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonOperationId {
+    replica: Vec<u8>,
+    counter: u64,
+}
+
+fn json_operation_id(id: &OperationId) -> JsonOperationId {
+    JsonOperationId {
+        replica: id.replica.as_bytes().to_vec(),
+        counter: id.counter,
+    }
 }
 
 fn node_hex(node: NodeId) -> String {
     format!("{:032x}", node.0)
+}
+
+fn json_source(source: &Option<MaterializationSource>) -> Option<JsonMaterializationSource> {
+    source.as_ref().map(|source| JsonMaterializationSource {
+        operation: JsonMaterializationSourceOperation {
+            id: json_operation_id(&source.operation.id),
+            lamport: source.operation.lamport,
+        },
+    })
 }
 
 pub(super) fn json_outcome_from_core(
@@ -66,42 +113,53 @@ pub(super) fn json_outcome_from_core(
                 node,
                 parent_after,
                 payload,
+                source,
             } => JsonMaterializationChange::Insert {
                 node: node_hex(*node),
                 parent_after: node_hex(*parent_after),
                 payload: payload.clone(),
+                source: json_source(source),
             },
             MaterializationChange::Move {
                 node,
                 parent_before,
                 parent_after,
+                source,
             } => JsonMaterializationChange::Move {
                 node: node_hex(*node),
                 parent_before: parent_before.map(node_hex),
                 parent_after: node_hex(*parent_after),
+                source: json_source(source),
             },
             MaterializationChange::Delete {
                 node,
                 parent_before,
+                source,
             } => JsonMaterializationChange::Delete {
                 node: node_hex(*node),
                 parent_before: parent_before.map(node_hex),
+                source: json_source(source),
             },
             MaterializationChange::Restore {
                 node,
                 parent_after,
                 payload,
+                source,
             } => JsonMaterializationChange::Restore {
                 node: node_hex(*node),
                 parent_after: parent_after.map(node_hex),
                 payload: payload.clone(),
+                source: json_source(source),
             },
-            MaterializationChange::Payload { node, payload } => {
-                JsonMaterializationChange::Payload {
-                    node: node_hex(*node),
-                    payload: payload.clone(),
-                }
-            }
+            MaterializationChange::Payload {
+                node,
+                payload,
+                source,
+            } => JsonMaterializationChange::Payload {
+                node: node_hex(*node),
+                payload: payload.clone(),
+                source: json_source(source),
+            },
         })
         .collect();
     JsonMaterializationOutcome {

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -5,7 +5,8 @@ use std::path::PathBuf;
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use treecrdt_core::{
-    order_key::allocate_between, MaterializationChange, MaterializationOutcome, NodeId, Operation,
+    order_key::allocate_between, MaterializationChange, MaterializationOutcome,
+    MaterializationSource, MaterializationSourceOperation, NodeId, Operation, OperationId,
     OperationKind, ReplicaId, VersionVector,
 };
 use treecrdt_test_support::{
@@ -44,25 +45,50 @@ enum JsonMaterializationChange {
         node: String,
         parent_after: String,
         payload: Option<Vec<u8>>,
+        source: Option<JsonMaterializationSource>,
     },
     Move {
         node: String,
         parent_before: Option<String>,
         parent_after: String,
+        source: Option<JsonMaterializationSource>,
     },
     Delete {
         node: String,
         parent_before: Option<String>,
+        source: Option<JsonMaterializationSource>,
     },
     Restore {
         node: String,
         parent_after: Option<String>,
         payload: Option<Vec<u8>>,
+        source: Option<JsonMaterializationSource>,
     },
     Payload {
         node: String,
         payload: Option<Vec<u8>>,
+        source: Option<JsonMaterializationSource>,
     },
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonMaterializationSource {
+    operation: JsonMaterializationSourceOperation,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonMaterializationSourceOperation {
+    id: JsonOperationId,
+    lamport: u64,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonOperationId {
+    replica: Vec<u8>,
+    counter: u64,
 }
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -84,6 +110,18 @@ fn hex_to_node_id(hex: &str) -> NodeId {
     NodeId(u128::from_str_radix(hex, 16).unwrap())
 }
 
+fn source_to_core(source: Option<JsonMaterializationSource>) -> Option<MaterializationSource> {
+    source.map(|source| MaterializationSource {
+        operation: MaterializationSourceOperation {
+            id: OperationId {
+                replica: ReplicaId::new(source.operation.id.replica),
+                counter: source.operation.id.counter,
+            },
+            lamport: source.operation.lamport,
+        },
+    })
+}
+
 fn json_outcome_to_core(outcome: JsonMaterializationOutcome) -> MaterializationOutcome {
     MaterializationOutcome {
         head_seq: outcome.head_seq,
@@ -95,42 +133,53 @@ fn json_outcome_to_core(outcome: JsonMaterializationOutcome) -> MaterializationO
                     node,
                     parent_after,
                     payload,
+                    source,
                 } => MaterializationChange::Insert {
                     node: hex_to_node_id(&node),
                     parent_after: hex_to_node_id(&parent_after),
                     payload,
+                    source: source_to_core(source),
                 },
                 JsonMaterializationChange::Move {
                     node,
                     parent_before,
                     parent_after,
+                    source,
                 } => MaterializationChange::Move {
                     node: hex_to_node_id(&node),
                     parent_before: parent_before.as_deref().map(hex_to_node_id),
                     parent_after: hex_to_node_id(&parent_after),
+                    source: source_to_core(source),
                 },
                 JsonMaterializationChange::Delete {
                     node,
                     parent_before,
+                    source,
                 } => MaterializationChange::Delete {
                     node: hex_to_node_id(&node),
                     parent_before: parent_before.as_deref().map(hex_to_node_id),
+                    source: source_to_core(source),
                 },
                 JsonMaterializationChange::Restore {
                     node,
                     parent_after,
                     payload,
+                    source,
                 } => MaterializationChange::Restore {
                     node: hex_to_node_id(&node),
                     parent_after: parent_after.as_deref().map(hex_to_node_id),
                     payload,
+                    source: source_to_core(source),
                 },
-                JsonMaterializationChange::Payload { node, payload } => {
-                    MaterializationChange::Payload {
-                        node: hex_to_node_id(&node),
-                        payload,
-                    }
-                }
+                JsonMaterializationChange::Payload {
+                    node,
+                    payload,
+                    source,
+                } => MaterializationChange::Payload {
+                    node: hex_to_node_id(&node),
+                    payload,
+                    source: source_to_core(source),
+                },
             })
             .collect(),
     }

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -1,8 +1,8 @@
 use std::slice;
 
 use treecrdt_core::{
-    MaterializationChange, MaterializationFrontier, MaterializationOutcome, NodeId, Operation,
-    ReplicaId,
+    MaterializationChange, MaterializationFrontier, MaterializationOutcome, MaterializationSource,
+    NodeId, Operation, ReplicaId,
 };
 
 pub trait MaterializationConformanceHarness {
@@ -21,6 +21,35 @@ pub trait MaterializationConformanceHarness {
 
 fn changed_nodes(outcome: &MaterializationOutcome) -> Vec<NodeId> {
     outcome.affected_nodes()
+}
+
+fn visible_payload_source(
+    change: &MaterializationChange,
+    target: NodeId,
+    expected_payload: &[u8],
+) -> Option<Option<MaterializationSource>> {
+    match change {
+        MaterializationChange::Insert {
+            node,
+            payload,
+            source,
+            ..
+        }
+        | MaterializationChange::Restore {
+            node,
+            payload,
+            source,
+            ..
+        }
+        | MaterializationChange::Payload {
+            node,
+            payload,
+            source,
+        } if *node == target && payload.as_deref() == Some(expected_payload) => {
+            Some(source.clone())
+        }
+        _ => None,
+    }
 }
 
 pub fn order_key_from_position(position: u16) -> Vec<u8> {
@@ -84,10 +113,15 @@ pub fn representative_remote_batch_matches_shape<H: MaterializationConformanceHa
 
     let outcome = harness.append_ops_with_materialization_outcome(&ops);
     assert_eq!(changed_nodes(&outcome), vec![NodeId::ROOT, p1, p2, child]);
-    assert!(outcome
+    let payload_source = outcome
         .changes
         .iter()
-        .any(|change| matches!(change, MaterializationChange::Payload { node, payload } if *node == child && payload.as_deref() == Some(&[8]))));
+        .find_map(|change| visible_payload_source(change, child, &[8]))
+        .expect("expected final child payload in materialization outcome");
+    assert_eq!(
+        payload_source,
+        Some(MaterializationSource::from_op(ops.last().unwrap()))
+    );
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![p1, p2]);
     assert_eq!(harness.visible_children(p2), vec![child]);
     assert_eq!(harness.payload(child), Some(vec![8]));

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -1,12 +1,57 @@
 import type { Operation, ReplicaId } from './index.js';
 import type { SqliteTreeChildRow, SqliteTreeRow, TreecrdtSqlitePlacement } from './sqlite.js';
 
+export type MaterializationSource = {
+  /**
+   * Operation that caused the visible change.
+   *
+   * `replica` is a low-level CRDT replica id, not an auth/user identity.
+   */
+  operation: {
+    id: {
+      replica: Uint8Array;
+      counter: number;
+    };
+    /** Lamport timestamp assigned to the operation. */
+    lamport: number;
+  };
+  /** Future auth metadata for the operation signer, when available. */
+  signer?: {
+    publicKey: Uint8Array;
+  };
+};
+
+type ChangeSource = {
+  /**
+   * Operation source metadata when the materializer can attribute the visible change to one exact op.
+   *
+   * Conservative catch-up/rebuild paths may omit this when a visible change is derived from rebuilt
+   * state instead of a single operation.
+   */
+  source?: MaterializationSource;
+};
+
 export type Change =
-  | { kind: 'insert'; node: string; parentAfter: string; payload: Uint8Array | null }
-  | { kind: 'move'; node: string; parentBefore: string | null; parentAfter: string }
-  | { kind: 'delete'; node: string; parentBefore: string | null }
-  | { kind: 'restore'; node: string; parentAfter: string | null; payload: Uint8Array | null }
-  | { kind: 'payload'; node: string; payload: Uint8Array | null };
+  | ({
+      kind: 'insert';
+      node: string;
+      parentAfter: string;
+      payload: Uint8Array | null;
+    } & ChangeSource)
+  | ({
+      kind: 'move';
+      node: string;
+      parentBefore: string | null;
+      parentAfter: string;
+    } & ChangeSource)
+  | ({ kind: 'delete'; node: string; parentBefore: string | null } & ChangeSource)
+  | ({
+      kind: 'restore';
+      node: string;
+      parentAfter: string | null;
+      payload: Uint8Array | null;
+    } & ChangeSource)
+  | ({ kind: 'payload'; node: string; payload: Uint8Array | null } & ChangeSource);
 
 /**
  * Coalesced result of advancing materialized state to `headSeq`.

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,6 +1,11 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
 import { emptyMaterializationOutcome } from './engine.js';
-import type { LocalWriteOptions, MaterializationEvent, MaterializationOutcome } from './engine.js';
+import type {
+  LocalWriteOptions,
+  MaterializationEvent,
+  MaterializationOutcome,
+  MaterializationSource,
+} from './engine.js';
 import {
   decodeNodeId,
   decodeReplicaId,
@@ -722,17 +727,38 @@ function decodeSqlitePayload(raw: unknown): Uint8Array | null {
   return Uint8Array.from(raw as any);
 }
 
+function decodeSqliteMaterializationSource(raw: unknown): MaterializationSource | undefined {
+  if (raw == null) return undefined;
+  const value = raw as any;
+  const operation = value.operation as any;
+  const operationId = operation?.id as any;
+  return {
+    operation: {
+      id: {
+        replica: decodeReplicaId(operationId.replica),
+        counter: Number(operationId.counter),
+      },
+      lamport: Number(operation.lamport),
+    },
+    ...(value.signer?.publicKey
+      ? { signer: { publicKey: Uint8Array.from(value.signer.publicKey) } }
+      : {}),
+  };
+}
+
 export function decodeSqliteMaterializationOutcome(raw: unknown): MaterializationOutcome {
   const value = (raw ?? {}) as any;
   const rawChanges = Array.isArray(value.changes) ? value.changes : [];
   const changes = rawChanges.map((change: any) => {
     const kind = String(change.kind);
+    const source = decodeSqliteMaterializationSource(change.source);
     if (kind === 'insert') {
       return {
         kind,
         node: decodeNodeId(change.node),
         parentAfter: decodeNodeId(change.parentAfter),
         payload: decodeSqlitePayload(change.payload),
+        ...(source ? { source } : {}),
       };
     }
     if (kind === 'move') {
@@ -741,6 +767,7 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         node: decodeNodeId(change.node),
         parentBefore: change.parentBefore == null ? null : decodeNodeId(change.parentBefore),
         parentAfter: decodeNodeId(change.parentAfter),
+        ...(source ? { source } : {}),
       };
     }
     if (kind === 'delete') {
@@ -748,6 +775,7 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         kind,
         node: decodeNodeId(change.node),
         parentBefore: change.parentBefore == null ? null : decodeNodeId(change.parentBefore),
+        ...(source ? { source } : {}),
       };
     }
     if (kind === 'restore') {
@@ -756,6 +784,7 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         node: decodeNodeId(change.node),
         parentAfter: change.parentAfter == null ? null : decodeNodeId(change.parentAfter),
         payload: decodeSqlitePayload(change.payload),
+        ...(source ? { source } : {}),
       };
     }
     if (kind === 'payload') {
@@ -763,6 +792,7 @@ export function decodeSqliteMaterializationOutcome(raw: unknown): Materializatio
         kind,
         node: decodeNodeId(change.node),
         payload: decodeSqlitePayload(change.payload),
+        ...(source ? { source } : {}),
       };
     }
     throw new Error(`unknown materialization change kind: ${kind}`);


### PR DESCRIPTION
## Summary
- add optional source metadata to each materialization change
- expose the causative operation as `source.operation.id.{replica,counter}` plus `source.operation.lamport`
- preserve source through core coalescing and the SQLite/wa-sqlite and Postgres adapters
- extend conformance coverage so local materialization events expose the operation that caused the visible change

Before:
```ts
{
  headSeq: 42,
  changes: [
    {
      kind: 'payload',
      node: '...',
      payload: new Uint8Array([...]),
    },
  ],
}
```

After:
```ts
{
  headSeq: 42,
  changes: [
    {
      kind: 'payload',
      node: '...',
      payload: new Uint8Array([...]),
      source: {
        operation: {
          id: {
            replica: new Uint8Array([...]),
            counter: 7,
          },
          lamport: 123,
        },
      },
    },
  ],
}
```

## Notes
- `source.operation.id.replica` is a low-level CRDT replica id, not auth/user identity
- `source.signer.publicKey` is reserved in the TypeScript shape for a later auth-aware follow-up
- source is optional because conservative catch-up can derive visible changes from rebuilt state instead of one exact operation
- this gives apps enough metadata to maintain local projections such as lastUpdated or updatedBy without putting that bookkeeping into payload bytes