### PR TITLE
Fix wa-sqlite cross-realm blob binding

### DIFF
--- a/.changeset/wa-sqlite-cross-realm-bind.md
+++ b/.changeset/wa-sqlite-cross-realm-bind.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Normalize cross-realm typed arrays before binding wa-sqlite blob parameters.

--- a/packages/treecrdt-wa-sqlite/src/db.ts
+++ b/packages/treecrdt-wa-sqlite/src/db.ts
@@ -1,5 +1,14 @@
 import type { Database } from './types.js';
 
+function normalizeBindValue(value: unknown): unknown {
+  if (ArrayBuffer.isView(value)) {
+    const view = value as ArrayBufferView;
+    return new Uint8Array(view.buffer, view.byteOffset, view.byteLength);
+  }
+
+  return value;
+}
+
 export function makeDbAdapter(sqlite3: any, handle: number): Database {
   const prepare = async (sql: string) => {
     const iter = sqlite3.statements(handle, sql, { unscoped: true });
@@ -13,7 +22,8 @@ export function makeDbAdapter(sqlite3: any, handle: number): Database {
 
   return {
     prepare,
-    bind: async (stmt: number, index: number, value: unknown) => sqlite3.bind(stmt, index, value),
+    bind: async (stmt: number, index: number, value: unknown) =>
+      sqlite3.bind(stmt, index, normalizeBindValue(value)),
     step: async (stmt: number) => sqlite3.step(stmt),
     column_text: async (stmt: number, index: number) => sqlite3.column_text(stmt, index),
     finalize: async (stmt: number) => sqlite3.finalize(stmt),

--- a/packages/treecrdt-wa-sqlite/tests/db-bind.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/db-bind.test.ts
@@ -1,0 +1,32 @@
+import vm from 'node:vm';
+import { expect, test } from 'vitest';
+import { makeDbAdapter } from '../src/db.js';
+
+test('makeDbAdapter normalizes cross-realm typed array bind values to blobs', async () => {
+  const foreignBytes = vm.runInNewContext('new Uint8Array([1, 2, 3])') as Uint8Array;
+  let bound: unknown;
+
+  const db = makeDbAdapter(
+    {
+      bind: (_stmt: number, _index: number, value: unknown) => {
+        bound = value;
+      },
+      statements: () => ({
+        next: async () => ({ value: 1 }),
+        return: async () => undefined,
+      }),
+      step: async () => 101,
+      column_text: async () => '',
+      finalize: async () => undefined,
+      exec: async () => undefined,
+      close: async () => undefined,
+    },
+    1,
+  );
+
+  await db.bind(1, 1, foreignBytes);
+
+  expect(foreignBytes).not.toBeInstanceOf(Uint8Array);
+  expect(bound).toBeInstanceOf(Uint8Array);
+  expect(Array.from(bound as Uint8Array)).toEqual([1, 2, 3]);
+});

--- a/packages/treecrdt-wa-sqlite/tests/node-client.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/node-client.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from 'vitest';
+import vm from 'node:vm';
 import {
   runTreecrdtEngineConformanceScenario,
   treecrdtEngineConformanceScenarios,
@@ -28,6 +29,18 @@ test('createTreecrdtClient smoke: insert and read in Node', async () => {
     await client.local.insert(replica, root, node, { type: 'last' }, null);
     expect(await client.tree.exists(node)).toBe(true);
     expect(await client.ops.all()).toHaveLength(1);
+  } finally {
+    await client.close();
+  }
+});
+
+test('createTreecrdtClient accepts cross-realm typed array payloads in Node', async () => {
+  const client = await createWaEngine({ docId: 'wa-sqlite-node-cross-realm-payload' });
+  const payload = vm.runInNewContext('new Uint8Array([1, 2, 3])') as Uint8Array;
+
+  try {
+    await client.local.payload(replica, root, payload);
+    expect(await client.tree.getPayload(root)).toEqual(Uint8Array.from([1, 2, 3]));
   } finally {
     await client.close();
   }


### PR DESCRIPTION
## Summary

- Normalize `ArrayBufferView` bind values to a same-realm `Uint8Array` before passing them to vendored wa-sqlite.
- Add a focused adapter regression test for cross-realm typed arrays.
- Add a real Node client payload regression test and a patch changeset for `@treecrdt/wa-sqlite`.

## Why

This addresses the failure pattern seen in `Antonov548/em#42`: under Vitest/jsdom/Vite, payload bytes can come from a different JS realm. Vendored wa-sqlite uses `instanceof Uint8Array` when deciding whether to bind a value as a SQLite blob, so a foreign-realm `Uint8Array` can be treated as an unknown value and converted to `NULL`. SQLite then rejects the call with errors like `treecrdt_local_payload: node must be 16-byte BLOB`.

## Conformance coverage

I do not think this is missing generic engine-conformance coverage. The existing conformance suite checks TreeCRDT engine behavior after the adapter is working. This bug sits below that, at the JS host/adapter binding boundary. The PR adds wa-sqlite-specific coverage there instead.

## Test plan

- `pnpm -C packages/treecrdt-wa-sqlite run test`
