### PR TITLE
feat(materialization): expose committed local signer

### DIFF
--- a/.changeset/local-auth-signer.md
+++ b/.changeset/local-auth-signer.md
@@ -1,0 +1,6 @@
+---
+'@treecrdt/interface': minor
+'@treecrdt/wa-sqlite': minor
+---
+
+Expose the verified signer of authenticated local writes on their materialization changes.

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -8,6 +8,12 @@ import {
   treecrdtEngineConformanceScenarios,
 } from '@treecrdt/engine-conformance';
 import {
+  getEd25519PublicKey,
+  issueTreecrdtCapabilityTokenV1,
+  randomEd25519SecretKey,
+} from '@treecrdt/auth';
+import type { MaterializationEvent } from '@treecrdt/interface/engine';
+import {
   createTreecrdtClient,
   defaultExtensionPath,
   loadTreecrdtExtension,
@@ -70,28 +76,57 @@ test('sqlite auth-aware local write rolls back on auth failure', async () => {
   }
 });
 
-test('sqlite auth-aware local write emits materialization after auth succeeds', async () => {
-  const client = await createNodeEngine({ docId: 'sqlite-auth-local-success' });
-  const events: unknown[] = [];
+test('sqlite materialization exposes the committed signer only for authenticated writes', async () => {
+  const docId = 'sqlite-auth-local-signer';
+  const client = await createNodeEngine({ docId });
+  const events: MaterializationEvent[] = [];
   const unsubscribe = client.onMaterialized((event) => events.push(event));
-  const authSession = {
-    authorizeLocalOps: vi.fn(async () => {
-      expect(events).toHaveLength(0);
-      return [validAuthProof()];
-    }),
-  };
-  const node = nodeIdFromInt(11);
+  const issuerPrivateKey = randomEd25519SecretKey();
+  const issuerPublicKey = await getEd25519PublicKey(issuerPrivateKey);
+  const signerPrivateKey = randomEd25519SecretKey();
+  const signerPublicKey = await getEd25519PublicKey(signerPrivateKey);
+  const authSession = client.auth.createSession({
+    trust: { issuerPublicKeys: [issuerPublicKey] },
+    local: {
+      privateKey: signerPrivateKey,
+      publicKey: signerPublicKey,
+      capabilityTokens: [
+        issueTreecrdtCapabilityTokenV1({
+          issuerPrivateKey,
+          subjectPublicKey: signerPublicKey,
+          docId,
+          actions: ['write_structure'],
+        }),
+      ],
+    },
+  });
+  await authSession.ready;
+  const unauthenticatedNode = nodeIdFromInt(11);
+  const authenticatedNode = nodeIdFromInt(12);
 
   try {
-    const op = await client.local.insert(replica, root, node, { type: 'last' }, null, {
-      authSession,
-    });
+    await client.local.insert(signerPublicKey, root, unauthenticatedNode, { type: 'last' }, null);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.changes[0]!.source?.signer).toBeUndefined();
+    events.length = 0;
+
+    const op = await client.local.insert(
+      signerPublicKey,
+      root,
+      authenticatedNode,
+      { type: 'last' },
+      null,
+      {
+        authSession,
+      },
+    );
 
     expect(op.kind.type).toBe('insert');
-    expect(authSession.authorizeLocalOps).toHaveBeenCalledTimes(1);
     expect(events).toHaveLength(1);
-    expect(await client.tree.exists(node)).toBe(true);
-    expect(await client.ops.all()).toHaveLength(1);
+    expect(events[0]!.changes[0]!.source?.operation?.id).toEqual(op.meta.id);
+    expect(events[0]!.changes[0]!.source?.signer?.publicKey).toEqual(op.meta.id.replica);
+    expect(await client.tree.exists(authenticatedNode)).toBe(true);
+    expect(await client.ops.all()).toHaveLength(2);
   } finally {
     unsubscribe();
     await client.close();
@@ -190,6 +225,8 @@ test('sqlite rejects authenticated prepare and commit inside caller transactions
 
 test('sqlite reauthorizes against fresh tree state after an optimistic conflict', async () => {
   const client = await createNodeEngine({ docId: 'sqlite-auth-local-stale-tree' });
+  const events: MaterializationEvent[] = [];
+  const unsubscribe = client.onMaterialized((event) => events.push(event));
   const otherReplica = Uint8Array.from(replica, (value, index) =>
     index === replica.length - 1 ? value + 1 : value,
   );
@@ -245,7 +282,14 @@ test('sqlite reauthorizes against fresh tree state after an optimistic conflict'
     expect(committed).toEqual(proposals[1].op);
     expect(await client.tree.parent(node)).toBe(destination);
     expect(await client.ops.all()).toHaveLength(6);
+    const signedChanges = events
+      .flatMap((event) => event.changes)
+      .filter((change) => change.source?.signer);
+    expect(signedChanges).toHaveLength(1);
+    expect(signedChanges[0]!.source?.operation?.id).toEqual(committed.meta.id);
+    expect(signedChanges[0]!.source?.signer?.publicKey).toEqual(committed.meta.id.replica);
   } finally {
+    unsubscribe();
     await client.close();
   }
 });

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -17,7 +17,7 @@ export type MaterializationSource = {
   };
   /** Local write ids supplied to the append/local write API that produced this visible change. */
   writeIds?: string[];
-  /** Future auth metadata for the operation signer, when available. */
+  /** Verified public key for an authenticated operation, when available. */
   signer?: {
     publicKey: Uint8Array;
   };

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -141,6 +141,34 @@ function emitLocalOutcome(
   if (outcome.changes.length > 0) emit?.(addMaterializationWriteId(outcome, writeId));
 }
 
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  return left.length === right.length && left.every((byte, index) => byte === right[index]);
+}
+
+function annotateCommittedSigner(
+  outcome: MaterializationOutcome,
+  committedOp: Operation,
+): MaterializationOutcome {
+  const publicKey = replicaIdToBytes(committedOp.meta.id.replica);
+  const counter = committedOp.meta.id.counter;
+  return {
+    ...outcome,
+    changes: outcome.changes.map((change) => {
+      const sourceId = change.source?.operation?.id;
+      if (!sourceId || sourceId.counter !== counter || !equalBytes(sourceId.replica, publicKey)) {
+        return change;
+      }
+      return {
+        ...change,
+        source: {
+          ...change.source,
+          signer: { publicKey: Uint8Array.from(publicKey) },
+        },
+      };
+    }),
+  };
+}
+
 const ROOT_NODE_BYTES = nodeIdToBytes16(ROOT_NODE_ID_HEX);
 
 function buildAppendOp(
@@ -742,7 +770,11 @@ export function createTreecrdtSqliteWriter(
       if (committedRaw?.conflict === true) continue;
 
       const committed = decodeLocalOpResult(committedRaw, proofSql);
-      emitLocalOutcome(committed.outcome, opts.onMaterialized, writeOpts?.writeId);
+      emitLocalOutcome(
+        annotateCommittedSigner(committed.outcome, committed.op),
+        opts.onMaterialized,
+        writeOpts?.writeId,
+      );
       return committed.op;
     }
 


### PR DESCRIPTION
## Goal

Expose the verified signer public key on materialization changes produced by authenticated local SQLite writes.

Applications can attribute the committed change without re-reading the proof store or trusting metadata supplied separately by an auth session.

## What changes

- After the authenticated optimistic commit succeeds, derive the signer from `committedOp.meta.id.replica`.
- Annotate only outcome changes whose source operation exactly matches that committed operation.
- Snapshot the public-key bytes before emitting the event.
- Leave unauthenticated writes and replay-derived changes unannotated.
- On an optimistic conflict, expose only the fresh operation that actually commits.

## Clean-slate choice

There is no optional `authSession.signer`, signer decoder, savepoint bridge, alternate commit path, or compatibility fallback. The signer identity comes from the exact operation whose proof and operation committed atomically in #195.

Remote signer propagation remains separate because it must come from the proof accepted at the remote commit boundary.

## Fast paths

- Unauthenticated writes perform no signer lookup or annotation.
- Authenticated writes reuse the already-returned committed operation; there is no database read, proof-store query, transaction, or extra signature verification.
- Only the small committed materialization outcome is mapped.

## Size

4 files, **+100/-18** relative to #195. Production behavior is 34 changed lines, roughly half the stale draft's signer bridge; the remaining diff is focused coverage.

## Verification

- relevant TypeScript builds
- sqlite-node conformance under Node 20: 34/34
- focused coverage for real capability-backed auth, unauthenticated writes, denial/no event, and optimistic conflict retry
- Prettier and diff checks

## Stack

Rebuilt cleanly on #195.