### PR TITLE
chore(sqlite-node): add verified native publishing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,6 @@
     "@treecrdt/engine-conformance",
     "@treecrdt/playground",
     "@treecrdt/postgres-napi",
-    "@treecrdt/sqlite-node",
     "@treecrdt/wa-sqlite-demo",
     "@treecrdt/wa-sqlite-vendor",
     "@treecrdt/wasm"

--- a/.changeset/fuzzy-pumpkins-share.md
+++ b/.changeset/fuzzy-pumpkins-share.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/sqlite-node': patch
+---
+
+Publish the native SQLite Node package with smoke-tested Linux, macOS, and Windows artifacts.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,24 +4,165 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      - .github/workflows/release.yml
+      - Cargo.lock
+      - Cargo.toml
+      - package.json
+      - pnpm-lock.yaml
+      - pnpm-workspace.yaml
+      - packages/treecrdt-core/**
+      - packages/treecrdt-sqlite-ext/**
+      - packages/treecrdt-sqlite-node/**
+      - scripts/repo-root.mjs
 
 permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+  contents: read
 
 concurrency:
-  group: release-main
-  cancel-in-progress: false
+  group: release-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   EM_VERSION: 4.0.21
   EM_CACHE_FOLDER: emsdk-cache
+  BETTER_SQLITE3_CURRENT: 12.11.1
 
 jobs:
+  release-plan:
+    name: Plan native release
+    runs-on: ubuntu-latest
+    outputs:
+      build_sqlite_node: ${{ steps.sqlite_node.outputs.build }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Check whether sqlite-node will publish
+        id: sqlite_node
+        shell: bash
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == 'pull_request' ]]; then
+            build=true
+            reason='pull request preflight requires the native artifact matrix'
+          else
+            version=$(node -p "require('./packages/treecrdt-sqlite-node/package.json').version")
+            # Changesets versions first and publishes only after the version PR lands.
+            if find .changeset -maxdepth 1 -type f -name '*.md' -print -quit | grep -q .; then
+              build=false
+              reason='pending changesets will create or update the version PR'
+            elif npm view "@treecrdt/sqlite-node@$version" version >/dev/null 2>&1; then
+              build=false
+              reason="@treecrdt/sqlite-node@$version is already published"
+            else
+              build=true
+              reason="@treecrdt/sqlite-node@$version needs native release artifacts"
+            fi
+          fi
+          echo "build=$build" >> "$GITHUB_OUTPUT"
+          echo "$reason"
+
+  sqlite-node-native:
+    name: Build sqlite-node (${{ matrix.triple }})
+    needs: release-plan
+    if: needs.release-plan.outputs.build_sqlite_node == 'true'
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            triple: x86_64-unknown-linux-gnu
+            file: libtreecrdt_sqlite_ext-linux-x64.so
+          - os: macos-26
+            triple: aarch64-apple-darwin
+            file: libtreecrdt_sqlite_ext-darwin-arm64.dylib
+          - os: macos-15-intel
+            triple: x86_64-apple-darwin
+            file: libtreecrdt_sqlite_ext-darwin-x64.dylib
+          - os: windows-2025
+            triple: x86_64-pc-windows-msvc
+            file: treecrdt_sqlite_ext-win32-x64.dll
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.26.1
+
+      - name: Install sqlite-node dependencies
+        run: pnpm install --frozen-lockfile --filter @treecrdt/sqlite-node
+
+      - name: Verify native target
+        shell: bash
+        run: |
+          test "$(rustc -vV | sed -n 's/^host: //p')" = "${{ matrix.triple }}"
+
+      - name: Build native SQLite extension
+        shell: bash
+        run: cargo rustc -p treecrdt-sqlite-ext --release --no-default-features --features "ext-sqlite rusqlite-storage" -- --crate-type=cdylib
+
+      - name: Copy native SQLite extension
+        run: node packages/treecrdt-sqlite-node/scripts/copy-ext.mjs
+
+      - name: Smoke test with better-sqlite3 9
+        run: node packages/treecrdt-sqlite-node/scripts/smoke-native.mjs "packages/treecrdt-sqlite-node/native/${{ matrix.file }}"
+
+      - name: Setup current Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Smoke test with current better-sqlite3
+        shell: bash
+        run: |
+          current_dir="$RUNNER_TEMP/better-sqlite3-current"
+          npm install --prefix "$current_dir" --no-save --no-package-lock "better-sqlite3@$BETTER_SQLITE3_CURRENT"
+          node packages/treecrdt-sqlite-node/scripts/smoke-native.mjs \
+            "packages/treecrdt-sqlite-node/native/${{ matrix.file }}" "$current_dir"
+
+      - name: Upload native SQLite extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: sqlite-node-native-${{ matrix.triple }}
+          path: packages/treecrdt-sqlite-node/native/${{ matrix.file }}
+          if-no-files-found: error
+          retention-days: 1
+
   release:
     name: Version or Publish
     runs-on: ubuntu-latest
+    needs: [release-plan, sqlite-node-native]
+    if: >-
+      ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      needs.release-plan.result == 'success' &&
+      (needs.sqlite-node-native.result == 'success' || needs.sqlite-node-native.result == 'skipped') }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -85,6 +226,14 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Download sqlite-node native artifacts
+        if: needs.release-plan.outputs.build_sqlite_node == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sqlite-node-native-*
+          path: packages/treecrdt-sqlite-node/native
+          merge-multiple: true
 
       - name: Setup Emscripten cache
         uses: actions/cache@v4

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "sync-server:postgres:db:stop": "node scripts/run-sync-server-postgres-db-stop.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only",
-    "build:publish": "pnpm --filter @treecrdt/wa-sqlite-vendor run build && pnpm --filter @treecrdt/wa-sqlite... --filter @treecrdt/sync... --filter @treecrdt/sync-server-postgres-node... --filter @treecrdt/discovery-server-node... run build",
+    "build:publish": "pnpm --filter @treecrdt/wa-sqlite-vendor run build && pnpm --filter @treecrdt/wa-sqlite... --filter @treecrdt/sync... --filter @treecrdt/sync-server-postgres-node... --filter @treecrdt/discovery-server-node... run build && pnpm --filter @treecrdt/sqlite-node run build:publish",
     "release": "pnpm run build:publish && changeset publish && node scripts/set-npm-public-access.mjs"
   },
   "devDependencies": {

--- a/packages/treecrdt-sqlite-node/README.md
+++ b/packages/treecrdt-sqlite-node/README.md
@@ -1,0 +1,47 @@
+# @treecrdt/sqlite-node
+
+Native Node.js SQLite runtime for TreeCRDT.
+
+This package wraps `better-sqlite3` and loads the TreeCRDT SQLite extension for direct Node
+process usage. Use `@treecrdt/wa-sqlite` when you need a browser or WASM-only runtime.
+
+```ts
+import { createTreecrdtClient, loadTreecrdtExtension } from '@treecrdt/sqlite-node';
+
+const client = await createTreecrdtClient({
+  runtime: { type: 'direct' },
+  storage: { type: 'memory' },
+  docId: 'scratch-doc',
+});
+
+await client.close();
+```
+
+File-backed storage uses the same direct native runtime:
+
+```ts
+const client = await createTreecrdtClient({
+  storage: { type: 'file', filename: './treecrdt.sqlite' },
+  docId: 'app-doc',
+});
+```
+
+The package expects a bundled native extension for the current `process.platform` and
+`process.arch`. Published packages support:
+
+- `x86_64-unknown-linux-gnu`
+- `aarch64-apple-darwin`
+- `x86_64-apple-darwin`
+- `x86_64-pc-windows-msvc`
+
+Each artifact is smoke-tested with the oldest and newest supported `better-sqlite3` major before
+it is published. Other targets can provide their own extension build:
+
+```ts
+const client = await createTreecrdtClient({
+  extension: { extensionPath: '/path/to/treecrdt_sqlite_ext' },
+});
+
+// For an existing better-sqlite3 Database:
+loadTreecrdtExtension(db, { extensionPath: '/path/to/treecrdt_sqlite_ext' });
+```

--- a/packages/treecrdt-sqlite-node/package.json
+++ b/packages/treecrdt-sqlite-node/package.json
@@ -1,10 +1,15 @@
 {
   "name": "@treecrdt/sqlite-node",
   "version": "0.0.1",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "native"
@@ -12,7 +17,10 @@
   "scripts": {
     "build:native-ext": "cd ../.. && pnpm run build:ext:native",
     "copy:ext": "node ./scripts/copy-ext.mjs",
+    "prepack": "node ./scripts/verify-package.mjs",
+    "verify:package:current": "node ./scripts/verify-package.mjs --current",
     "build:ts": "tsc -p tsconfig.json",
+    "build:publish": "pnpm run build:ts",
     "build": "pnpm run build:native-ext && pnpm run copy:ext && pnpm run build:ts",
     "test": "pnpm -C ../sync-protocol/protocol run build && pnpm -C ../sync-protocol/material/sqlite run build && pnpm run build && vitest run",
     "benchmark:ops": "pnpm -C ../sync-protocol/protocol run build && pnpm -C ../sync-protocol/material/sqlite run build && pnpm run build && tsx ./scripts/bench.ts",
@@ -21,7 +29,7 @@
     "benchmark": "pnpm run benchmark:ops && pnpm run benchmark:note-paths && pnpm run benchmark:sync"
   },
   "peerDependencies": {
-    "better-sqlite3": "^9.0.0"
+    "better-sqlite3": ">=9 <13"
   },
   "dependencies": {
     "@treecrdt/interface": "workspace:*",
@@ -47,5 +55,18 @@
     "typescript": "^5.9.3",
     "vitest": "^1.6.0",
     "ws": "^8.18.3"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cybersemics/treecrdt.git",
+    "directory": "packages/treecrdt-sqlite-node"
+  },
+  "bugs": {
+    "url": "https://github.com/cybersemics/treecrdt/issues"
+  },
+  "homepage": "https://github.com/cybersemics/treecrdt#readme",
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/treecrdt-sqlite-node/scripts/copy-ext.mjs
+++ b/packages/treecrdt-sqlite-node/scripts/copy-ext.mjs
@@ -55,15 +55,10 @@ const src = candidates[0].fullPath;
 const destDir = path.resolve(scriptDir, "../native");
 fs.mkdirSync(destDir, { recursive: true });
 const destBase = ext === ".dll" ? "treecrdt_sqlite_ext" : "libtreecrdt_sqlite_ext";
-const dest = path.join(destDir, `${destBase}${ext}`);
+const dest = path.join(destDir, `${destBase}-${process.platform}-${process.arch}${ext}`);
+const legacyDest = path.join(destDir, `${destBase}${ext}`);
 
-try {
-  if (fs.existsSync(dest)) fs.rmSync(dest, { force: true });
-  const rel = path.relative(destDir, src);
-  fs.symlinkSync(rel, dest, "file");
-  console.log(`Linked ${dest} -> ${src}`);
-} catch (err) {
-  console.warn(`Failed to create symlink, falling back to copy: ${err}`);
-  fs.copyFileSync(src, dest);
-  console.log(`Copied ${src} -> ${dest}`);
-}
+if (fs.existsSync(dest)) fs.rmSync(dest, { force: true });
+if (legacyDest !== dest && fs.existsSync(legacyDest)) fs.rmSync(legacyDest, { force: true });
+fs.copyFileSync(src, dest);
+console.log(`Copied ${src} -> ${dest}`);

--- a/packages/treecrdt-sqlite-node/scripts/smoke-native.mjs
+++ b/packages/treecrdt-sqlite-node/scripts/smoke-native.mjs
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { dirnameFromImportMeta } from '../../../scripts/repo-root.mjs';
+
+const scriptDir = dirnameFromImportMeta(import.meta.url);
+const packageRoot = path.resolve(scriptDir, '..');
+const extensionArg = process.argv[2];
+const moduleRoot = path.resolve(process.argv[3] ?? packageRoot);
+
+if (!extensionArg) {
+  throw new Error('Usage: node smoke-native.mjs <extension-path> [better-sqlite3-module-root]');
+}
+
+const extensionPath = path.resolve(extensionArg);
+const require = createRequire(path.join(moduleRoot, 'package.json'));
+const Database = require('better-sqlite3');
+const db = new Database(':memory:');
+
+try {
+  db.loadExtension(extensionPath, 'sqlite3_treecrdt_init');
+  const row = db.prepare('SELECT treecrdt_version() AS version').get();
+  if (typeof row?.version !== 'string' || row.version.length === 0) {
+    throw new Error('treecrdt_version() did not return a version string');
+  }
+  console.log(`Loaded ${path.basename(extensionPath)} (TreeCRDT ${row.version})`);
+} finally {
+  db.close();
+}

--- a/packages/treecrdt-sqlite-node/scripts/verify-package.mjs
+++ b/packages/treecrdt-sqlite-node/scripts/verify-package.mjs
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { dirnameFromImportMeta } from '../../../scripts/repo-root.mjs';
+
+const scriptDir = dirnameFromImportMeta(import.meta.url);
+const packageRoot = path.resolve(scriptDir, '..');
+const nativeDir = path.join(packageRoot, 'native');
+const supportedArtifacts = new Map([
+  ['x86_64-unknown-linux-gnu', 'libtreecrdt_sqlite_ext-linux-x64.so'],
+  ['aarch64-apple-darwin', 'libtreecrdt_sqlite_ext-darwin-arm64.dylib'],
+  ['x86_64-apple-darwin', 'libtreecrdt_sqlite_ext-darwin-x64.dylib'],
+  ['x86_64-pc-windows-msvc', 'treecrdt_sqlite_ext-win32-x64.dll'],
+]);
+
+function currentNativeFile() {
+  const ext =
+    process.platform === 'darwin' ? '.dylib' : process.platform === 'win32' ? '.dll' : '.so';
+  const base = ext === '.dll' ? 'treecrdt_sqlite_ext' : 'libtreecrdt_sqlite_ext';
+  return `${base}-${process.platform}-${process.arch}${ext}`;
+}
+
+function requireFile(file, message) {
+  if (!fs.existsSync(file)) {
+    throw new Error(`${message}: ${path.relative(packageRoot, file)}`);
+  }
+
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile()) {
+    throw new Error(`Expected a regular file: ${path.relative(packageRoot, file)}`);
+  }
+
+  if (stat.size === 0) {
+    throw new Error(`Expected a non-empty file: ${path.relative(packageRoot, file)}`);
+  }
+}
+
+requireFile(path.join(packageRoot, 'dist', 'index.js'), 'Missing built JavaScript');
+requireFile(path.join(packageRoot, 'dist', 'index.d.ts'), 'Missing built TypeScript declarations');
+
+const currentOnly = process.argv.includes('--current');
+const expectedArtifacts = currentOnly
+  ? [...supportedArtifacts].filter(([, file]) => file === currentNativeFile())
+  : supportedArtifacts;
+
+if (expectedArtifacts.length === 0) {
+  throw new Error(`Unsupported native target: ${process.platform}/${process.arch}`);
+}
+
+for (const [triple, file] of expectedArtifacts) {
+  requireFile(path.join(nativeDir, file), `Missing TreeCRDT SQLite artifact for ${triple}`);
+}
+
+if (!currentOnly) {
+  const supportedFiles = new Set(supportedArtifacts.values());
+  const unexpectedFiles = fs
+    .readdirSync(nativeDir, { withFileTypes: true })
+    .filter((entry) => !supportedFiles.has(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  if (unexpectedFiles.length > 0) {
+    throw new Error(`Unexpected native package artifacts: ${unexpectedFiles.join(', ')}`);
+  }
+}
+
+console.log(
+  `Verified @treecrdt/sqlite-node ${currentOnly ? 'current-platform' : 'release'} artifacts`,
+);

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -68,8 +69,8 @@ export type SqliteNodeClient = Omit<TreecrdtSqliteNodeDatabaseClient, 'storage'>
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SQLITE_FILE_SUFFIXES = ['', '-journal', '-wal', '-shm'];
 
-function platformExt(): '.dylib' | '.so' | '.dll' {
-  switch (process.platform) {
+function platformExt(platform = process.platform): '.dylib' | '.so' | '.dll' {
+  switch (platform) {
     case 'darwin':
       return '.dylib';
     case 'win32':
@@ -79,14 +80,18 @@ function platformExt(): '.dylib' | '.so' | '.dll' {
   }
 }
 
+function nativeExtensionFileName(platform = process.platform, arch = process.arch): string {
+  const ext = platformExt(platform);
+  const base = ext === '.dll' ? 'treecrdt_sqlite_ext' : 'libtreecrdt_sqlite_ext';
+  return `${base}-${platform}-${arch}${ext}`;
+}
+
 /**
  * Resolve the bundled TreeCRDT SQLite extension for this platform.
  * Falls back to the `native/` directory within this package.
  */
 export function defaultExtensionPath(): string {
-  const ext = platformExt();
-  const base = ext === '.dll' ? 'treecrdt_sqlite_ext' : 'libtreecrdt_sqlite_ext';
-  return path.resolve(__dirname, '../native', `${base}${ext}`);
+  return path.resolve(__dirname, '../native', nativeExtensionFileName());
 }
 
 /**
@@ -95,6 +100,11 @@ export function defaultExtensionPath(): string {
 export function loadTreecrdtExtension(db: LoadableDatabase, opts: LoadOptions = {}): string {
   const path = opts.extensionPath ?? defaultExtensionPath();
   const entrypoint = opts.entrypoint ?? 'sqlite3_treecrdt_init';
+  if (!existsSync(path)) {
+    throw new Error(
+      `TreeCRDT SQLite native extension not found at ${path}. This package may not include a native artifact for ${process.platform}/${process.arch}; install a supported package version or pass a custom extensionPath.`,
+    );
+  }
   db.loadExtension(path, entrypoint);
   return path;
 }


### PR DESCRIPTION
## What this does

Makes `@treecrdt/sqlite-node` publishable with a fail-closed native release pipeline.

The managed runtime API itself is in #169. This PR contains only npm metadata, package documentation, native artifact naming/verification, and release automation.

## Supported native targets

- Linux GNU x64 (`ubuntu-24.04`)
- macOS arm64 (`macos-26`)
- macOS Intel x64 (`macos-15-intel`)
- Windows MSVC x64 (`windows-2025`)

Every matrix job verifies its Rust host triple, builds and copies one regular platform-qualified library, loads it through `better-sqlite3`, and queries `treecrdt_version()` before upload.

Artifacts are smoke-tested with the locked `better-sqlite3` 9 / Node 20 combination and current `better-sqlite3` 12.11.1 / Node 24. The peer range is `>=9 <13`.

## Pre-merge and publish safety

- A path-filtered pull-request preflight runs all four native builders before merge.
- PR jobs have read-only contents permission, no OIDC, no publishing secrets, and cannot run Changesets version/publish.
- `prepack` requires built JS/declarations and all four exact, nonempty regular native files.
- Unexpected native files fail verification.
- The npm tarball contains only README, package metadata, `dist`, and the four native libraries—no source, scripts, or build tree.
- Unsupported platforms fail with a clear custom-extension-path error.
- Custom builds use `extension: { extensionPath }`, or `loadTreecrdtExtension(db, { extensionPath })` for caller-owned databases.

## Release fast path

On main, a small plan job skips all four native builders while pending Changesets are only creating/updating the Version Packages PR, and skips them when the current sqlite-node version is already published. On a version-PR merge with an unpublished sqlite-node version, the matrix runs before Changesets publish.

The publish job downloads those artifacts and builds sqlite-node TypeScript only; it no longer recompiles a redundant fifth Linux binary. Changesets still owns version PRs, publishing, tags, and GitHub releases.

## Debloat

- Removes unexported `src` from the package tarball.
- No native binaries are committed to Git.
- Release-only checks live in two small scripts instead of production code.
- Incremental review: 10 files, +346/-25.

## Validation

- sqlite-node tests: 38/38
- Native Rust release build
- TypeScript/dependency builds
- Local arm64 load/query smoke with better-sqlite3 9.6 and 12.11.1
- Current-platform and full-matrix structural verification
- `npm pack` contents verified
- YAML, permissions/condition simulations, Prettier, and diff checks

## Draft status

Keep draft until this PR's GitHub preflight validates the real Linux, macOS arm64, macOS Intel, and Windows artifacts. Each builder fails before upload, and prepack fails before publish, if any artifact is invalid or missing.

## Dependency

Stacked on the mirror of #169. Review only this release/package delta.
