### PR TITLE
bench(wa-sqlite): measure scheduler contention

### DIFF
--- a/.changeset/shared-worker-priority-scheduler.md
+++ b/.changeset/shared-worker-priority-scheduler.md
@@ -1,0 +1,8 @@
+---
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+'@treecrdt/sync-sqlite': patch
+---
+
+Let worker-backed clients prioritize reads between background sync append batches while preserving
+normal call ordering and bounding foreground starvation.

--- a/packages/sync-protocol/material/sqlite/src/backend.ts
+++ b/packages/sync-protocol/material/sqlite/src/backend.ts
@@ -1,5 +1,6 @@
 import type { Operation } from '@treecrdt/interface';
 import { bytesToHex, hexToBytes } from '@treecrdt/interface/ids';
+import type { WriteOptions } from '@treecrdt/interface/engine';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import { deriveOpRefV0 } from '@treecrdt/sync-protocol';
 import type { Filter, OpRef, SyncBackend } from '@treecrdt/sync-protocol';
@@ -18,7 +19,7 @@ export type TreecrdtSyncBackendClient = {
   ops: {
     all?: () => Promise<Operation[]>;
     get: (opRefs: OpRef[]) => Promise<Operation[]>;
-    appendMany: (ops: Operation[]) => Promise<unknown>;
+    appendMany: (ops: Operation[], opts?: WriteOptions) => Promise<unknown>;
   };
 };
 
@@ -169,7 +170,7 @@ export function createTreecrdtSyncBackendFromClient(
 
     applyOps: async (ops) => {
       if (ops.length === 0) return;
-      await client.ops.appendMany(ops);
+      await client.ops.appendMany(ops, { priority: 'background' });
     },
 
     ...(pending

--- a/packages/treecrdt-sync/tests/in-memory-sync.test.ts
+++ b/packages/treecrdt-sync/tests/in-memory-sync.test.ts
@@ -112,9 +112,11 @@ test('syncOnce defaults split inbound applies into modest batches', async () => 
   const { client: aClient, getOps: getAllA } = createInMemoryTestClient(docId, []);
   const { client: bClient } = createInMemoryTestClient(docId, remoteOps);
   const appendBatchSizes: number[] = [];
+  const appendPriorities: Array<string | undefined> = [];
   const appendMany = aClient.ops.appendMany.bind(aClient.ops);
   aClient.ops.appendMany = async (ops, writeOpts) => {
     appendBatchSizes.push(ops.length);
+    appendPriorities.push(writeOpts?.priority);
     return appendMany(ops, writeOpts);
   };
 
@@ -142,6 +144,7 @@ test('syncOnce defaults split inbound applies into modest batches', async () => 
   expect(appendBatchSizes.length).toBeGreaterThan(1);
   expect(Math.max(...appendBatchSizes)).toBeLessThanOrEqual(DEFAULT_MAX_OPS_PER_BATCH);
   expect(appendBatchSizes.reduce((sum, size) => sum + size, 0)).toBe(totalOps);
+  expect(new Set(appendPriorities)).toEqual(new Set(['background']));
 });
 
 test('syncOnce pulls insert, move, payload, and delete operations', async () => {

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -126,6 +126,11 @@ export function addMaterializationWriteId(
 
 export type WriteOptions = {
   writeId?: string;
+  /**
+   * Scheduling hint for runtimes that serialize requests through a worker.
+   * Background writes may yield to foreground operations.
+   */
+  priority?: 'foreground' | 'background';
 };
 
 export type LocalWriteAuthSession = {

--- a/packages/treecrdt-wa-sqlite/e2e/main.tsx
+++ b/packages/treecrdt-wa-sqlite/e2e/main.tsx
@@ -7,6 +7,7 @@ import './src/closed-client';
 import './src/drop-opfs';
 import './src/lifecycle';
 import './src/responsiveness';
+import './src/runtime-bench';
 import './src/sync';
 
 const container = document.getElementById('root');

--- a/packages/treecrdt-wa-sqlite/e2e/package.json
+++ b/packages/treecrdt-wa-sqlite/e2e/package.json
@@ -12,7 +12,7 @@
     "preview:path": "vite preview --host --port 4172 --base /base-path/ --strictPort",
     "dev": "vite",
     "test:e2e": "pnpm -C ../../treecrdt-benchmark run build && pnpm -C ../../sync-protocol/protocol run build && pnpm -C ../../sync-protocol/material/sqlite run build && pnpm -C ../../treecrdt-engine-conformance run build && pnpm run build:wa-sqlite && playwright test",
-    "bench": "pnpm -C ../../treecrdt-benchmark run build && pnpm run build && playwright test tests/bench-opfs.spec.ts tests/bench-sync.spec.ts --reporter=line"
+    "bench": "pnpm -C ../../treecrdt-benchmark run build && pnpm run build && playwright test tests/bench-opfs.spec.ts tests/bench-sync.spec.ts tests/bench-runtime.spec.ts --reporter=line"
   },
   "dependencies": {
     "@treecrdt/benchmark": "workspace:*",

--- a/packages/treecrdt-wa-sqlite/e2e/src/runtime-bench.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/runtime-bench.ts
@@ -1,0 +1,311 @@
+import { createTreecrdtClient } from '@treecrdt/wa-sqlite';
+import { makeOp, nodeIdFromInt, quantile, type BenchmarkResult } from '@treecrdt/benchmark';
+import type { Operation } from '@treecrdt/interface';
+import { replicaFromLabel } from './op-helpers.js';
+
+type RuntimeChoice = 'direct' | 'dedicated-worker' | 'shared-worker';
+type StorageChoice = 'memory' | 'opfs';
+type RemoteIngestPriority = 'normal' | 'background';
+
+type RuntimeMixedWriteBenchOptions = {
+  runtime: RuntimeChoice;
+  storage?: StorageChoice;
+  docId?: string;
+  filename?: string;
+  prefillOps?: number;
+  remoteOps?: number;
+  remoteBatchSize?: number;
+  remoteIngestPriority?: RemoteIngestPriority;
+  localWrites?: number;
+  readSamples?: number;
+  readIntervalMs?: number;
+  localWriteIntervalMs?: number;
+  yieldBetweenRemoteBatchesMs?: number;
+};
+
+type RuntimeMixedWriteBenchResult = BenchmarkResult & {
+  extra: {
+    runtime: RuntimeChoice;
+    storage: StorageChoice;
+    prefillOps: number;
+    remoteOps: number;
+    remoteBatchSize: number;
+    remoteBatchCount: number;
+    remoteIngestPriority: RemoteIngestPriority;
+    remoteBatchDurationsMs: number[];
+    remoteBatchMinMs: number;
+    remoteBatchP50Ms: number;
+    remoteBatchP95Ms: number;
+    remoteBatchMaxMs: number;
+    localWrites: number;
+    localWriteDurationsMs: number[];
+    localWriteMinMs: number;
+    localWriteP50Ms: number;
+    localWriteP95Ms: number;
+    localWriteMaxMs: number;
+    readSamples: number;
+    readDurationsMs: number[];
+    readMinMs: number;
+    readP50Ms: number;
+    readP95Ms: number;
+    readMaxMs: number;
+    localWriteIntervalMs: number;
+    readIntervalMs: number;
+    yieldBetweenRemoteBatchesMs: number;
+    expectedChildCount: number;
+    finalChildCount: number;
+  };
+};
+
+const ROOT_NODE = '0'.repeat(32);
+
+function orderKeyFromOffset(offset: number): Uint8Array {
+  const bytes = new Uint8Array(4);
+  new DataView(bytes.buffer).setUint32(0, offset + 1, false);
+  return bytes;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function sampleBatchIndex(sample: number, sampleCount: number, batchCount: number): number {
+  if (sampleCount <= 1 || batchCount <= 1) return 0;
+  return Math.round((sample * (batchCount - 1)) / (sampleCount - 1));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function summarizeDurations(durationsMs: number[]) {
+  if (durationsMs.length === 0) {
+    return {
+      minMs: 0,
+      p50Ms: 0,
+      p95Ms: 0,
+      maxMs: 0,
+    };
+  }
+  return {
+    minMs: Math.min(...durationsMs),
+    p50Ms: quantile(durationsMs, 0.5),
+    p95Ms: quantile(durationsMs, 0.95),
+    maxMs: Math.max(...durationsMs),
+  };
+}
+
+function makeInsertOps(opts: {
+  replica: Uint8Array;
+  count: number;
+  startCounter: number;
+  startLamport?: number;
+  startNodeInt: number;
+  startOrderOffset?: number;
+}): Operation[] {
+  return Array.from({ length: opts.count }, (_, offset) => {
+    const counter = opts.startCounter + offset;
+    const lamport = (opts.startLamport ?? opts.startCounter) + offset;
+    const orderOffset = (opts.startOrderOffset ?? opts.startNodeInt) + offset;
+    return makeOp(opts.replica, counter, lamport, {
+      type: 'insert',
+      parent: ROOT_NODE,
+      node: nodeIdFromInt(opts.startNodeInt + offset),
+      orderKey: orderKeyFromOffset(orderOffset),
+    });
+  });
+}
+
+export async function runRuntimeMixedWriteBench(
+  opts: RuntimeMixedWriteBenchOptions,
+): Promise<RuntimeMixedWriteBenchResult> {
+  const runtime = opts.runtime;
+  const storage = opts.storage ?? 'opfs';
+  const prefillOps = opts.prefillOps ?? 0;
+  const remoteOps = opts.remoteOps ?? 2_000;
+  const remoteBatchSize = opts.remoteBatchSize ?? 500;
+  const remoteIngestPriority = opts.remoteIngestPriority ?? 'background';
+  const localWrites = opts.localWrites ?? 20;
+  const readSamples = opts.readSamples ?? 20;
+  const readIntervalMs = opts.readIntervalMs ?? 0;
+  const localWriteIntervalMs = opts.localWriteIntervalMs ?? 5;
+  const yieldBetweenRemoteBatchesMs = opts.yieldBetweenRemoteBatchesMs ?? 1;
+  const remoteBatchCount = Math.ceil(remoteOps / remoteBatchSize);
+  const docId = opts.docId ?? `runtime-mixed-${storage}-${runtime}-${crypto.randomUUID()}`;
+  const filename =
+    opts.filename ?? `/runtime-mixed-${storage}-${runtime}-${crypto.randomUUID()}.db`;
+  const remoteReplica = replicaFromLabel(`runtime-remote-${storage}-${runtime}`);
+  const localReplica = replicaFromLabel(`runtime-local-${storage}-${runtime}`);
+  const expectedChildCount = prefillOps + remoteOps + localWrites;
+  const client = await createTreecrdtClient({
+    docId,
+    storage:
+      storage === 'opfs' ? { type: 'opfs', filename, fallback: 'throw' } : { type: 'memory' },
+    runtime: { type: runtime },
+  });
+
+  try {
+    if (prefillOps > 0) {
+      try {
+        await client.ops.appendMany(
+          makeInsertOps({
+            replica: replicaFromLabel(`runtime-prefill-${storage}-${runtime}`),
+            count: prefillOps,
+            startCounter: 1,
+            startNodeInt: 1,
+            startOrderOffset: 1,
+          }),
+        );
+      } catch (error) {
+        throw new Error(`runtime mixed benchmark prefill failed: ${errorMessage(error)}`);
+      }
+    }
+
+    const remoteBatchDurationsMs: number[] = [];
+    const localWriteDurationsMs: number[] = [];
+    const readDurationsMs: number[] = [];
+    const batchStarted = Array.from({ length: remoteBatchCount }, deferred);
+    let finalChildCount = 0;
+    const start = performance.now();
+
+    const runRemoteIngest = async () => {
+      for (let batchIndex = 0; batchIndex < remoteBatchCount; batchIndex += 1) {
+        const batchStartCounter = batchIndex * remoteBatchSize + 1;
+        const remaining = remoteOps - batchIndex * remoteBatchSize;
+        const batchOps = Math.min(remoteBatchSize, remaining);
+        const batch = makeInsertOps({
+          replica: remoteReplica,
+          count: batchOps,
+          startCounter: batchStartCounter,
+          startLamport: prefillOps + batchStartCounter,
+          startNodeInt: 100_000 + batchIndex * remoteBatchSize,
+          startOrderOffset: 100_000 + batchIndex * remoteBatchSize,
+        });
+
+        // Release the samples assigned to this batch only after the remote write is about to be
+        // queued. This spreads foreground reads and local writes across the full ingest window.
+        batchStarted[batchIndex]!.resolve();
+        const batchStart = performance.now();
+        try {
+          await client.ops.appendMany(
+            batch,
+            remoteIngestPriority === 'background' ? { priority: 'background' } : undefined,
+          );
+        } catch (error) {
+          throw new Error(`runtime mixed benchmark remote ingest failed: ${errorMessage(error)}`);
+        }
+        remoteBatchDurationsMs.push(performance.now() - batchStart);
+
+        if (batchIndex < remoteBatchCount - 1 && yieldBetweenRemoteBatchesMs >= 0) {
+          await sleep(yieldBetweenRemoteBatchesMs);
+        }
+      }
+    };
+
+    const runLocalWrites = async () => {
+      for (let i = 0; i < localWrites; i += 1) {
+        await batchStarted[sampleBatchIndex(i, localWrites, remoteBatchCount)]!.promise;
+        if (i > 0 && localWriteIntervalMs > 0) await sleep(localWriteIntervalMs);
+        const writeStart = performance.now();
+        try {
+          await client.local.insert(
+            localReplica,
+            ROOT_NODE,
+            nodeIdFromInt(200_000 + i),
+            { type: 'last' },
+            null,
+          );
+        } catch (error) {
+          throw new Error(`runtime mixed benchmark local write failed: ${errorMessage(error)}`);
+        }
+        localWriteDurationsMs.push(performance.now() - writeStart);
+      }
+    };
+
+    const runReads = async () => {
+      for (let i = 0; i < readSamples; i += 1) {
+        await batchStarted[sampleBatchIndex(i, readSamples, remoteBatchCount)]!.promise;
+        if (i > 0 && readIntervalMs > 0) await sleep(readIntervalMs);
+        const readStart = performance.now();
+        try {
+          finalChildCount = (await client.tree.children(ROOT_NODE)).length;
+        } catch (error) {
+          throw new Error(`runtime mixed benchmark read sample failed: ${errorMessage(error)}`);
+        }
+        readDurationsMs.push(performance.now() - readStart);
+      }
+    };
+
+    await Promise.all([runRemoteIngest(), runLocalWrites(), runReads()]);
+    finalChildCount = (await client.tree.children(ROOT_NODE)).length;
+    if (finalChildCount !== expectedChildCount) {
+      throw new Error(
+        `runtime mixed benchmark child count mismatch: expected ${expectedChildCount}, got ${finalChildCount}`,
+      );
+    }
+
+    const durationMs = performance.now() - start;
+    const totalOps = remoteOps + localWrites;
+    const remoteBatchSummary = summarizeDurations(remoteBatchDurationsMs);
+    const localWriteSummary = summarizeDurations(localWriteDurationsMs);
+    const readSummary = summarizeDurations(readDurationsMs);
+
+    return {
+      name: `runtime-mixed-sync-ingest-local-writes-${storage}-${runtime}-${remoteIngestPriority}-prefill-${prefillOps}`,
+      totalOps,
+      durationMs,
+      opsPerSec: durationMs > 0 ? (totalOps / durationMs) * 1000 : Infinity,
+      extra: {
+        runtime,
+        storage,
+        prefillOps,
+        remoteOps,
+        remoteBatchSize,
+        remoteBatchCount,
+        remoteIngestPriority,
+        remoteBatchDurationsMs,
+        remoteBatchMinMs: remoteBatchSummary.minMs,
+        remoteBatchP50Ms: remoteBatchSummary.p50Ms,
+        remoteBatchP95Ms: remoteBatchSummary.p95Ms,
+        remoteBatchMaxMs: remoteBatchSummary.maxMs,
+        localWrites,
+        localWriteDurationsMs,
+        localWriteMinMs: localWriteSummary.minMs,
+        localWriteP50Ms: localWriteSummary.p50Ms,
+        localWriteP95Ms: localWriteSummary.p95Ms,
+        localWriteMaxMs: localWriteSummary.maxMs,
+        readSamples,
+        readDurationsMs,
+        readMinMs: readSummary.minMs,
+        readP50Ms: readSummary.p50Ms,
+        readP95Ms: readSummary.p95Ms,
+        readMaxMs: readSummary.maxMs,
+        localWriteIntervalMs,
+        readIntervalMs,
+        yieldBetweenRemoteBatchesMs,
+        expectedChildCount,
+        finalChildCount,
+      },
+    };
+  } finally {
+    await client.drop();
+  }
+}
+
+declare global {
+  interface Window {
+    __runTreecrdtRuntimeMixedWriteBench?: typeof runRuntimeMixedWriteBench;
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.__runTreecrdtRuntimeMixedWriteBench = runRuntimeMixedWriteBench;
+}

--- a/packages/treecrdt-wa-sqlite/e2e/tests/bench-runtime.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/bench-runtime.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+import { repoRootFromImportMeta, writeResult } from '@treecrdt/benchmark/node';
+import { envInt, envIntList } from '@treecrdt/benchmark';
+
+type RuntimeChoice = 'direct' | 'dedicated-worker' | 'shared-worker';
+type StorageChoice = 'memory' | 'opfs';
+type RemoteIngestPriority = 'normal' | 'background';
+type RuntimeScenario = {
+  id: string;
+  runtime: RuntimeChoice;
+  storage: StorageChoice;
+};
+
+const defaultScenarios: RuntimeScenario[] = [
+  { id: 'memory-direct', runtime: 'direct', storage: 'memory' },
+  { id: 'memory-worker', runtime: 'dedicated-worker', storage: 'memory' },
+  { id: 'opfs-worker', runtime: 'dedicated-worker', storage: 'opfs' },
+  { id: 'opfs-shared', runtime: 'shared-worker', storage: 'opfs' },
+];
+
+const remoteOps = envInt('TREECRDT_RUNTIME_BENCH_REMOTE_OPS') ?? 2_000;
+const remoteBatchSize = envInt('TREECRDT_RUNTIME_BENCH_REMOTE_BATCH_SIZE') ?? 500;
+const localWrites = envInt('TREECRDT_RUNTIME_BENCH_LOCAL_WRITES') ?? 20;
+const readSamples = envInt('TREECRDT_RUNTIME_BENCH_READ_SAMPLES') ?? 20;
+const readIntervalMs = envInt('TREECRDT_RUNTIME_BENCH_READ_INTERVAL_MS') ?? 0;
+const localWriteIntervalMs = envInt('TREECRDT_RUNTIME_BENCH_LOCAL_WRITE_INTERVAL_MS') ?? 5;
+const yieldBetweenRemoteBatchesMs = envInt('TREECRDT_RUNTIME_BENCH_REMOTE_BATCH_YIELD_MS') ?? 1;
+const defaultRemoteIngestPriorities: RemoteIngestPriority[] = ['normal', 'background'];
+
+function envChoiceList<T>(name: string, fallback: readonly T[], id: (choice: T) => string): T[] {
+  const raw = process.env[name];
+  if (!raw) return [...fallback];
+  const requested = raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (requested.length === 0) return [...fallback];
+  const choices = new Map(fallback.map((choice) => [id(choice), choice]));
+  return requested.map((value) => {
+    const choice = choices.get(value);
+    if (!choice) throw new Error(`Invalid ${name} value: ${value}`);
+    return choice;
+  });
+}
+
+const prefillSizes = envIntList('TREECRDT_RUNTIME_BENCH_PREFILL_OPS') ?? [0, 5_000];
+const trials = envInt('TREECRDT_RUNTIME_BENCH_TRIALS') ?? 4;
+const scenarios = envChoiceList(
+  'TREECRDT_RUNTIME_BENCH_SCENARIOS',
+  defaultScenarios,
+  (scenario) => scenario.id,
+);
+const remoteIngestPriorities = envChoiceList(
+  'TREECRDT_RUNTIME_BENCH_PRIORITIES',
+  defaultRemoteIngestPriorities,
+  (priority) => priority,
+);
+
+test.skip(!!process.env.CI, 'Raw browser benchmarks run in the benchmark workflow.');
+
+test('wa-sqlite runtime/storage mixed sync-ingest/local-write benchmarks', async ({ page }) => {
+  test.setTimeout(600_000);
+  page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));
+  await page.goto('/');
+  await page.waitForFunction(
+    () => typeof window.__runTreecrdtRuntimeMixedWriteBench === 'function',
+  );
+
+  const repoRoot = repoRootFromImportMeta(import.meta.url, 4);
+  const outDir = path.join(repoRoot, 'benchmarks', 'wa-sqlite-runtime');
+
+  for (const [scenarioIndex, scenario] of scenarios.entries()) {
+    for (const prefillOps of prefillSizes) {
+      for (let trial = 1; trial <= trials; trial += 1) {
+        const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+        const trialPriorities =
+          trial % 2 === 1 ? remoteIngestPriorities : [...remoteIngestPriorities].reverse();
+        for (const remoteIngestPriority of trialPriorities) {
+          const result = await page.evaluate(
+            async (opts) => {
+              const runner = window.__runTreecrdtRuntimeMixedWriteBench;
+              if (!runner) throw new Error('__runTreecrdtRuntimeMixedWriteBench not available');
+              return await runner(opts);
+            },
+            {
+              runtime: scenario.runtime,
+              storage: scenario.storage,
+              docId: `runtime-mixed-${scenario.id}-${remoteIngestPriority}-${prefillOps}-${suffix}`,
+              filename: `/rt-${scenarioIndex}-${prefillOps}-${trial}-${remoteIngestPriority[0]}-${suffix}.db`,
+              prefillOps,
+              remoteOps,
+              remoteBatchSize,
+              remoteIngestPriority,
+              localWrites,
+              readSamples,
+              readIntervalMs,
+              localWriteIntervalMs,
+              yieldBetweenRemoteBatchesMs,
+            },
+          );
+
+          expect(result.totalOps).toBe(remoteOps + localWrites);
+          expect(result.extra.runtime).toBe(scenario.runtime);
+          expect(result.extra.storage).toBe(scenario.storage);
+          expect(result.extra.remoteIngestPriority).toBe(remoteIngestPriority);
+          expect(result.extra.finalChildCount).toBe(prefillOps + remoteOps + localWrites);
+          expect(result.extra.remoteBatchDurationsMs.length).toBe(
+            Math.ceil(remoteOps / remoteBatchSize),
+          );
+          expect(result.extra.localWriteDurationsMs.length).toBe(localWrites);
+          expect(result.extra.readDurationsMs.length).toBe(readSamples);
+
+          const outFile = path.join(
+            outDir,
+            `${scenario.id}-${remoteIngestPriority}-prefill-${prefillOps}-trial-${trial}.json`,
+          );
+          const payload = await writeResult(result, {
+            implementation: 'wa-sqlite',
+            storage: `browser-${scenario.storage}-${scenario.runtime}`,
+            workload: `${result.name}-trial-${trial}`,
+            outFile,
+            extra: { trial },
+          });
+          console.log(JSON.stringify(payload));
+        }
+      }
+    }
+  }
+});

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -39,6 +39,7 @@ import {
   type RpcResponse,
   type RpcResult,
 } from './rpc.js';
+import { createRpcScheduler } from './rpc-scheduler.js';
 import { openTreecrdtDb, type OpenTreecrdtDbOptions, type OpenTreecrdtDbResult } from './open.js';
 import type {
   ClientMaterializationDispatcher,
@@ -52,6 +53,7 @@ import type {
   NormalizedRuntimeOptions,
   NormalizedStorageOptions,
   RpcCall,
+  RpcCallOptions,
   RuntimeMode,
   SharedWorkerFactory,
   StorageMode,
@@ -63,6 +65,28 @@ import type {
 export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
 // Keep long browser appendMany calls from monopolizing the worker queue.
 const APPEND_MANY_RPC_CHUNK_SIZE = 2500;
+
+function rpcRequest<M extends RpcMethod>(
+  id: number,
+  method: M,
+  params: RpcParams<M>,
+  options?: RpcCallOptions,
+): RpcRequest<M> {
+  return options?.priority
+    ? { id, method, params, priority: options.priority }
+    : { id, method, params };
+}
+
+function createPrioritizedRpcCall(runRaw: RpcCall): RpcCall {
+  const schedule = createRpcScheduler();
+
+  return <M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    options?: RpcCallOptions,
+  ): Promise<RpcResult<M>> =>
+    schedule(options?.priority ?? 'normal', () => runRaw(method, params, options));
+}
 
 function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
   const raw = opts.storage ?? { type: 'auto' };
@@ -324,29 +348,22 @@ async function createWorkerClient(opts: {
   >();
   let terminalError: Error | null = null;
   let closed = false;
-  let callQueue: Promise<void> = Promise.resolve();
 
   const closedError = new Error(CLIENT_CLOSED_ERROR);
-  const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
-    promise.then(
-      () => undefined,
-      () => undefined,
-    );
-
-  const callRaw = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+  const callRaw = <M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    options?: RpcCallOptions,
+  ): Promise<RpcResult<M>> => {
     if (closed) return Promise.reject(closedError);
     const id = nextId++;
     if (terminalError) return Promise.reject(terminalError);
     return new Promise((resolve, reject) => {
       pending.set(id, { resolve, reject });
-      worker.postMessage({ id, method, params } satisfies RpcRequest<M>);
+      worker.postMessage(rpcRequest(id, method, params, options));
     });
   };
-  const call = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
-    const run = callQueue.then(() => callRaw(method, params));
-    callQueue = settleQueue(run);
-    return run;
-  };
+  const call = createPrioritizedRpcCall(callRaw);
 
   const onMessage = (ev: MessageEvent<RpcResponse | RpcPushMessage>) => {
     const data = ev.data;
@@ -462,29 +479,22 @@ async function createSharedWorkerClient(opts: {
   >();
   let terminalError: Error | null = null;
   let closed = false;
-  let callQueue: Promise<void> = Promise.resolve();
 
   const closedError = new Error(CLIENT_CLOSED_ERROR);
-  const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
-    promise.then(
-      () => undefined,
-      () => undefined,
-    );
-
-  const callRaw = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
+  const callRaw = <M extends RpcMethod>(
+    method: M,
+    params: RpcParams<M>,
+    options?: RpcCallOptions,
+  ): Promise<RpcResult<M>> => {
     if (closed) return Promise.reject(closedError);
     const id = nextId++;
     if (terminalError) return Promise.reject(terminalError);
     return new Promise((resolve, reject) => {
       pending.set(id, { resolve, reject });
-      port.postMessage({ id, method, params } satisfies RpcRequest<M>);
+      port.postMessage(rpcRequest(id, method, params, options));
     });
   };
-  const call = <M extends RpcMethod>(method: M, params: RpcParams<M>): Promise<RpcResult<M>> => {
-    const run = callQueue.then(() => callRaw(method, params));
-    callQueue = settleQueue(run);
-    return run;
-  };
+  const call = createPrioritizedRpcCall(callRaw);
   const materialized = createClientMaterializationDispatcher({
     broadcast: (event) => {
       void call('broadcastMaterialized', [event]).catch(() => {
@@ -744,7 +754,7 @@ export async function buildDirectClient(
       throw wrapError(method, err);
     }
   };
-  const call: RpcCall = (method, params) => {
+  const call: RpcCall = (method, params, _options) => {
     const run = callQueue.then(() => runDirectCall(method, params));
     callQueue = settleQueue(run);
     return run;
@@ -806,18 +816,20 @@ function makeTreecrdtClientFromCall(opts: {
     localWriters.set(key, next);
     return next;
   };
+  const foregroundCall: RpcCall = (method, params) =>
+    call(method, params, { priority: 'foreground' });
 
   const opsSinceImpl = async (lamport: number, root?: string) => {
-    const rows = await call('opsSince', [lamport, root]);
+    const rows = await foregroundCall('opsSince', [lamport, root]);
     return decodeSqliteOps(rows);
   };
-  const opRefsAllImpl = async () => decodeSqliteOpRefs(await call('opRefsAll', []));
+  const opRefsAllImpl = async () => decodeSqliteOpRefs(await foregroundCall('opRefsAll', []));
   const opRefsChildrenImpl = async (parent: string) =>
-    decodeSqliteOpRefs(await call('opRefsChildren', [parent]));
+    decodeSqliteOpRefs(await foregroundCall('opRefsChildren', [parent]));
   const opsByOpRefsImpl = async (opRefs: Uint8Array[]) =>
-    decodeSqliteOps(await call('opsByOpRefs', [opRefs.map((r) => Array.from(r))]));
+    decodeSqliteOps(await foregroundCall('opsByOpRefs', [opRefs.map((r) => Array.from(r))]));
   const treeChildrenImpl = async (parent: string) =>
-    decodeSqliteNodeIds(await call('treeChildren', [parent]));
+    decodeSqliteNodeIds(await foregroundCall('treeChildren', [parent]));
   const treeChildrenPageImpl = async (
     parent: string,
     cursor: { orderKey: Uint8Array; node: Uint8Array } | null,
@@ -826,26 +838,30 @@ function makeTreecrdtClientFromCall(opts: {
     const rpcCursor = cursor
       ? { orderKey: Array.from(cursor.orderKey), node: Array.from(cursor.node) }
       : null;
-    return decodeSqliteTreeChildRows(await call('treeChildrenPage', [parent, rpcCursor, limit]));
+    return decodeSqliteTreeChildRows(
+      await foregroundCall('treeChildrenPage', [parent, rpcCursor, limit]),
+    );
   };
-  const treeDumpImpl = async () => decodeSqliteTreeRows(await call('treeDump', []));
-  const treeNodeCountImpl = async () => Number(await call('treeNodeCount', []));
+  const treeDumpImpl = async () => decodeSqliteTreeRows(await foregroundCall('treeDump', []));
+  const treeNodeCountImpl = async () => Number(await foregroundCall('treeNodeCount', []));
   const treeParentImpl = async (node: string) => {
-    const result = await call('treeParent', [node]);
+    const result = await foregroundCall('treeParent', [node]);
     if (result === null) return null;
     return nodeIdFromBytes16(toRpcBytes(result));
   };
-  const treeExistsImpl = async (node: string) => Boolean(await call('treeExists', [node]));
+  const treeExistsImpl = async (node: string) =>
+    Boolean(await foregroundCall('treeExists', [node]));
   const treeGetPayloadImpl = async (node: string) => {
-    const result = await call('treePayload', [node]);
+    const result = await foregroundCall('treePayload', [node]);
     return result === null ? null : toRpcBytes(result);
   };
-  const headLamportImpl = async () => Number(await call('headLamport', []));
+  const headLamportImpl = async () => Number(await foregroundCall('headLamport', []));
   const replicaMaxCounterImpl = async (replica: Operation['meta']['id']['replica']) =>
-    Number(await call('replicaMaxCounter', [Array.from(encodeReplica(replica))]));
+    Number(await foregroundCall('replicaMaxCounter', [Array.from(encodeReplica(replica))]));
   const appendManyImpl = async (operations: Operation[], writeOpts?: WriteOptions) => {
+    const callOptions = writeOpts?.priority ? { priority: writeOpts.priority } : undefined;
     if (operations.length <= APPEND_MANY_RPC_CHUNK_SIZE) {
-      const outcome = await call('appendMany', [operations]);
+      const outcome = await call('appendMany', [operations], callOptions);
       materialized.emitOutcome(outcome, writeOpts?.writeId);
       return;
     }
@@ -853,7 +869,11 @@ function makeTreecrdtClientFromCall(opts: {
     const outcomes: MaterializationOutcome[] = [];
     for (let start = 0; start < operations.length; start += APPEND_MANY_RPC_CHUNK_SIZE) {
       outcomes.push(
-        await call('appendMany', [operations.slice(start, start + APPEND_MANY_RPC_CHUNK_SIZE)]),
+        await call(
+          'appendMany',
+          [operations.slice(start, start + APPEND_MANY_RPC_CHUNK_SIZE)],
+          callOptions,
+        ),
       );
     }
     materialized.emitOutcome(mergeMaterializationOutcomes(outcomes), writeOpts?.writeId);
@@ -928,7 +948,8 @@ function makeTreecrdtClientFromCall(opts: {
     runner,
     ops: {
       append: async (op, writeOpts?: WriteOptions) => {
-        const outcome = await call('append', [op]);
+        const callOptions = writeOpts?.priority ? { priority: writeOpts.priority } : undefined;
+        const outcome = await call('append', [op], callOptions);
         materialized.emitOutcome(outcome, writeOpts?.writeId);
       },
       appendMany: appendManyImpl,

--- a/packages/treecrdt-wa-sqlite/src/rpc-scheduler.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc-scheduler.ts
@@ -1,0 +1,62 @@
+import type { RpcPriority } from './rpc.js';
+
+export type RpcSchedulePriority = RpcPriority | 'normal';
+
+type ScheduledJob = {
+  priority: RpcSchedulePriority;
+  run: () => Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+};
+
+// Bound foreground bypasses so a steady read stream cannot starve sync forever.
+const MAX_FOREGROUND_BURST = 8;
+
+/** Serializes RPC work while allowing reads to bypass only explicitly-background work. */
+export function createRpcScheduler() {
+  const queue: ScheduledJob[] = [];
+  let running = false;
+  let foregroundBurst = 0;
+
+  const nextJobIndex = (): number => {
+    // A normal call is an ordering barrier: a later read must not jump an earlier local write.
+    const normalBarrier = queue.findIndex((job) => job.priority === 'normal');
+    const foreground = queue.findIndex(
+      (job, index) =>
+        job.priority === 'foreground' && (normalBarrier === -1 || index < normalBarrier),
+    );
+    if (
+      foreground !== -1 &&
+      (foregroundBurst < MAX_FOREGROUND_BURST || queue[0]?.priority === 'foreground')
+    ) {
+      return foreground;
+    }
+    return 0;
+  };
+
+  const drain = () => {
+    if (running || queue.length === 0) return;
+    const [job] = queue.splice(nextJobIndex(), 1);
+    if (!job) return;
+    running = true;
+    foregroundBurst = job.priority === 'foreground' ? foregroundBurst + 1 : 0;
+    void Promise.resolve()
+      .then(job.run)
+      .then(job.resolve, job.reject)
+      .finally(() => {
+        running = false;
+        drain();
+      });
+  };
+
+  return <T>(priority: RpcSchedulePriority, run: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      queue.push({
+        priority,
+        run,
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      drain();
+    });
+}

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -51,11 +51,13 @@ export type RpcSchema = {
 export type RpcMethod = keyof RpcSchema;
 export type RpcParams<M extends RpcMethod> = RpcSchema[M]['params'];
 export type RpcResult<M extends RpcMethod> = RpcSchema[M]['result'];
+export type RpcPriority = 'foreground' | 'background';
 
 export type RpcRequest<M extends RpcMethod = RpcMethod> = {
   id: number;
   method: M;
   params: RpcParams<M>;
+  priority?: RpcPriority;
 };
 
 export type RpcResponse<M extends RpcMethod = RpcMethod> =

--- a/packages/treecrdt-wa-sqlite/src/shared-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/shared-worker.ts
@@ -8,6 +8,7 @@ import {
   type RpcRequest,
   type RpcResult,
 } from './rpc.js';
+import { createRpcScheduler } from './rpc-scheduler.js';
 import { openTreecrdtDb } from './open.js';
 import {
   CommonWorkerSession,
@@ -39,13 +40,7 @@ class SharedCommonWorkerSession extends CommonWorkerSession {
 const ports = new Set<MessagePort>();
 const session = new SharedCommonWorkerSession();
 const coreHandlers = createCommonWorkerRpcHandlers(session);
-let callQueue: Promise<void> = Promise.resolve();
-
-const settleQueue = <T>(promise: Promise<T>): Promise<void> =>
-  promise.then(
-    () => undefined,
-    () => undefined,
-  );
+const scheduleRequest = createRpcScheduler();
 
 function broadcastMaterialized(event: MaterializationEvent, exclude?: MessagePort) {
   if (event.changes.length === 0) return;
@@ -71,8 +66,7 @@ function broadcastMaterialized(event: MaterializationEvent, exclude?: MessagePor
     const respondError = (error: string) => {
       port.postMessage({ id: request.id, ok: false, error });
     };
-    const run = callQueue.then(() => handleRequest(port, request));
-    callQueue = settleQueue(run);
+    const run = scheduleRequest(request.priority ?? 'normal', () => handleRequest(port, request));
     run.then(
       (result) => respondSuccess(result),
       (err) => respondError(err instanceof Error ? err.message : String(err)),

--- a/packages/treecrdt-wa-sqlite/src/types.ts
+++ b/packages/treecrdt-wa-sqlite/src/types.ts
@@ -1,7 +1,7 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
-import type { RpcMethod, RpcParams, RpcRequest, RpcResult } from './rpc.js';
+import type { RpcMethod, RpcParams, RpcPriority, RpcRequest, RpcResult } from './rpc.js';
 
 // Minimal wa-sqlite surface needed by the adapter. Exported so consumers
 // don't need to import types from wa-sqlite directly.
@@ -71,9 +71,11 @@ export type MessagePortProxy = {
   removeEventListener: (type: 'message' | 'messageerror', fn: (ev: any) => void) => void;
 };
 
+export type RpcCallOptions = { priority?: RpcPriority };
 export type RpcCall = <M extends RpcMethod>(
   method: M,
   params: RpcParams<M>,
+  options?: RpcCallOptions,
 ) => Promise<RpcResult<M>>;
 export type SharedWorkerFactory = (options?: WorkerOptions & { name?: string }) => SharedWorker;
 export type CrossTabMaterializationScope = {

--- a/packages/treecrdt-wa-sqlite/tests/rpc-scheduler.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/rpc-scheduler.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from 'vitest';
+import { createRpcScheduler, type RpcSchedulePriority } from '../src/rpc-scheduler.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('foreground work can run between background jobs', async () => {
+  const schedule = createRpcScheduler();
+  const first = deferred();
+  const order: string[] = [];
+
+  const running = schedule('background', async () => {
+    order.push('background-1');
+    await first.promise;
+  });
+  await Promise.resolve();
+  const background = schedule('background', async () => {
+    order.push('background-2');
+  });
+  const foreground = schedule('foreground', async () => {
+    order.push('foreground');
+  });
+
+  first.resolve();
+  await Promise.all([running, background, foreground]);
+  expect(order).toEqual(['background-1', 'foreground', 'background-2']);
+});
+
+test('normal work is an ordering barrier for later foreground work', async () => {
+  const schedule = createRpcScheduler();
+  const first = deferred();
+  const order: string[] = [];
+
+  const running = schedule('background', async () => {
+    order.push('background-1');
+    await first.promise;
+  });
+  await Promise.resolve();
+  const normal = schedule('normal', async () => {
+    order.push('normal');
+  });
+  const background = schedule('background', async () => {
+    order.push('background-2');
+  });
+  const foreground = schedule('foreground', async () => {
+    order.push('foreground');
+  });
+
+  first.resolve();
+  await Promise.all([running, normal, background, foreground]);
+  expect(order).toEqual(['background-1', 'normal', 'foreground', 'background-2']);
+});
+
+test('foreground bursts do not starve queued background work', async () => {
+  const schedule = createRpcScheduler();
+  const first = deferred();
+  const order: string[] = [];
+
+  const running = schedule('normal', () => first.promise);
+  await Promise.resolve();
+  const jobs: Promise<void>[] = [
+    schedule('background', async () => {
+      order.push('background');
+    }),
+  ];
+  for (let index = 0; index < 9; index += 1) {
+    jobs.push(
+      schedule('foreground', async () => {
+        order.push(`foreground-${index}`);
+      }),
+    );
+  }
+
+  first.resolve();
+  await Promise.all([running, ...jobs]);
+  expect(order.indexOf('background')).toBe(8);
+});
+
+test.each(['foreground', 'normal', 'background'] satisfies RpcSchedulePriority[])(
+  'a rejected %s job does not stall the scheduler',
+  async (priority) => {
+    const schedule = createRpcScheduler();
+    const rejected = schedule(priority, async () => {
+      throw new Error('expected failure');
+    });
+    const next = schedule('normal', async () => 'completed');
+
+    await expect(rejected).rejects.toThrow('expected failure');
+    await expect(next).resolves.toBe('completed');
+  },
+);


### PR DESCRIPTION
## Purpose

Experimental raw-browser harness used to evaluate #167's worker RPC scheduler. It measures background remote ingest while foreground reads and normal local writes share the same wa-sqlite client.

The experiment has finished. Its useful evidence is preserved here and in #167; this PR is being closed rather than merged as permanent infrastructure.

## What is measured

- Direct, dedicated-worker, and shared-worker runtimes.
- Memory and OPFS storage.
- Empty and 5,000-operation prefilled trees.
- Remote append batches at **normal** and **background** priority in the same build.
- Foreground read latency, normal local-write latency, remote-batch latency, total duration, and exact final tree count.

Normal omits the priority option and preserves FIFO barriers. Background exercises #167's foreground bypass. Direct memory is the no-scheduler control.

## Avoiding misleading fast paths

- Four trials per scenario, with priority order alternating normal/background and background/normal.
- Trial identity is recorded in workload metadata and output filenames.
- Reads and writes are released across remote batch-start barriers instead of only during the opening batch.
- Every run uses an isolated database and verifies the expected final child count.
- Physical SQLite filenames are deliberately short and opaque; descriptive labels remain in result metadata. This avoids confusing OPFS pathname capacity with scheduler behavior.

The first run exposed the independent OPFS path-capacity bug fixed by #213: wa-sqlite reported 64 bytes, while one filename plus SQLite's `-journal` suffix was 66 bytes. It was deterministic `SQLITE_CANTOPEN`, not a teardown race. The false cooldown/workaround was removed.

## Results

[Focused run 29203415286](https://github.com/cybersemics/treecrdt/actions/runs/29203415286) completed all **64/64** runtime rows. Values below are background-vs-normal deltas between four-trial medians; negative latency is better.

| Runtime / prefill | Read p95 | Local-write p95 | Remote-batch p95 |
| --- | ---: | ---: | ---: |
| Memory direct / 0 | +0.7% | -2.6% | +1.4% |
| Memory direct / 5k | +0.1% | -1.2% | +0.8% |
| Memory worker / 0 | **-12.2%** | +1.3% | +4.0% |
| Memory worker / 5k | +0.4% | +0.0% | +1.0% |
| OPFS worker / 0 | **-16.1%** | +1.1% | +0.9% |
| OPFS worker / 5k | -2.6% | -2.9% | -2.4% |
| OPFS shared / 0 | +1.0% | +1.4% | +1.5% |
| OPFS shared / 5k | +0.4% | +0.6% | +0.7% |

The useful result is narrow and repeatable: every empty-tree trial improved dedicated-worker read p95 (memory: 11.3–14.6%; OPFS: 14.4–17.9%). Populated cases stayed near neutral. The largest median latency regression was 4.0% remote-batch p95.

The shared-worker case used one client/port, so it did not exercise the distinct cross-tab/global scheduler. That finding led #167 to remove shared-worker scheduling and retain only the validated dedicated-worker path. Four trials are directional evidence, not a claim of statistical certainty.

`durationMs` was captured after the final integrity read, so it dilutes the derived throughput comparison. The latency samples and exact final-count validation are unaffected; #167 deliberately does not use the throughput field.

## Scope and validation

- One commit; 4 files, **+443/-1**.
- Reuses shared benchmark helpers and the existing Playwright invocation.
- Prettier, diff checks, Vite production build, Playwright discovery, and normal GitHub CI pass.
- #212's focused web dispatch completed both sides, uploaded the artifact, and published the result comment.

## Why close instead of merge

- The harness adds **+443/-1** and increased the web benchmark from about 9.9 to 16.4 minutes per checkout (roughly 66%).
- No threshold or regression gate consumes these scenario pairs automatically.
- Keeping it would impose recurring code and runner cost after the decision it was built for.
- The raw artifact, methodology, and decision-relevant results remain linked above.
