### PR TITLE
fix(auth): bind defensive-delete state in op signatures

### DIFF
--- a/.changeset/auth-known-state-signatures.md
+++ b/.changeset/auth-known-state-signatures.md
@@ -1,0 +1,7 @@
+---
+'@treecrdt/auth': minor
+---
+
+Bind canonical defensive-delete `knownState` to one operation signature format. Require it on
+deletes, reject non-empty state on other operation kinds, and sign its explicit presence or absence
+on every operation.

--- a/docs/sync/v0/auth.md
+++ b/docs/sync/v0/auth.md
@@ -177,6 +177,7 @@ Ops are signed with the doc-scoped Ed25519 key. The signature covers:
 - `doc_id`
 - `op_id` (`replica_id` + `counter`)
 - `lamport`
+- explicit defensive-delete `known_state` presence and bytes
 - op kind + fields
 - payload bytes (ciphertext bytes if payloads are encrypted)
 
@@ -192,7 +193,8 @@ sig_input = concat(
   u64_be(counter),
   u64_be(lamport),
   u8(kind_tag),
-  kind_fields
+  kind_fields,
+  known_state
 )
 ```
 
@@ -212,6 +214,29 @@ Kind tags and fields:
   - node(16)
   - value_tag(u8): 0=clear, 1=payload
   - if value_tag=1: u32_be(len(payload)) || payload_bytes
+
+Every operation uses this one signature format. `known_state` is encoded after the operation fields:
+
+```
+known_state = absent:  u8(0)
+              present: u8(1) || u32_be(len(bytes)) || bytes
+```
+
+The present form must contain the canonical UTF-8 JSON version-vector encoding used by the
+auth-enabled persistent backends: `{"entries":[...]}` without whitespace, with entries sorted
+lexicographically by replica bytes and each entry encoded as
+`{"replica":[...],"frontier":n,"ranges":[[start,end],...]}`. Signers and verifiers reject other
+spellings so persistence cannot change signed bytes.
+
+The v0 cross-language counter limit is `Number.MAX_SAFE_INTEGER` (`9007199254740991`). Frontiers
+and range bounds MUST be integers at or below that limit; range bounds MUST be positive. Ranges
+MUST be normalized exactly as the Rust version vector stores them: each `start <= end`, starts are
+strictly ordered, ranges neither overlap nor touch, and every start is greater than `frontier + 1`.
+
+Policy APIs require non-empty `known_state` on deletes and reject non-empty state on every other
+operation; tombstones use the explicit absent-state form. Because every operation signs the
+presence tag, a relay cannot strip delete state to bypass this policy. Applications use
+`signTreecrdtOp` and `verifyTreecrdtOp`, which enforce these invariants.
 
 ## Subtree scope enforcement and `pending_context`
 

--- a/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
+++ b/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
@@ -45,7 +45,7 @@ import {
   type CapabilityGrant,
   type TreecrdtCapabilityRevocationCheckContext,
 } from './capability.js';
-import { signTreecrdtOpV1, verifyTreecrdtOpV1 } from './op-sig.js';
+import { signTreecrdtOp, verifyTreecrdtOp } from './op-sig.js';
 import { getField } from './claims.js';
 import {
   capAllowsNode,
@@ -650,7 +650,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
           });
           proofRef = selected.tokenId;
         }
-        const sig = await signTreecrdtOpV1({
+        const sig = await signTreecrdtOp({
           docId: ctx.docId,
           op,
           privateKey: opts.localPrivateKey,
@@ -755,7 +755,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
         });
         if (scopeRes === 'deny') throw new Error('capability does not allow op');
 
-        const ok = await verifyTreecrdtOpV1({
+        const ok = await verifyTreecrdtOp({
           docId: ctx.docId,
           op,
           signature: a.sig,

--- a/packages/treecrdt-auth/src/internal/op-sig.ts
+++ b/packages/treecrdt-auth/src/internal/op-sig.ts
@@ -6,9 +6,9 @@ import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import { signEd25519, verifyEd25519 } from '../ed25519.js';
 import { concatBytes, u32be, u64be, u8 } from './bytes.js';
 
-const OP_SIG_V1_DOMAIN = utf8ToBytes('treecrdt/op-sig/v1');
+const OP_SIG_DOMAIN = utf8ToBytes('treecrdt/op-sig/v1');
 
-export function encodeTreecrdtOpSigInputV1(opts: { docId: string; op: Operation }): Uint8Array {
+function encodeTreecrdtOpFields(opts: { docId: string; op: Operation }): Uint8Array {
   const docIdBytes = utf8ToBytes(opts.docId);
   const replicaBytes = replicaIdToBytes(opts.op.meta.id.replica);
 
@@ -80,8 +80,6 @@ export function encodeTreecrdtOpSigInputV1(opts: { docId: string; op: Operation 
   }
 
   return concatBytes(
-    OP_SIG_V1_DOMAIN,
-    u8(0),
     u32be(docIdBytes.length),
     docIdBytes,
     u32be(replicaBytes.length),
@@ -93,21 +91,122 @@ export function encodeTreecrdtOpSigInputV1(opts: { docId: string; op: Operation 
   );
 }
 
-export async function signTreecrdtOpV1(opts: {
+function encodeKnownState(op: Operation): Uint8Array {
+  const knownState = op.meta.knownState;
+  return knownState === undefined || knownState.length === 0
+    ? u8(0)
+    : concatBytes(u8(1), u32be(knownState.length), assertCanonicalKnownState(knownState));
+}
+
+function invalidKnownState(): never {
+  throw new Error(
+    'knownState must use canonical TreeCRDT v0 version-vector JSON with counters within Number.MAX_SAFE_INTEGER',
+  );
+}
+
+function isV0VersionVectorCounter(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function assertCanonicalKnownState(bytes: Uint8Array): Uint8Array {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  } catch {
+    return invalidKnownState();
+  }
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.entries)) {
+    return invalidKnownState();
+  }
+
+  const replicas = new Set<string>();
+  const entries = parsed.entries.map((entry: any) => {
+    if (
+      !entry ||
+      typeof entry !== 'object' ||
+      !Array.isArray(entry.replica) ||
+      !entry.replica.every(
+        (byte: unknown) =>
+          typeof byte === 'number' && Number.isInteger(byte) && byte >= 0 && byte <= 255,
+      ) ||
+      !isV0VersionVectorCounter(entry.frontier) ||
+      !Array.isArray(entry.ranges)
+    ) {
+      return invalidKnownState();
+    }
+
+    // Rust keeps ranges normalized: positive inclusive bounds, separated by at least one
+    // missing counter, and strictly beyond the contiguous frontier.
+    let previousEnd = entry.frontier;
+    for (const range of entry.ranges) {
+      if (
+        !Array.isArray(range) ||
+        range.length !== 2 ||
+        !isV0VersionVectorCounter(range[0]) ||
+        !isV0VersionVectorCounter(range[1]) ||
+        range[0] === 0 ||
+        range[0] > range[1] ||
+        range[0] - previousEnd <= 1
+      ) {
+        return invalidKnownState();
+      }
+      previousEnd = range[1];
+    }
+
+    const replicaKey = entry.replica.join(',');
+    if (replicas.has(replicaKey)) return invalidKnownState();
+    replicas.add(replicaKey);
+    return {
+      replica: entry.replica,
+      frontier: entry.frontier,
+      ranges: entry.ranges,
+    };
+  });
+  entries.sort((a: any, b: any) => {
+    const length = Math.min(a.replica.length, b.replica.length);
+    for (let i = 0; i < length; i += 1) {
+      if (a.replica[i] !== b.replica[i]) return a.replica[i] - b.replica[i];
+    }
+    return a.replica.length - b.replica.length;
+  });
+
+  const canonical = utf8ToBytes(JSON.stringify({ entries }));
+  if (canonical.length !== bytes.length || canonical.some((byte, index) => byte !== bytes[index])) {
+    return invalidKnownState();
+  }
+  return bytes;
+}
+
+function assertPolicyOperation(op: Operation): void {
+  const hasKnownState = op.meta.knownState !== undefined && op.meta.knownState.length > 0;
+  if (op.kind.type === 'delete' && !hasKnownState) {
+    throw new Error('delete operations require non-empty knownState');
+  }
+  if (op.kind.type !== 'delete' && hasKnownState) {
+    throw new Error('knownState is only allowed on delete operations');
+  }
+}
+
+export function encodeTreecrdtOpSigInput(opts: { docId: string; op: Operation }): Uint8Array {
+  assertPolicyOperation(opts.op);
+  return concatBytes(OP_SIG_DOMAIN, u8(0), encodeTreecrdtOpFields(opts), encodeKnownState(opts.op));
+}
+
+export async function signTreecrdtOp(opts: {
   docId: string;
   op: Operation;
   privateKey: Uint8Array;
 }): Promise<Uint8Array> {
-  const msg = encodeTreecrdtOpSigInputV1({ docId: opts.docId, op: opts.op });
+  const msg = encodeTreecrdtOpSigInput({ docId: opts.docId, op: opts.op });
   return signEd25519(msg, opts.privateKey);
 }
 
-export async function verifyTreecrdtOpV1(opts: {
+export async function verifyTreecrdtOp(opts: {
   docId: string;
   op: Operation;
   signature: Uint8Array;
   publicKey: Uint8Array;
 }): Promise<boolean> {
-  const msg = encodeTreecrdtOpSigInputV1({ docId: opts.docId, op: opts.op });
+  const msg = encodeTreecrdtOpSigInput({ docId: opts.docId, op: opts.op });
   return await verifyEd25519(opts.signature, msg, opts.publicKey);
 }

--- a/packages/treecrdt-auth/src/treecrdt-auth.ts
+++ b/packages/treecrdt-auth/src/treecrdt-auth.ts
@@ -11,11 +11,7 @@ export type {
   TreecrdtCapabilityRevocationOptions,
 } from './internal/capability.js';
 
-export {
-  encodeTreecrdtOpSigInputV1,
-  signTreecrdtOpV1,
-  verifyTreecrdtOpV1,
-} from './internal/op-sig.js';
+export { encodeTreecrdtOpSigInput, signTreecrdtOp, verifyTreecrdtOp } from './internal/op-sig.js';
 
 export type { TreecrdtScopeEvaluator } from './internal/scope.js';
 

--- a/packages/treecrdt-auth/tests/auth.test.ts
+++ b/packages/treecrdt-auth/tests/auth.test.ts
@@ -307,10 +307,18 @@ test('auth: signOps selects proof_ref per op when multiple tokens exist', async 
     node: nodeIdFromInt(1),
     orderKey: orderKeyFromPosition(0),
   });
-  const opDelete = makeOp(aPk, 2, 2, {
-    type: 'delete',
-    node: nodeIdFromInt(1),
-  });
+  const knownState = (frontier: number) =>
+    new TextEncoder().encode(
+      JSON.stringify({ entries: [{ replica: Array.from(aPk), frontier, ranges: [] }] }),
+    );
+  const opDelete: Operation = {
+    meta: {
+      id: { replica: aPk, counter: 2 },
+      lamport: 2,
+      knownState: knownState(1),
+    },
+    kind: { type: 'delete', node: nodeIdFromInt(1) },
+  };
 
   const ops = [opInsert, opDelete];
   const ctx = { docId, purpose: 'reconcile' as const, filterId: 'all' };
@@ -328,6 +336,23 @@ test('auth: signOps selects proof_ref per op when multiple tokens exist', async 
   expect(bytesToHex(auth?.[1]!.proofRef!)).toBe(bytesToHex(tokenDeleteId));
 
   await authB.verifyOps?.(ops, auth, ctx);
+
+  const changedState: Operation = {
+    ...opDelete,
+    meta: { ...opDelete.meta, knownState: knownState(2) },
+  };
+  await expect(authB.verifyOps?.([changedState], [auth![1]!], ctx)).rejects.toThrow(
+    /invalid op signature/i,
+  );
+
+  const strippedState: Operation = {
+    ...opDelete,
+    meta: { id: opDelete.meta.id, lamport: opDelete.meta.lamport },
+  };
+  await expect(authA.signOps?.([strippedState], ctx)).rejects.toThrow(/require.*knownState/i);
+  await expect(authB.verifyOps?.([strippedState], [auth![1]!], ctx)).rejects.toThrow(
+    /require.*knownState/i,
+  );
 
   const badAuth = [{ ...auth?.[0]!, proofRef: tokenDeleteId }, auth?.[1]!];
   await expect(authB.verifyOps?.(ops, badAuth, ctx)).rejects.toThrow(

--- a/packages/treecrdt-auth/tests/op-sig.test.ts
+++ b/packages/treecrdt-auth/tests/op-sig.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from 'vitest';
+import { hashes as ed25519Hashes, getPublicKey, utils as ed25519Utils } from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+
+import type { Operation } from '@treecrdt/interface';
+import {
+  encodeTreecrdtOpSigInput,
+  signTreecrdtOp,
+  verifyTreecrdtOp,
+} from '../dist/treecrdt-auth.js';
+
+ed25519Hashes.sha512 = sha512;
+
+const node = '00112233445566778899aabbccddeeff';
+const meta = {
+  id: { replica: new Uint8Array(32), counter: 1 },
+  lamport: 1,
+};
+
+function operation(kind: Operation['kind'], state?: Uint8Array): Operation {
+  return { meta: { ...meta, ...(state ? { knownState: state } : {}) }, kind };
+}
+
+function knownState(frontier = 0, ranges: Array<[number, number]> = []): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify({ entries: [{ replica: [1], frontier, ranges }] }),
+  );
+}
+
+test('one signature format binds the explicit knownState field', async () => {
+  const privateKey = ed25519Utils.randomSecretKey();
+  const publicKey = await getPublicKey(privateKey);
+  const state = knownState();
+  const op = operation({ type: 'delete', node }, state);
+
+  const input = encodeTreecrdtOpSigInput({ docId: 'doc', op });
+  const domain = new TextEncoder().encode('treecrdt/op-sig/v1');
+  expect(input.slice(0, domain.length + 1)).toEqual(Uint8Array.from([...domain, 0]));
+  expect(input.slice(-(state.length + 5), -state.length)).toEqual(
+    Uint8Array.from([1, 0, 0, 0, state.length]),
+  );
+  expect(input.slice(-state.length)).toEqual(state);
+
+  const signature = await signTreecrdtOp({ docId: 'doc', op, privateKey });
+  await expect(verifyTreecrdtOp({ docId: 'doc', op, signature, publicKey })).resolves.toBe(true);
+  await expect(
+    verifyTreecrdtOp({
+      docId: 'doc',
+      op: { ...op, meta: { ...op.meta, knownState: knownState(1) } },
+      signature,
+      publicKey,
+    }),
+  ).resolves.toBe(false);
+  await expect(
+    verifyTreecrdtOp({
+      docId: 'doc',
+      op: operation(op.kind),
+      signature,
+      publicKey,
+    }),
+  ).rejects.toThrow(/require.*knownState/i);
+
+  expect(() =>
+    encodeTreecrdtOpSigInput({
+      docId: 'doc',
+      op: operation({ type: 'delete', node }, new TextEncoder().encode('{ "entries": [] }')),
+    }),
+  ).toThrow(/canonical/i);
+});
+
+test('canonical knownState accepts normalized gapped ranges', () => {
+  const state = knownState(2, [
+    [4, 5],
+    [7, 7],
+  ]);
+
+  expect(() =>
+    encodeTreecrdtOpSigInput({
+      docId: 'doc',
+      op: operation({ type: 'delete', node }, state),
+    }),
+  ).not.toThrow();
+});
+
+test.each<[string, number, Array<[number, number]>]>([
+  ['zero bounds', 0, [[0, 1]]],
+  ['reversed ranges', 0, [[3, 2]]],
+  ['frontier overlap', 2, [[2, 4]]],
+  ['frontier adjacency', 2, [[3, 4]]],
+  [
+    'unsorted ranges',
+    0,
+    [
+      [5, 6],
+      [3, 3],
+    ],
+  ],
+  [
+    'overlapping ranges',
+    0,
+    [
+      [3, 5],
+      [5, 7],
+    ],
+  ],
+  [
+    'adjacent ranges',
+    0,
+    [
+      [3, 4],
+      [5, 6],
+    ],
+  ],
+  ['unsafe counters', Number.MAX_SAFE_INTEGER + 1, []],
+])('canonical knownState rejects %s', (_name, frontier, ranges) => {
+  expect(() =>
+    encodeTreecrdtOpSigInput({
+      docId: 'doc',
+      op: operation({ type: 'delete', node }, knownState(frontier, ranges)),
+    }),
+  ).toThrow(/Number\.MAX_SAFE_INTEGER/);
+});
+
+test('signature policy only allows knownState on deletes', async () => {
+  const privateKey = ed25519Utils.randomSecretKey();
+  const publicKey = await getPublicKey(privateKey);
+  const state = knownState();
+  const nonDeleteKinds: Operation['kind'][] = [
+    {
+      type: 'insert',
+      parent: '00000000000000000000000000000000',
+      node,
+      orderKey: new Uint8Array([1]),
+    },
+    {
+      type: 'move',
+      node,
+      newParent: '00000000000000000000000000000000',
+      orderKey: new Uint8Array([1]),
+    },
+    { type: 'payload', node, payload: null },
+    { type: 'tombstone', node },
+  ];
+
+  for (const kind of nonDeleteKinds) {
+    await expect(
+      signTreecrdtOp({ docId: 'doc', op: operation(kind, state), privateKey }),
+    ).rejects.toThrow(/only allowed on delete/i);
+  }
+
+  const tombstone = operation({ type: 'tombstone', node });
+  expect(encodeTreecrdtOpSigInput({ docId: 'doc', op: tombstone }).at(-1)).toBe(0);
+  const signature = await signTreecrdtOp({ docId: 'doc', op: tombstone, privateKey });
+  await expect(
+    verifyTreecrdtOp({ docId: 'doc', op: tombstone, signature, publicKey }),
+  ).resolves.toBe(true);
+});


### PR DESCRIPTION
## Problem

Defensive deletes use `meta.knownState` to decide which unseen descendant changes restore a subtree. The old signature input omitted those bytes, so a relay could change or remove causal state without invalidating the signature.

## Fix

- Define one operation-signature format under `treecrdt/op-sig/v1` for every operation kind.
- Sign an explicit absent/present tag plus the exact `knownState` bytes.
- Require non-empty canonical state on deletes and reject non-empty state on every other operation.
- Validate the normalized Rust version-vector range invariants and the v0 `Number.MAX_SAFE_INTEGER` counter limit.
- Expose only the generic encode/sign/verify API.

## Clean-slate choice

There is no v1/v2 dispatch, legacy verifier, deprecated helper, downgrade path, or migration vector. Development operations/proofs produced by the old unsigned-state format must be recreated.

## Fast paths

- Operations without state append only the one-byte absent tag.
- JSON parsing and range validation run only for defensive deletes.
- Signing and verification use one domain and one code path.

## Verification

- Auth TypeScript build passes.
- Auth Vitest passes.
- Coverage includes byte mutation/removal, malformed and non-normalized ranges, gapped vectors, policy rejection, and authenticated sync.

## Stack

Based directly on main; #200 is no longer a dependency.
