### PR TITLE
feat(sqlite-node): add managed runtime options

### DIFF
--- a/packages/treecrdt-sqlite-node/scripts/bench-note-paths.ts
+++ b/packages/treecrdt-sqlite-node/scripts/bench-note-paths.ts
@@ -1,7 +1,4 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
-
-import Database from 'better-sqlite3';
 
 import {
   buildFanoutInsertTreeOps,
@@ -12,9 +9,8 @@ import {
 } from '@treecrdt/benchmark';
 import { repoRootFromImportMeta, writeResult } from '@treecrdt/benchmark/node';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
-import { nodeIdToBytes16 } from '@treecrdt/interface/ids';
 
-import { createTreecrdtClient, createSqliteNodeApi, loadTreecrdtExtension } from '../dist/index.js';
+import { createTreecrdtClient, type SqliteNodeClient } from '../dist/index.js';
 
 type StorageKind = 'memory' | 'file';
 type NotePathBenchKind = 'read-children-payloads' | 'insert-into-large-tree';
@@ -199,7 +195,7 @@ async function openSeededClient(opts: {
   bench: NotePathBenchKind;
   size: number;
   seedOps: Operation[];
-}): Promise<Awaited<ReturnType<typeof createTreecrdtClient>>> {
+}): Promise<SqliteNodeClient> {
   const dbPath =
     opts.storage === 'memory'
       ? ':memory:'
@@ -210,24 +206,15 @@ async function openSeededClient(opts: {
           `${opts.bench}-${opts.size}-${crypto.randomUUID()}.db`,
         );
 
-  if (opts.storage === 'file') {
-    await fs.mkdir(path.dirname(dbPath), { recursive: true });
-  }
-
-  const db = new Database(dbPath);
-  loadTreecrdtExtension(db);
-  const api = createSqliteNodeApi(db);
-  await api.setDocId('treecrdt-note-paths-bench');
-  await api.appendOps!(opts.seedOps, nodeIdToBytes16, (replica) => replica);
-
-  const client = await createTreecrdtClient(db, { docId: 'treecrdt-note-paths-bench' });
+  const client = await createTreecrdtClient({
+    docId: 'treecrdt-note-paths-bench',
+    storage: opts.storage === 'file' ? { type: 'file', filename: dbPath } : { type: 'memory' },
+  });
+  await client.ops.appendMany(opts.seedOps);
   return {
     ...client,
     close: async () => {
-      await client.close();
-      if (opts.storage === 'file') {
-        await fs.rm(dbPath).catch(() => {});
-      }
+      await client.drop();
     },
   };
 }

--- a/packages/treecrdt-sqlite-node/scripts/bench-sync.ts
+++ b/packages/treecrdt-sqlite-node/scripts/bench-sync.ts
@@ -55,7 +55,11 @@ import {
 } from '@treecrdt/sync-protocol/transport';
 import { startSyncServer } from '@treecrdt/sync-server-postgres-node';
 
-import { createTreecrdtClient, createSqliteNodeApi, loadTreecrdtExtension } from '../dist/index.js';
+import {
+  createTreecrdtClientFromDatabase,
+  createSqliteNodeApi,
+  loadTreecrdtExtension,
+} from '../dist/index.js';
 import {
   resetBackendProfiler,
   takeBackendProfilerSnapshot,
@@ -1022,7 +1026,7 @@ async function makeBackend(opts: {
   initialMaxLamport: number;
   profileLabel?: string;
 }): Promise<FlushableSyncBackend<Operation>> {
-  const client = await createTreecrdtClient(opts.db, { docId: opts.docId });
+  const client = await createTreecrdtClientFromDatabase(opts.db, { docId: opts.docId });
   const backend = createTreecrdtSyncBackendFromClient(client, opts.docId);
   const queued = makeQueuedSyncBackend<Operation>({
     docId: opts.docId,
@@ -1063,7 +1067,7 @@ async function measureFirstViewAfterSync(
   docId: string,
   firstView: NonNullable<ReturnType<typeof buildSyncBenchCase>['firstView']>,
 ): Promise<number> {
-  const client = await createTreecrdtClient(db, { docId });
+  const client = await createTreecrdtClientFromDatabase(db, { docId });
   const expectedChildren = Math.min(firstView.expectedChildren, firstView.pageSize);
   const startedAt = performance.now();
   const rows = await client.tree.childrenPage(firstView.parent, null, firstView.pageSize);

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -39,7 +40,33 @@ export type LoadableDatabase = {
   loadExtension: (path: string, entryPoint?: string) => void;
 };
 
+export type SqliteNodeStorage = { type: 'memory' } | { type: 'file'; filename: string };
+export type SqliteNodeRuntime = { type: 'direct' };
+export type SqliteNodeClientOptions = {
+  storage?: SqliteNodeStorage;
+  runtime?: SqliteNodeRuntime;
+  extension?: LoadOptions;
+  docId?: string;
+};
+
+export type TreecrdtSqliteNodeDatabaseClient = TreecrdtEngine & {
+  mode: 'node';
+  storage: 'sqlite';
+  docId: string;
+  runner: SqliteRunner;
+  auth: TreecrdtSqliteAuthApi;
+  close: () => Promise<void>;
+};
+
+export type SqliteNodeClient = Omit<TreecrdtSqliteNodeDatabaseClient, 'storage'> & {
+  runtime: 'direct';
+  storage: 'memory' | 'file';
+  filename: string;
+  drop: () => Promise<void>;
+};
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SQLITE_FILE_SUFFIXES = ['', '-journal', '-wal', '-shm'];
 
 function platformExt(): '.dylib' | '.so' | '.dll' {
   switch (process.platform) {
@@ -113,24 +140,113 @@ function createRunner(db: any): SqliteRunner {
   return runner;
 }
 
-export function createSqliteNodeApi(db: any, opts: { maxBulkOps?: number } = {}): TreecrdtAdapter {
-  return createTreecrdtSqliteAdapter(createRunner(db), opts);
+export function createSqliteNodeApi(db: any): TreecrdtAdapter {
+  return createTreecrdtSqliteAdapter(createRunner(db));
+}
+
+async function loadDatabaseCtor(): Promise<new (filename: string) => any> {
+  return (
+    (await import('better-sqlite3').catch((err) => {
+      throw new Error(
+        `better-sqlite3 native binding not available; ensure it is installed/built before using @treecrdt/sqlite-node: ${err}`,
+      );
+    })) as { default: new (filename: string) => any }
+  ).default;
+}
+
+function normalizeManagedRuntime(opts: SqliteNodeClientOptions): SqliteNodeRuntime {
+  const runtime = opts.runtime ?? { type: 'direct' };
+  if (!runtime || typeof runtime !== 'object' || runtime.type !== 'direct') {
+    throw new Error('@treecrdt/sqlite-node only supports runtime: { type: "direct" }');
+  }
+  return runtime;
+}
+
+function normalizeManagedStorage(opts: SqliteNodeClientOptions): SqliteNodeStorage {
+  const storage = opts.storage ?? { type: 'memory' };
+  if (!storage || typeof storage !== 'object') {
+    throw new Error(
+      '@treecrdt/sqlite-node storage must use object options, e.g. { type: "memory" } or { type: "file", filename }',
+    );
+  }
+  if (storage.type === 'memory') return storage;
+  if (storage.type === 'file') {
+    if (!storage.filename) {
+      throw new Error('@treecrdt/sqlite-node file storage requires a filename');
+    }
+    return storage;
+  }
+  throw new Error('@treecrdt/sqlite-node storage.type must be "memory" or "file"');
+}
+
+async function removeSqliteFiles(filename: string): Promise<void> {
+  await Promise.all(
+    SQLITE_FILE_SUFFIXES.map((suffix) => fs.rm(`${filename}${suffix}`, { force: true })),
+  );
 }
 
 /**
- * High-level engine API (matches `@treecrdt/wa-sqlite` client shape).
+ * Managed Node runtime entrypoint for native SQLite.
  *
- * This is the recommended surface for applications: it exposes local op minting via the SQLite
- * extension UDFs and typed reads (decoded ops/opRefs/tree rows).
+ * This mirrors the runtime/storage matrix used by `@treecrdt/wa-sqlite`, but keeps the native
+ * Node package explicit: direct runtime only, backed by either an in-memory or file database.
  */
-export function createTreecrdtClient(
+export async function createTreecrdtClient(
+  opts: SqliteNodeClientOptions = {},
+): Promise<SqliteNodeClient> {
+  normalizeManagedRuntime(opts);
+  const storage = normalizeManagedStorage(opts);
+  // Keep teardown bound to the file that was opened even if the process changes cwd later.
+  const filename = storage.type === 'file' ? path.resolve(storage.filename) : ':memory:';
+
+  if (storage.type === 'file') {
+    await fs.mkdir(path.dirname(filename), { recursive: true });
+  }
+
+  const Database = await loadDatabaseCtor();
+  const db = new Database(filename);
+  let client: TreecrdtSqliteNodeDatabaseClient;
+  try {
+    loadTreecrdtExtension(db, opts.extension);
+    client = await createTreecrdtClientFromDatabase(db, { docId: opts.docId });
+  } catch (err) {
+    try {
+      db.close();
+    } catch {
+      // Preserve the initialization failure.
+    }
+    throw err;
+  }
+
+  let closePromise: Promise<void> | null = null;
+  const close = () => (closePromise ??= client.close());
+  let dropPromise: Promise<void> | null = null;
+  const drop = () =>
+    (dropPromise ??= (async () => {
+      await close();
+      if (storage.type === 'file') await removeSqliteFiles(filename);
+    })());
+
+  return {
+    ...client,
+    runtime: 'direct',
+    storage: storage.type,
+    filename,
+    close,
+    drop,
+  };
+}
+
+/**
+ * Wrap an existing better-sqlite3 Database in the TreeCRDT engine API.
+ */
+export function createTreecrdtClientFromDatabase(
   db: any,
-  opts: { docId?: string; maxBulkOps?: number } = {},
-): Promise<TreecrdtEngine & { runner: SqliteRunner; auth: TreecrdtSqliteAuthApi }> {
+  opts: { docId?: string } = {},
+): Promise<TreecrdtSqliteNodeDatabaseClient> {
   const runner = createRunner(db);
   const materialized = createMaterializationDispatcher();
   const adapter = createTreecrdtSqliteAdapter(runner, {
-    maxBulkOps: opts.maxBulkOps,
     onMaterialized: materialized.emitEvent,
   });
   const docId = opts.docId ?? 'treecrdt';

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -1,17 +1,13 @@
 import { expect, test, vi } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import {
   conformanceSlugify,
   runTreecrdtEngineConformanceScenario,
   treecrdtEngineConformanceScenarios,
 } from '@treecrdt/engine-conformance';
-import {
-  createTreecrdtClient,
-  defaultExtensionPath,
-  loadTreecrdtExtension,
-} from '../dist/index.js';
+import { createTreecrdtClient, type SqliteNodeClient } from '../dist/index.js';
 
 const root = '0'.repeat(32);
 const replica = Uint8Array.from({ length: 32 }, (_, i) => (i === 31 ? 1 : 0));
@@ -21,15 +17,10 @@ function nodeIdFromInt(n: number): string {
 }
 
 async function createNodeEngine(opts: { docId: string; path?: string }) {
-  const { default: Database } = await import('better-sqlite3').catch((err) => {
-    throw new Error(
-      `better-sqlite3 native binding not available; ensure it is installed/built before running native tests: ${err}`,
-    );
+  return await createTreecrdtClient({
+    docId: opts.docId,
+    storage: opts.path ? { type: 'file', filename: opts.path } : { type: 'memory' },
   });
-
-  const db = new Database(opts.path ?? ':memory:');
-  loadTreecrdtExtension(db, { extensionPath: defaultExtensionPath() });
-  return await createTreecrdtClient(db, { docId: opts.docId });
 }
 
 test('conformance registry includes materialization-event scenarios', () => {
@@ -38,6 +29,85 @@ test('conformance registry includes materialization-event scenarios', () => {
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
   expect(names).toContain('local ops: materialization changes include writeId');
+});
+
+test('sqlite-node managed client defaults to direct in-memory storage', async () => {
+  const client = await createTreecrdtClient({ docId: 'sqlite-node-managed-memory' });
+  const node = nodeIdFromInt(1);
+
+  try {
+    expect(client.mode).toBe('node');
+    expect(client.runtime).toBe('direct');
+    expect(client.storage).toBe('memory');
+    expect(client.filename).toBe(':memory:');
+
+    await client.local.insert(replica, root, node, { type: 'last' }, null);
+    expect(await client.tree.exists(node)).toBe(true);
+
+    await client.close();
+    await client.close();
+  } finally {
+    await client.drop();
+  }
+});
+
+test('sqlite-node managed client reopens and drops file storage', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'treecrdt-node-managed-file-'));
+  const filename = join(dir, 'treecrdt.sqlite');
+  const relativeFilename = relative(process.cwd(), filename);
+  const node = nodeIdFromInt(2);
+  let reopened: SqliteNodeClient | null = null;
+
+  try {
+    const client = await createTreecrdtClient({
+      docId: 'sqlite-node-managed-file',
+      storage: { type: 'file', filename: relativeFilename },
+    });
+
+    try {
+      expect(client.runtime).toBe('direct');
+      expect(client.storage).toBe('file');
+      expect(client.filename).toBe(resolve(relativeFilename));
+      await client.local.insert(replica, root, node, { type: 'last' }, null);
+    } finally {
+      await client.close();
+    }
+
+    reopened = await createTreecrdtClient({
+      docId: 'sqlite-node-managed-file',
+      storage: { type: 'file', filename },
+    });
+    expect(await reopened.tree.exists(node)).toBe(true);
+
+    await reopened.drop();
+    reopened = null;
+    expect(existsSync(filename)).toBe(false);
+  } finally {
+    await reopened?.drop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('sqlite-node managed client closes the database when initialization fails', async () => {
+  const { default: Database } = await import('better-sqlite3');
+  const close = vi.spyOn(Database.prototype, 'close');
+
+  try {
+    await expect(
+      createTreecrdtClient({
+        extension: { extensionPath: '/missing/treecrdt-extension' },
+      }),
+    ).rejects.toThrow();
+    expect(close).toHaveBeenCalledOnce();
+  } finally {
+    close.mockRestore();
+  }
+});
+
+test('sqlite-node managed client rejects unsupported runtime options', async () => {
+  await expect(
+    createTreecrdtClient({ runtime: { type: 'dedicated-worker' } as any }),
+  ).rejects.toThrow('@treecrdt/sqlite-node only supports runtime');
 });
 
 test('sqlite auth-aware local write rolls back on auth failure', async () => {

--- a/packages/treecrdt-sqlite-node/tests/sync-backend.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/sync-backend.test.ts
@@ -6,42 +6,26 @@ import { join } from 'node:path';
 import { defineSyncBackendContract } from '../../sync-protocol/protocol/tests/helpers/sync-backend-contract.ts';
 import { createTreecrdtSyncBackendFromClient } from '../../sync-protocol/material/sqlite/dist/backend.js';
 
-import {
-  createTreecrdtClient,
-  defaultExtensionPath,
-  loadTreecrdtExtension,
-} from '../dist/index.js';
-
-async function loadDatabaseCtor() {
-  return (
-    await import('better-sqlite3').catch((err) => {
-      throw new Error(
-        `better-sqlite3 native binding not available; ensure it is installed/built before running native tests: ${err}`,
-      );
-    })
-  ).default;
-}
+import { createTreecrdtClient, type SqliteNodeClient } from '../dist/index.js';
 
 describe('sqlite-node sync backend contract', () => {
   defineSyncBackendContract('sqlite-node sync backend', async () => {
-    const Database = await loadDatabaseCtor();
     const dir = mkdtempSync(join(tmpdir(), 'treecrdt-node-sync-backend-'));
     const dbPath = join(dir, 'backend.sqlite');
-    const dbs: Array<{ close: () => void }> = [];
+    const clients: SqliteNodeClient[] = [];
 
     return {
       supportsDocIsolationAcrossOpen: false,
       openBackend: async (docId) => {
-        const db = new Database(dbPath);
-        dbs.push(db);
-        loadTreecrdtExtension(db, { extensionPath: defaultExtensionPath() });
-        return createTreecrdtSyncBackendFromClient(
-          await createTreecrdtClient(db, { docId }),
+        const client = await createTreecrdtClient({
           docId,
-        );
+          storage: { type: 'file', filename: dbPath },
+        });
+        clients.push(client);
+        return createTreecrdtSyncBackendFromClient(client, docId);
       },
       close: async () => {
-        for (const db of dbs) db.close();
+        for (const client of clients) await client.close();
         rmSync(dir, { recursive: true, force: true });
       },
     };


### PR DESCRIPTION
## What this does

Adds a managed `@treecrdt/sqlite-node` constructor with the same explicit runtime/storage shape used by the browser client:

- `runtime: { type: "direct" }`
- `storage: { type: "memory" }`
- `storage: { type: "file", filename }`

`createTreecrdtClient()` now owns opening, extension loading, closing, and optional file deletion. Callers that already own a `better-sqlite3` database use the explicit `createTreecrdtClientFromDatabase()` helper.

The package is still private. Publishing and release automation remain in the separate follow-up PR #170.

## Lifecycle guarantees

- Memory is the default and opens directly without filesystem work.
- File parent directories are created when needed.
- Relative file paths are resolved once at open time, so a later `process.chdir()` cannot make `drop()` delete a different path.
- Failed extension loading or TreeCRDT initialization closes the database before rethrowing the original error.
- Concurrent/repeated `close()` and `drop()` calls share one promise.
- `close()` preserves file storage; `drop()` closes first, then removes the database and SQLite sidecars.

## Clean API change

The old private-package overload `createTreecrdtClient(db)` is renamed to `createTreecrdtClientFromDatabase(db)`. There is no compatibility overload or deprecated alias. The sqlite-node API also drops the obsolete `maxBulkOps` option instead of carrying it into the new constructors.

## Debloat

The diff stays within sqlite-node: one implementation file, two test files, and two benchmark call-site updates. Publishing metadata, release workflows, and native artifact packaging are not included.

## Validation

- sqlite-node conformance: 34/34
- sync backend contract: 4/4
- TypeScript build
- one-iteration note-path benchmark smoke test from the original branch
