### PR TITLE
Add local undo capture helpers

### DIFF
--- a/.changeset/tall-planes-undo.md
+++ b/.changeset/tall-planes-undo.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/interface': minor
+---
+
+Add `@treecrdt/interface/edits` helpers for capturing, undoing, and redoing local edits.

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1,5 +1,6 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
+import { edits } from '@treecrdt/interface/edits';
 import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 
@@ -139,6 +140,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
     {
       name: 'local ops: materialization changes include writeId',
       run: scenarioLocalOpsMaterializationWriteId,
+    },
+    {
+      name: 'local undo: capture/apply supports undo and redo',
+      run: scenarioLocalUndoCaptureApply,
     },
     {
       name: 'append/appendMany: idempotent + headLamport monotonic',
@@ -629,6 +634,86 @@ async function scenarioLocalOpsMaterializationWriteId(
     'bound local insert',
   );
   assertChangeSource(boundInsertEvents[0]!, boundNode, boundInsertOp!, 'bound local insert');
+}
+
+async function scenarioLocalUndoCaptureApply(ctx: TreecrdtEngineConformanceContext): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parentA = nodeIdFromInt(51);
+  const parentB = nodeIdFromInt(52);
+  const sibling = nodeIdFromInt(53);
+  const node = nodeIdFromInt(54);
+  const inserted = nodeIdFromInt(55);
+  const originalPayload = new TextEncoder().encode('original-payload');
+  const nextPayload = new TextEncoder().encode('next-payload');
+  const insertedPayload = new TextEncoder().encode('inserted-payload');
+
+  await engine.local.insert(replica, root, parentA, { type: 'last' }, null);
+  await engine.local.insert(replica, root, parentB, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, sibling, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, node, { type: 'last' }, originalPayload);
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'initial parentA');
+
+  const captured = await edits.capture(engine, replica, async (local) => {
+    const move = await local.move(node, parentB, { type: 'last' });
+    const payload = await local.payload(node, nextPayload);
+    return [move, payload];
+  });
+  assertEqual(captured.operations.length, 2, 'captured operation count');
+  assertEqual(captured.undo.actions.length, 2, 'captured undo action count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling], 'parentA after captured move');
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'parentB after captured move');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after captured write');
+
+  const undone = await edits.undo(engine, replica, captured);
+  assertEqual(undone.operations.length, 2, 'undo operation count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'parentA after undo');
+  assertArrayEqual(await engine.tree.children(parentB), [], 'parentB after undo');
+  assertBytesEqual(await engine.tree.getPayload(node), originalPayload, 'payload after undo');
+
+  const redone = await edits.redo(engine, replica, undone);
+  assertEqual(redone.operations.length, 2, 'redo operation count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling], 'parentA after redo');
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'parentB after redo');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after redo');
+
+  const insertCapture = await edits.capture(engine, replica, async (local) =>
+    local.insert(parentB, inserted, { type: 'last' }, insertedPayload),
+  );
+  assertEqual(insertCapture.operations.length, 1, 'insert capture operation count');
+  assertEqual(await engine.tree.exists(inserted), true, 'inserted exists before undo');
+
+  const insertUndone = await edits.undo(engine, replica, insertCapture);
+  assertEqual(insertUndone.operations.length, 1, 'insert undo operation count');
+  assertEqual(await engine.tree.exists(inserted), false, 'inserted hidden after undo');
+
+  await edits.redo(engine, replica, insertUndone);
+  assertEqual(await engine.tree.exists(inserted), true, 'inserted restored after redo');
+  assertBytesEqual(
+    await engine.tree.getPayload(inserted),
+    insertedPayload,
+    'inserted payload after redo',
+  );
+  assertArrayEqual(
+    await engine.tree.children(parentB),
+    [node, inserted],
+    'parentB after insert redo',
+  );
+
+  const deleteCapture = await edits.capture(engine, replica, async (local) => local.delete(node));
+  assertEqual(deleteCapture.operations.length, 1, 'delete capture operation count');
+  assertEqual(await engine.tree.exists(node), false, 'node hidden after delete');
+  assertArrayEqual(await engine.tree.children(parentB), [inserted], 'parentB after delete');
+
+  await edits.undo(engine, replica, deleteCapture);
+  assertEqual(await engine.tree.exists(node), true, 'node restored after delete undo');
+  assertArrayEqual(
+    await engine.tree.children(parentB),
+    [node, inserted],
+    'parentB after delete undo',
+  );
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after delete undo');
 }
 
 async function scenarioAppendIdempotentAndHeadLamportMonotonic(

--- a/packages/treecrdt-ts/package.json
+++ b/packages/treecrdt-ts/package.json
@@ -24,6 +24,10 @@
     "./engine": {
       "import": "./dist/src/engine.js",
       "types": "./dist/src/engine.d.ts"
+    },
+    "./edits": {
+      "import": "./dist/src/edits.js",
+      "types": "./dist/src/edits.d.ts"
     }
   },
   "files": [

--- a/packages/treecrdt-ts/src/edits.ts
+++ b/packages/treecrdt-ts/src/edits.ts
@@ -1,0 +1,210 @@
+import type { Operation, ReplicaId } from './index.js';
+import type { TreecrdtSqlitePlacement } from './sqlite.js';
+import type {
+  BoundTreecrdtEngineLocal,
+  LocalWriteOptions,
+  TreecrdtEngineLocal,
+  TreecrdtEngineTree,
+} from './engine.js';
+
+export type DeleteAction = {
+  type: 'delete';
+  node: string;
+};
+
+export type MoveAction = {
+  type: 'move';
+  node: string;
+  parent: string;
+  placement: TreecrdtSqlitePlacement;
+};
+
+export type PayloadAction = {
+  type: 'payload';
+  node: string;
+  payload: Uint8Array | null;
+};
+
+/**
+ * A forward local write that reverses a previously captured local write.
+ *
+ * These are intentionally not oplog rewinds. Applying a plan mints new local ops, so undo/redo
+ * remains mergeable with remote peers.
+ */
+export type Action = DeleteAction | MoveAction | PayloadAction;
+
+export type Plan = {
+  actions: Action[];
+};
+
+export type Target = {
+  tree: TreecrdtEngineTree;
+  local: TreecrdtEngineLocal;
+};
+
+export type Captured<T> = {
+  result: T;
+  operations: Operation[];
+  undo: Plan;
+};
+
+export type Undoable = {
+  undo: Plan;
+};
+
+export type Redoable = {
+  redo: Plan;
+};
+
+export type UndoResult = {
+  operations: Operation[];
+  redo: Plan;
+};
+
+export type RedoResult = {
+  operations: Operation[];
+  undo: Plan;
+};
+
+function cloneBytes(bytes: Uint8Array | null): Uint8Array | null {
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
+async function visiblePlacementBefore(
+  tree: TreecrdtEngineTree,
+  parent: string,
+  node: string,
+): Promise<TreecrdtSqlitePlacement> {
+  const siblings = await tree.children(parent);
+  const index = siblings.indexOf(node);
+  if (index < 0) {
+    throw new Error(`treecrdt: cannot capture undo position for non-visible node ${node}`);
+  }
+  if (index === 0) return { type: 'first' };
+  return { type: 'after', after: siblings[index - 1]! };
+}
+
+async function currentMoveUndoAction(tree: TreecrdtEngineTree, node: string): Promise<Action> {
+  if (!(await tree.exists(node))) return { type: 'delete', node };
+
+  const parent = await tree.parent(node);
+  if (parent === null) {
+    throw new Error(`treecrdt: cannot capture undo parent for root or missing node ${node}`);
+  }
+  return {
+    type: 'move',
+    node,
+    parent,
+    placement: await visiblePlacementBefore(tree, parent, node),
+  };
+}
+
+/**
+ * Capture the inverse of local writes performed through the supplied callback.
+ *
+ * The callback receives a bound local writer. Use that writer for every write that should be part
+ * of the undo plan. The returned plan is ordered for direct application.
+ */
+export async function capture<T>(
+  target: Target,
+  replica: ReplicaId,
+  fn: (local: BoundTreecrdtEngineLocal) => Promise<T>,
+  defaults: LocalWriteOptions = {},
+): Promise<Captured<T>> {
+  const base = target.local.forReplica(replica, defaults);
+  const operations: Operation[] = [];
+  const actions: Action[] = [];
+
+  const record = (op: Operation, action: Action) => {
+    operations.push(op);
+    actions.unshift(action);
+  };
+
+  const local: BoundTreecrdtEngineLocal = {
+    insert: async (parent, node, placement, payload, opts) => {
+      const op = await base.insert(parent, node, placement, payload, opts);
+      record(op, { type: 'delete', node });
+      return op;
+    },
+    move: async (node, newParent, placement, opts) => {
+      const undo = await currentMoveUndoAction(target.tree, node);
+      const op = await base.move(node, newParent, placement, opts);
+      record(op, undo);
+      return op;
+    },
+    delete: async (node, opts) => {
+      const undo = await currentMoveUndoAction(target.tree, node);
+      const op = await base.delete(node, opts);
+      record(op, undo);
+      return op;
+    },
+    payload: async (node, payload, opts) => {
+      const previous = await target.tree.getPayload(node);
+      const op = await base.payload(node, payload, opts);
+      record(op, { type: 'payload', node, payload: cloneBytes(previous) });
+      return op;
+    },
+  };
+
+  const result = await fn(local);
+  return { result, operations, undo: { actions } };
+}
+
+export async function applyToLocal(
+  local: BoundTreecrdtEngineLocal,
+  plan: Plan,
+  opts?: LocalWriteOptions,
+): Promise<Operation[]> {
+  const operations: Operation[] = [];
+  for (const action of plan.actions) {
+    switch (action.type) {
+      case 'delete':
+        operations.push(await local.delete(action.node, opts));
+        break;
+      case 'move':
+        operations.push(await local.move(action.node, action.parent, action.placement, opts));
+        break;
+      case 'payload':
+        operations.push(await local.payload(action.node, cloneBytes(action.payload), opts));
+        break;
+    }
+  }
+  return operations;
+}
+
+export function apply(
+  target: Target,
+  replica: ReplicaId,
+  plan: Plan,
+  opts?: LocalWriteOptions,
+): Promise<Operation[]> {
+  return applyToLocal(target.local.forReplica(replica), plan, opts);
+}
+
+export async function undo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Undoable,
+  opts?: LocalWriteOptions,
+): Promise<UndoResult> {
+  const applied = await capture(target, replica, (local) => applyToLocal(local, edit.undo, opts));
+  return { operations: applied.operations, redo: applied.undo };
+}
+
+export async function redo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Redoable,
+  opts?: LocalWriteOptions,
+): Promise<RedoResult> {
+  const applied = await capture(target, replica, (local) => applyToLocal(local, edit.redo, opts));
+  return { operations: applied.operations, undo: applied.undo };
+}
+
+export const edits = {
+  apply,
+  applyToLocal,
+  capture,
+  redo,
+  undo,
+};


### PR DESCRIPTION
## Summary

Adds a first TreeCRDT-level reversible local edit surface:

- `@treecrdt/interface/edits` exports an `edits` object with `capture`, `undo`, and `redo` helpers.
- `edits.capture` records inverse local actions while the caller performs writes through a bound local writer.
- `edits.undo` applies the captured undo plan by minting new local ops and returns a redo plan.
- `edits.redo` applies a redo plan by minting new local ops and returns a new undo plan.
- Adds shared conformance coverage for move/payload undo, redo, insert undo/redo, and delete restore through forward local writes.

This intentionally does not rewind or mutate the oplog. Undo/redo is modeled as new forward local writes so it remains CRDT-friendly and syncable.

## Example

```ts
import { edits } from '@treecrdt/interface/edits';

const edit = await edits.capture(client, replica, async (local) => {
  await local.move(nodeId, newParentId, { type: 'last' });
  await local.payload(nodeId, new TextEncoder().encode('next payload'));
});

// Undo by appending forward local ops.
const undone = await edits.undo(client, replica, edit);

// Redo by applying the redo plan returned by undo.
const redone = await edits.redo(client, replica, undone);

// The returned objects carry the ops to push to sync and the next inverse plan.
undone.operations;
undone.redo;
redone.operations;
redone.undo;
```

If this API is eventually published, upstream apps like `em` can use it with any runtime that exposes the shared `TreecrdtEngine` surface. It is a useful primitive for provider-level undo metadata, though em still needs app-side plumbing to attach semantic edit plans to its existing Redux undo history.
