### PR TITLE
feat(wa-sqlite): add an opt-in single-owner OPFS WAL mode

### DIFF
--- a/.changeset/opfs-single-owner-wal.md
+++ b/.changeset/opfs-single-owner-wal.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': minor
+---
+
+Add an opt-in single-owner WAL write mode for dedicated-worker OPFS clients.

--- a/packages/treecrdt-wa-sqlite/README.md
+++ b/packages/treecrdt-wa-sqlite/README.md
@@ -32,6 +32,28 @@ const client = await createTreecrdtClient({
 
 See the [playground](../../examples/playground/README.md) for a full browser demo.
 
+### OPFS single-owner WAL mode
+
+Apps that guarantee one dedicated worker is the only owner of an OPFS database can opt in to
+SQLite WAL with exclusive locking:
+
+```ts
+const client = await createTreecrdtClient({
+  storage: {
+    type: 'opfs',
+    filename: '/treecrdt.db',
+    fallback: 'throw',
+    writeMode: 'single-owner-wal',
+  },
+  runtime: { type: 'dedicated-worker' },
+});
+```
+
+`runtime: { type: 'auto' }` also selects a dedicated worker for OPFS. Direct and shared-worker
+runtimes reject this mode. It uses wa-sqlite's `AccessHandlePoolVFS`, which is not
+filesystem-transparent; use the default OPFS mode for multi-tab ownership or direct file
+import/export.
+
 ## Node usage (in-memory WASM)
 
 On Node, `createTreecrdtClient()` runs wa-sqlite in-process with an in-memory database. OPFS and worker runtimes are not supported.

--- a/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
@@ -1,4 +1,9 @@
-import { createTreecrdtClient, detectOpfsSupport, type TreecrdtClient } from '@treecrdt/wa-sqlite';
+import {
+  createTreecrdtClient,
+  detectOpfsSupport,
+  type OpfsWriteMode,
+  type TreecrdtClient,
+} from '@treecrdt/wa-sqlite';
 import { nodeIdFromInt } from '@treecrdt/benchmark';
 import { replicaFromLabel } from './op-helpers.js';
 
@@ -18,6 +23,7 @@ type LifecycleOptions = {
   filename: string;
   runtime: LifecycleRuntime;
   sharedWorkerName?: string;
+  writeMode?: OpfsWriteMode;
 };
 
 export type LifecycleState = {
@@ -34,12 +40,19 @@ export type LifecycleState = {
   childParent: string | null;
   parentPayload: string | null;
   childPayload: string | null;
+  journalMode: string | null;
+  lockingMode: string | null;
 };
 
 async function createOpfsLifecycleClient(opts: LifecycleOptions): Promise<TreecrdtClient> {
   return createTreecrdtClient({
     docId: opts.docId,
-    storage: { type: 'opfs', filename: opts.filename, fallback: 'throw' },
+    storage: {
+      type: 'opfs',
+      filename: opts.filename,
+      fallback: 'throw',
+      writeMode: opts.writeMode,
+    },
     runtime:
       opts.runtime === 'shared-worker' && opts.sharedWorkerName
         ? { type: 'shared-worker', name: opts.sharedWorkerName }
@@ -64,6 +77,8 @@ async function summarizeLifecycleState(client: TreecrdtClient): Promise<Lifecycl
     childParent: await client.tree.parent(childId),
     parentPayload: parentPayload ? textDecoder.decode(parentPayload) : null,
     childPayload: childPayload ? textDecoder.decode(childPayload) : null,
+    journalMode: await client.runner.getText('PRAGMA journal_mode'),
+    lockingMode: await client.runner.getText('PRAGMA locking_mode'),
   };
 }
 

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -2,11 +2,13 @@ import { test, expect, type Page } from '@playwright/test';
 
 type LifecycleHarness = NonNullable<Window['__treecrdtLifecycle']>;
 type LifecycleRuntime = 'direct' | 'dedicated-worker' | 'shared-worker';
+type LifecycleWriteMode = 'default' | 'single-owner-wal';
 type LifecycleOptions = {
   docId: string;
   filename: string;
   runtime: LifecycleRuntime;
   sharedWorkerName?: string;
+  writeMode?: LifecycleWriteMode;
 };
 
 const scenarios: Array<{
@@ -184,6 +186,44 @@ test.describe('browser OPFS lifecycle', () => {
     } finally {
       await drop(page, { ...firstOpts, runtime: 'direct' }).catch(() => {});
       await drop(page, { ...secondOpts, runtime: 'direct' }).catch(() => {});
+    }
+  });
+
+  test('reopens a dedicated-worker OPFS store in single-owner WAL mode', async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name !== 'chromium-dev') test.skip();
+    test.setTimeout(120_000);
+    page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));
+
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+    const opts = {
+      docId: `lifecycle-wal-${suffix}`,
+      filename: `/lifecycle-wal-${'p'.repeat(64)}-${suffix}.db`,
+      runtime: 'dedicated-worker' as const,
+      writeMode: 'single-owner-wal' as const,
+    };
+    const walPathBytes = new TextEncoder().encode(`${opts.filename}-wal`).byteLength;
+    expect(walPathBytes).toBeGreaterThan(64);
+    expect(walPathBytes).toBeLessThan(512);
+
+    await waitForHarness(page);
+    const opfsSupport = await support(page);
+    if (!opfsSupport.available) test.skip(true, `OPFS unavailable: ${opfsSupport.reason}`);
+
+    try {
+      await drop(page, opts);
+      const written = await write(page, { ...opts, closeBeforeReload: true });
+      expectReloadedTree(written, { mode: 'worker', runtime: 'dedicated-worker' });
+      expect(written.journalMode).toBe('wal');
+      expect(written.lockingMode).toBe('exclusive');
+
+      const reopened = await read(page, opts);
+      expectReloadedTree(reopened, { mode: 'worker', runtime: 'dedicated-worker' });
+      expect(reopened.journalMode).toBe('wal');
+      expect(reopened.lockingMode).toBe('exclusive');
+    } finally {
+      await drop(page, opts).catch(() => {});
     }
   });
 });

--- a/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
+++ b/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
@@ -34,6 +34,12 @@ const vendorDistRoot = (() => {
 
 const sources = [
   {
+    src: path.join(vendorRoot, 'src/examples/AccessHandlePoolVFS.js'),
+    name: 'AccessHandlePoolVFS.js',
+    transform: (content) =>
+      content.replace('../FacadeVFS.js', './FacadeVFS.js').replace('../VFS.js', './VFS.js'),
+  },
+  {
     src: path.join(vendorRoot, 'src/examples/OPFSCoopSyncVFS.js'),
     name: 'OPFSCoopSyncVFS.js',
     transform: (content) =>

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -51,6 +51,7 @@ import type {
   MessagePortProxy,
   NormalizedRuntimeOptions,
   NormalizedStorageOptions,
+  OpfsWriteMode,
   RpcCall,
   RuntimeMode,
   SharedWorkerFactory,
@@ -64,6 +65,12 @@ export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
 // Keep long browser appendMany calls from monopolizing the worker queue.
 const APPEND_MANY_RPC_CHUNK_SIZE = 2500;
 
+function normalizeOpfsWriteMode(value: unknown): OpfsWriteMode {
+  if (value === undefined || value === 'default') return 'default';
+  if (value === 'single-owner-wal') return 'single-owner-wal';
+  throw new Error('createTreecrdtClient storage.writeMode must be "default" or "single-owner-wal"');
+}
+
 function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
   const raw = opts.storage ?? { type: 'auto' };
   if (!raw || typeof raw !== 'object') {
@@ -73,7 +80,12 @@ function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions 
   }
 
   if (raw.type === 'memory') {
-    return { type: 'memory', requireOpfs: false, fallback: 'memory' };
+    return {
+      type: 'memory',
+      requireOpfs: false,
+      fallback: 'memory',
+      opfsWriteMode: 'default',
+    };
   }
   if (raw.type === 'opfs') {
     const fallback = raw.fallback ?? 'throw';
@@ -82,6 +94,7 @@ function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions 
       filename: raw.filename,
       requireOpfs: fallback === 'throw',
       fallback,
+      opfsWriteMode: normalizeOpfsWriteMode(raw.writeMode),
     };
   }
   if (raw.type !== 'auto') {
@@ -93,6 +106,7 @@ function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions 
     filename: raw.filename,
     requireOpfs: fallback === 'throw',
     fallback,
+    opfsWriteMode: 'default',
   };
 }
 
@@ -160,6 +174,16 @@ export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<Tr
     runtime,
   );
 
+  if (
+    shouldUseOpfs &&
+    storage.opfsWriteMode === 'single-owner-wal' &&
+    resolvedRuntime !== 'dedicated-worker'
+  ) {
+    throw new Error(
+      'OPFS storage.writeMode "single-owner-wal" requires runtime "dedicated-worker" or runtime "auto"',
+    );
+  }
+
   if (resolvedRuntime === 'shared-worker') {
     return createSharedWorkerClient({
       baseUrl,
@@ -182,6 +206,7 @@ export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<Tr
       filename: storage.filename,
       storage: shouldUseOpfs ? 'opfs' : 'memory',
       requireOpfs: storage.requireOpfs,
+      opfsWriteMode: storage.opfsWriteMode,
       docId,
       workerUrl: runtime.type === 'dedicated-worker' ? runtime.workerUrl : undefined,
     });
@@ -306,6 +331,7 @@ async function createWorkerClient(opts: {
   baseUrl?: string;
   filename?: string;
   storage: StorageMode;
+  opfsWriteMode: OpfsWriteMode;
   docId: string;
   requireOpfs?: boolean;
   workerUrl?: string | URL;
@@ -383,7 +409,13 @@ async function createWorkerClient(opts: {
   // init
   let initResult: RpcResult<'init'>;
   try {
-    initResult = await call('init', [opts.baseUrl ?? '/', opts.filename, opts.storage, opts.docId]);
+    initResult = await call('init', [
+      opts.baseUrl ?? '/',
+      opts.filename,
+      opts.storage,
+      opts.docId,
+      opts.opfsWriteMode,
+    ]);
   } catch (err) {
     cleanup();
     throw err;
@@ -653,6 +685,8 @@ export async function buildDirectClient(
   const db = opened.db;
   const finalStorage: StorageMode = opened.storage;
   const filename = opened.filename;
+  const opfsVfsKind = opened.opfsVfsKind;
+  const opfsVfsName = opened.opfsVfsName;
   if (finalStorage === 'opfs') {
     materialized.enableCrossTab({ docId: opts.docId, filename });
   }
@@ -764,7 +798,7 @@ export async function buildDirectClient(
         case 'drop': {
           if (db.close) await db.close();
           if (finalStorage === 'opfs') {
-            await clearOpfsStorage(filename);
+            await clearOpfsStorage(filename, { vfsKind: opfsVfsKind, vfsName: opfsVfsName });
           }
           return undefined as any;
         }
@@ -797,7 +831,7 @@ export async function buildDirectClient(
       if (closed) return;
       if (db.close) await db.close();
       if (finalStorage === 'opfs') {
-        await clearOpfsStorage(filename);
+        await clearOpfsStorage(filename, { vfsKind: opfsVfsKind, vfsName: opfsVfsName });
       }
       closed = true;
     },

--- a/packages/treecrdt-wa-sqlite/src/common-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/common-worker.ts
@@ -4,7 +4,7 @@ import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { Operation } from '@treecrdt/interface';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import type { OpenTreecrdtDbResult } from './open.js';
-import { clearOpfsStorage } from './opfs.js';
+import { clearOpfsStorage, type OpfsVfsKind } from './opfs.js';
 import { rpcBinaryResult, type RpcInitResult, type RpcSqlParams } from './rpc.js';
 
 export function openedToRpcInitResult(opened: OpenTreecrdtDbResult): RpcInitResult {
@@ -22,6 +22,8 @@ export class CommonWorkerSession {
   api: TreecrdtAdapter | null = null;
   storedFilename: string | undefined;
   storedStorage: 'memory' | 'opfs' = 'memory';
+  storedOpfsVfsKind: OpfsVfsKind | undefined;
+  storedOpfsVfsName: string | undefined;
 
   protected onAfterReset(): void {}
 
@@ -30,6 +32,8 @@ export class CommonWorkerSession {
     this.api = opened.api;
     this.storedFilename = opened.filename;
     this.storedStorage = opened.storage;
+    this.storedOpfsVfsKind = opened.opfsVfsKind;
+    this.storedOpfsVfsName = opened.opfsVfsName;
   }
 
   async closeDbAndReset(): Promise<void> {
@@ -38,6 +42,8 @@ export class CommonWorkerSession {
     this.api = null;
     this.storedFilename = undefined;
     this.storedStorage = 'memory';
+    this.storedOpfsVfsKind = undefined;
+    this.storedOpfsVfsName = undefined;
     this.onAfterReset();
     if (db?.close) await db.close();
   }
@@ -45,9 +51,11 @@ export class CommonWorkerSession {
   async drop(): Promise<null> {
     const filename = this.storedFilename;
     const storage = this.storedStorage;
+    const opfsVfsKind = this.storedOpfsVfsKind;
+    const opfsVfsName = this.storedOpfsVfsName;
     await this.closeDbAndReset();
     if (storage === 'opfs' && filename) {
-      await clearOpfsStorage(filename);
+      await clearOpfsStorage(filename, { vfsKind: opfsVfsKind, vfsName: opfsVfsName });
     }
     return null;
   }

--- a/packages/treecrdt-wa-sqlite/src/index.browser.ts
+++ b/packages/treecrdt-wa-sqlite/src/index.browser.ts
@@ -2,6 +2,7 @@ export type {
   ClientMode,
   ClientOptions,
   Database,
+  OpfsWriteMode,
   RuntimeMode,
   StorageMode,
   TreecrdtAssets,

--- a/packages/treecrdt-wa-sqlite/src/index.node.ts
+++ b/packages/treecrdt-wa-sqlite/src/index.node.ts
@@ -2,6 +2,7 @@ export type {
   ClientMode,
   ClientOptions,
   Database,
+  OpfsWriteMode,
   RuntimeMode,
   StorageMode,
   TreecrdtAssets,

--- a/packages/treecrdt-wa-sqlite/src/open-core.ts
+++ b/packages/treecrdt-wa-sqlite/src/open-core.ts
@@ -1,7 +1,8 @@
-import { createOpfsVfs, type OpfsVfsKind } from './opfs.js';
+import { accessHandlePoolVfsNameForFilename, createOpfsVfs, type OpfsVfsKind } from './opfs.js';
 import { createWaSqliteApi } from './adapter.js';
-import type { Database } from './types.js';
+import type { Database, OpfsWriteMode } from './types.js';
 import { makeDbAdapter } from './db.js';
+import { dbGetText } from './sql.js';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
 import { initializeTreecrdtExtension } from './extension.js';
@@ -14,6 +15,7 @@ export type OpenTreecrdtDbOptions = {
   requireOpfs?: boolean;
   onMaterialized?: (event: MaterializationEvent) => void;
   opfsVfs?: OpfsVfsKind;
+  opfsWriteMode?: OpfsWriteMode;
 };
 
 export type OpenTreecrdtDbResult = {
@@ -21,6 +23,8 @@ export type OpenTreecrdtDbResult = {
   api: TreecrdtAdapter;
   storage: 'memory' | 'opfs';
   filename: string;
+  opfsVfsKind?: OpfsVfsKind;
+  opfsVfsName?: string;
   opfsError?: string;
 };
 
@@ -57,6 +61,7 @@ async function openInitializedDatabase(
   filename: string,
   opts: OpenTreecrdtDbOptions,
   vfsName?: string,
+  beforeExtensionInit?: (db: Database) => Promise<void>,
 ): Promise<{ db: Database; api: TreecrdtAdapter }> {
   let db: Database | undefined;
   try {
@@ -64,6 +69,7 @@ async function openInitializedDatabase(
       ? await sqlite3.open_v2(filename, undefined, vfsName)
       : await sqlite3.open_v2(filename);
     db = makeDbAdapter(sqlite3, handle);
+    await beforeExtensionInit?.(db);
     await initializeTreecrdtExtension(module, handle);
     const api = createWaSqliteApi(db, { onMaterialized: opts.onMaterialized });
     await api.setDocId(opts.docId);
@@ -71,6 +77,28 @@ async function openInitializedDatabase(
   } catch (err) {
     await closeIgnoringErrors(db?.close ? () => db!.close!() : undefined);
     throw err;
+  }
+}
+
+async function configureOpfsWriteMode(db: Database, mode: OpfsWriteMode): Promise<void> {
+  if (mode === 'default') return;
+
+  const lockingMode = await dbGetText(db, 'PRAGMA locking_mode=EXCLUSIVE');
+  const currentJournalMode = await dbGetText(db, 'PRAGMA journal_mode');
+  const journalMode =
+    currentJournalMode?.toLowerCase() === 'wal'
+      ? currentJournalMode
+      : await dbGetText(db, 'PRAGMA journal_mode=WAL');
+  const confirmedJournalMode = await dbGetText(db, 'PRAGMA journal_mode');
+  const confirmedLockingMode = await dbGetText(db, 'PRAGMA locking_mode');
+
+  if (
+    confirmedJournalMode?.toLowerCase() !== 'wal' ||
+    confirmedLockingMode?.toLowerCase() !== 'exclusive'
+  ) {
+    throw new Error(
+      `OPFS single-owner WAL requested but SQLite reported journal_mode=${confirmedJournalMode ?? journalMode ?? 'null'} locking_mode=${confirmedLockingMode ?? lockingMode ?? 'null'}`,
+    );
   }
 }
 
@@ -101,13 +129,20 @@ export async function openTreecrdtDbFromLoaded(
   let opfsError: string | undefined;
   let opfsFailure: unknown;
   const requestedFilename = opts.filename ?? '/treecrdt.db';
+  const opfsWriteMode = opts.opfsWriteMode ?? 'default';
 
   if (opts.storage === 'opfs') {
     let vfs: { close?: () => Promise<void> | void } | undefined;
     try {
+      const opfsVfsKind: OpfsVfsKind =
+        opfsWriteMode === 'single-owner-wal' ? 'access-handle-pool' : (opts.opfsVfs ?? 'coop-sync');
+      const opfsVfsName =
+        opfsVfsKind === 'access-handle-pool'
+          ? await accessHandlePoolVfsNameForFilename(requestedFilename)
+          : OPFS_VFS_NAME;
       const initializedVfs = await createOpfsVfs(module, {
-        name: OPFS_VFS_NAME,
-        kind: opts.opfsVfs,
+        name: opfsVfsName,
+        kind: opfsVfsKind,
       });
       vfs = initializedVfs;
       sqlite3.vfs_register(initializedVfs, false);
@@ -116,13 +151,16 @@ export async function openTreecrdtDbFromLoaded(
         module,
         requestedFilename,
         opts,
-        OPFS_VFS_NAME,
+        opfsVfsName,
+        (db) => configureOpfsWriteMode(db, opfsWriteMode),
       );
       return {
         ...opened,
         db: closeDatabaseWithVfs(opened.db, initializedVfs),
         storage: 'opfs',
         filename: requestedFilename,
+        opfsVfsKind,
+        opfsVfsName,
       };
     } catch (err) {
       opfsFailure = err;

--- a/packages/treecrdt-wa-sqlite/src/opfs.ts
+++ b/packages/treecrdt-wa-sqlite/src/opfs.ts
@@ -37,14 +37,46 @@ export function detectOpfsSupport(): OpfsSupport {
 
 const DB_RELATED_FILE_SUFFIXES = ['', '-journal', '-wal'];
 
+export type ClearOpfsStorageOptions = {
+  vfsKind?: OpfsVfsKind;
+  vfsName?: string;
+};
+
+export async function accessHandlePoolVfsNameForFilename(filename: string): Promise<string> {
+  const normalized = new URL(filename, 'file://localhost/').pathname;
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(normalized));
+  const suffix = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  return `opfs-ahp-${suffix}`;
+}
+
+async function clearAccessHandlePoolStorage(vfsName: string): Promise<void> {
+  try {
+    const root = await navigator.storage.getDirectory();
+    await root.removeEntry(vfsName, { recursive: true });
+  } catch (err) {
+    if ((err as Error)?.name !== 'NotFoundError') throw err;
+  }
+}
+
 /**
  * Remove database and related files (journal, wal) from OPFS storage.
  * Call only after the database handle is closed.
  *
  * @param filename - Path used when opening (e.g. /treecrdt.db or /treecrdt-playground.db)
  */
-export async function clearOpfsStorage(filename: string): Promise<void> {
+export async function clearOpfsStorage(
+  filename: string,
+  opts: ClearOpfsStorageOptions = {},
+): Promise<void> {
   if (!hasOpfsGetDirectory()) return;
+  if (opts.vfsKind === 'access-handle-pool') {
+    await clearAccessHandlePoolStorage(
+      opts.vfsName ?? (await accessHandlePoolVfsNameForFilename(filename)),
+    );
+    return;
+  }
 
   const path = filename.startsWith('/') ? filename.slice(1) : filename;
   const parts = path.split('/').filter(Boolean);
@@ -118,7 +150,7 @@ export async function opfsStorageExists(filename: string): Promise<boolean> {
   return false;
 }
 
-export type OpfsVfsKind = 'coop-sync' | 'any-context';
+export type OpfsVfsKind = 'coop-sync' | 'any-context' | 'access-handle-pool';
 
 export type OpfsVfsOptions = {
   name?: string;
@@ -128,7 +160,7 @@ export type OpfsVfsOptions = {
 const OPFS_MAX_PATHNAME = 512;
 
 function withOpfsPathCapacity(vfs: any): any {
-  // SQLite appends sidecar suffixes such as "-journal" after checking this capacity.
+  // SQLite appends sidecar suffixes such as "-journal" and "-wal" after checking this capacity.
   vfs.mxPathname = Math.max(vfs.mxPathname ?? 0, OPFS_MAX_PATHNAME);
   return vfs;
 }
@@ -139,6 +171,12 @@ function withOpfsPathCapacity(vfs: any): any {
  */
 export async function createOpfsVfs(module: any, opts: OpfsVfsOptions = {}): Promise<any> {
   const name = opts.name ?? 'opfs';
+  if (opts.kind === 'access-handle-pool') {
+    // @ts-ignore vendored module lacks type declarations
+    const { AccessHandlePoolVFS } = await import('./vendor/AccessHandlePoolVFS.js');
+    return withOpfsPathCapacity(await AccessHandlePoolVFS.create(name, module));
+  }
+
   if (opts.kind === 'any-context') {
     // @ts-ignore vendored module lacks type declarations
     const { OPFSAnyContextVFS } = await import('./vendor/OPFSAnyContextVFS.js');

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -4,6 +4,7 @@ import type { MaterializationEvent, MaterializationOutcome } from '@treecrdt/int
 export const SHARED_WORKER_DROPPED_ERROR = 'TreeCRDT shared database was dropped';
 
 export type RpcStorageMode = 'memory' | 'opfs';
+export type RpcOpfsWriteMode = 'default' | 'single-owner-wal';
 
 export type RpcSqlParam = number | string | null | Uint8Array;
 export type RpcSqlParams = RpcSqlParam[];
@@ -13,13 +14,20 @@ export type RpcInitParams = {
   filename?: string;
   storage: RpcStorageMode;
   docId: string;
+  opfsWriteMode?: RpcOpfsWriteMode;
 };
 
 export type RpcInitResult = { storage: RpcStorageMode; filename: string; opfsError?: string };
 
 export type RpcSchema = {
   init: {
-    params: [baseUrl: string, filename: string | undefined, storage: RpcStorageMode, docId: string];
+    params: [
+      baseUrl: string,
+      filename: string | undefined,
+      storage: RpcStorageMode,
+      docId: string,
+      opfsWriteMode?: RpcOpfsWriteMode,
+    ];
     result: RpcInitResult;
   };
   sqlExec: { params: [sql: string]; result: void };

--- a/packages/treecrdt-wa-sqlite/src/types.ts
+++ b/packages/treecrdt-wa-sqlite/src/types.ts
@@ -18,9 +18,19 @@ export type Database = {
 export type StorageMode = 'memory' | 'opfs';
 export type ClientMode = 'direct' | 'worker';
 export type RuntimeMode = 'direct' | 'dedicated-worker' | 'shared-worker';
+export type OpfsWriteMode = 'default' | 'single-owner-wal';
 export type TreecrdtStorage =
   | { type: 'memory' }
-  | { type: 'opfs'; filename?: string; fallback?: 'throw' | 'memory' }
+  | {
+      type: 'opfs';
+      filename?: string;
+      fallback?: 'throw' | 'memory';
+      /**
+       * Enables WAL with exclusive locking. The application must guarantee that
+       * one dedicated worker is the only owner of this OPFS database.
+       */
+      writeMode?: OpfsWriteMode;
+    }
   | { type: 'auto'; filename?: string; fallback?: 'memory' | 'throw' };
 export type TreecrdtRuntime =
   | { type: 'auto' }
@@ -52,6 +62,7 @@ export type NormalizedStorageOptions = {
   filename?: string;
   requireOpfs: boolean;
   fallback: 'memory' | 'throw';
+  opfsWriteMode: OpfsWriteMode;
 };
 
 export type NormalizedRuntimeOptions = TreecrdtRuntime;

--- a/packages/treecrdt-wa-sqlite/src/worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/worker.ts
@@ -1,6 +1,11 @@
 /// <reference lib="webworker" />
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
-import { transferablesForRpcBinaryResult, type RpcMethod, type RpcRequest } from './rpc.js';
+import {
+  transferablesForRpcBinaryResult,
+  type RpcMethod,
+  type RpcOpfsWriteMode,
+  type RpcRequest,
+} from './rpc.js';
 import { openTreecrdtDb } from './open.js';
 import {
   CommonWorkerSession,
@@ -20,6 +25,7 @@ async function init(
   filename: string | undefined,
   storageParam: 'memory' | 'opfs',
   docId: string,
+  opfsWriteMode: RpcOpfsWriteMode = 'default',
 ) {
   await session.closeDbAndReset();
   const opened = await openTreecrdtDb({
@@ -28,6 +34,7 @@ async function init(
     storage: storageParam,
     docId,
     requireOpfs: false,
+    opfsWriteMode,
     onMaterialized: postMaterialized,
   });
   session.applyOpened(opened);

--- a/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
@@ -1,22 +1,41 @@
 import { beforeEach, expect, test, vi } from 'vitest';
 
-vi.mock('../src/opfs.js', () => ({ createOpfsVfs: vi.fn() }));
+vi.mock('../src/opfs.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/opfs.js')>();
+  return {
+    ...actual,
+    accessHandlePoolVfsNameForFilename: vi.fn(actual.accessHandlePoolVfsNameForFilename),
+    createOpfsVfs: vi.fn(),
+  };
+});
 
-import { createOpfsVfs } from '../src/opfs.js';
+import { accessHandlePoolVfsNameForFilename, createOpfsVfs } from '../src/opfs.js';
 import { openTreecrdtDbFromLoaded } from '../src/open-core.js';
 
-function createFakeModule(initResult = 0) {
+function createFakeModule(initResult = 0, events?: string[]) {
   return {
-    cwrap: vi.fn(() => vi.fn(async () => initResult)),
+    cwrap: vi.fn(() =>
+      vi.fn(async () => {
+        events?.push('extension-init');
+        return initResult;
+      }),
+    ),
     retryOps: [] as Promise<unknown>[],
     pendingOps: [] as Promise<unknown>[],
   };
 }
 
 function createFakeSqlite(
-  opts: { failOpen?: string; failOpenError?: Error; failInitializationHandle?: number } = {},
+  opts: {
+    failOpen?: string;
+    failOpenError?: Error;
+    failInitializationHandle?: number;
+    queryText?: Record<string, string | null | Array<string | null>>;
+    events?: string[];
+  } = {},
 ) {
   const statementHandles = new Map<number, number>();
+  const statementText = new Map<number, string | null>();
   let nextHandle = 1;
   let nextStatement = 100;
 
@@ -26,9 +45,15 @@ function createFakeSqlite(
       if (filename === opts.failOpen) throw opts.failOpenError ?? new Error('OPFS open failed');
       return nextHandle++;
     }),
-    statements: vi.fn((handle: number) => {
+    statements: vi.fn((handle: number, sql: string) => {
       const statement = nextStatement++;
       statementHandles.set(statement, handle);
+      if (opts.queryText && Object.prototype.hasOwnProperty.call(opts.queryText, sql)) {
+        const configured = opts.queryText?.[sql];
+        const value = Array.isArray(configured) ? (configured.shift() ?? null) : configured;
+        statementText.set(statement, value ?? null);
+      }
+      opts.events?.push(`prepare:${sql}`);
       return {
         next: async () => ({ value: statement }),
         return: async () => undefined,
@@ -39,9 +64,9 @@ function createFakeSqlite(
       if (statementHandles.get(statement) === opts.failInitializationHandle) {
         throw new Error('TreeCRDT initialization failed');
       }
-      return 101;
+      return statementText.has(statement) ? 100 : 101;
     }),
-    column_text: vi.fn(),
+    column_text: vi.fn((statement: number) => statementText.get(statement)),
     finalize: vi.fn(),
     exec: vi.fn(),
     close: vi.fn(),
@@ -49,6 +74,7 @@ function createFakeSqlite(
 }
 
 beforeEach(() => {
+  vi.mocked(accessHandlePoolVfsNameForFilename).mockClear();
   vi.mocked(createOpfsVfs).mockReset();
 });
 
@@ -98,6 +124,36 @@ test('falls back to memory when opening the OPFS database fails', async () => {
   expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
   expect(vfs.close).toHaveBeenCalledOnce();
   expect(loadFresh).toHaveBeenCalledOnce();
+});
+
+test('falls back before VFS creation when WAL storage naming fails', async () => {
+  vi.mocked(accessHandlePoolVfsNameForFilename).mockRejectedValueOnce(
+    new Error('storage naming failed'),
+  );
+  const sqlite3 = createFakeSqlite();
+  const memorySqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn(async () => ({
+    sqlite3: memorySqlite3,
+    module: createFakeModule(),
+  }));
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/fallback-name.db',
+      docId: 'fallback-name',
+      requireOpfs: false,
+      opfsWriteMode: 'single-owner-wal',
+    },
+    { sqlite3, module: createFakeModule() },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(opened.opfsError).toBe('storage naming failed');
+  expect(createOpfsVfs).not.toHaveBeenCalled();
+  expect(sqlite3.open_v2).not.toHaveBeenCalled();
+  expect(memorySqlite3.open_v2).toHaveBeenCalledWith(':memory:');
 });
 
 test('closes a partially initialized OPFS database before falling back', async () => {
@@ -202,12 +258,59 @@ test('keeps the successful OPFS path single-pass and closes its database and VFS
   expect(sqlite3.open_v2).toHaveBeenCalledOnce();
   expect(sqlite3.open_v2).toHaveBeenCalledWith('/success.db', undefined, 'opfs');
   expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
+  expect(createOpfsVfs).toHaveBeenCalledWith(expect.anything(), {
+    name: 'opfs',
+    kind: 'coop-sync',
+  });
+  expect(sqlite3.statements.mock.calls.some(([, sql]) => String(sql).startsWith('PRAGMA'))).toBe(
+    false,
+  );
   expect(loadFresh).not.toHaveBeenCalled();
 
   await opened.db.close?.();
   await opened.db.close?.();
   expect(sqlite3.close).toHaveBeenCalledOnce();
   expect(vfs.close).toHaveBeenCalledOnce();
+});
+
+test('configures WAL before extension initialization and selects the VFS explicitly', async () => {
+  const events: string[] = [];
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite({
+    events,
+    queryText: {
+      'PRAGMA locking_mode=EXCLUSIVE': 'exclusive',
+      'PRAGMA journal_mode': ['delete', 'wal'],
+      'PRAGMA journal_mode=WAL': 'wal',
+      'PRAGMA locking_mode': 'exclusive',
+    },
+  });
+  const filename = '/wal.db';
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename,
+      docId: 'wal',
+      requireOpfs: true,
+      opfsWriteMode: 'single-owner-wal',
+    },
+    { sqlite3, module: createFakeModule(0, events) },
+    vi.fn(),
+  );
+
+  expect(opened.opfsVfsKind).toBe('access-handle-pool');
+  expect(opened.opfsVfsName).toMatch(/^opfs-ahp-[0-9a-f]{64}$/);
+  expect(createOpfsVfs).toHaveBeenCalledWith(expect.anything(), {
+    name: opened.opfsVfsName,
+    kind: 'access-handle-pool',
+  });
+  expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
+  expect(sqlite3.open_v2).toHaveBeenCalledWith(filename, undefined, opened.opfsVfsName);
+  expect(events.indexOf('prepare:PRAGMA locking_mode=EXCLUSIVE')).toBeLessThan(
+    events.indexOf('extension-init'),
+  );
 });
 
 test('required OPFS closes the VFS and does not attempt memory fallback', async () => {

--- a/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
@@ -125,6 +125,23 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+test('single-owner WAL rejects direct and shared-worker runtimes before startup', async () => {
+  vi.stubGlobal('window', { crossOriginIsolated: true });
+  vi.stubGlobal('navigator', { storage: { getDirectory: vi.fn() } });
+  vi.stubGlobal('SharedWorker', class {});
+
+  for (const runtime of ['direct', 'shared-worker'] as const) {
+    await expect(
+      createTreecrdtClient({
+        storage: { type: 'opfs', writeMode: 'single-owner-wal' },
+        runtime: { type: runtime },
+      }),
+    ).rejects.toThrow(
+      'OPFS storage.writeMode "single-owner-wal" requires runtime "dedicated-worker" or runtime "auto"',
+    );
+  }
+});
+
 for (const runtime of ['dedicated-worker', 'shared-worker'] as const) {
   test(`${runtime} cleans up after rejected initialization`, async () => {
     const endpoint = installEndpoint(runtime, (request) => ({


### PR DESCRIPTION
## Summary

Add an opt-in `storage.writeMode: 'single-owner-wal'` for applications that guarantee one dedicated worker is the only owner of an OPFS database.

The mode uses wa-sqlite's `AccessHandlePoolVFS`, gives each filename a stable VFS identity, raises SQLite's pathname capacity to 512 bytes, and enables `locking_mode=EXCLUSIVE` plus `journal_mode=WAL` before TreeCRDT schema initialization. Startup fails if SQLite does not confirm both settings. Drop cleanup uses the same VFS identity.

Only `dedicated-worker` is accepted; `auto` is accepted when it resolves to that path. Direct and SharedWorker runtimes are rejected.

## Scope and safety

The default cooperative OPFS mode is unchanged and remains the correct choice for multi-tab or otherwise shared ownership. `AccessHandlePoolVFS` is not filesystem-transparent and must not be opened concurrently elsewhere. This option does not establish single ownership—the application must guarantee it.

## Stack

Depends on #209 and is last in the stack. Merge with a merge commit after #209.
