### PR TITLE
Add targeted tree placement lookup

### DIFF
--- a/.changeset/tall-planes-undo.md
+++ b/.changeset/tall-planes-undo.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/interface': minor
+---
+
+Add `@treecrdt/interface/edits` helpers for capturing, undoing, and redoing local edits.

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1,5 +1,6 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
+import { edits } from '@treecrdt/interface/edits';
 import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 
@@ -139,6 +140,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
     {
       name: 'local ops: materialization changes include writeId',
       run: scenarioLocalOpsMaterializationWriteId,
+    },
+    {
+      name: 'local undo: capture/apply supports undo and redo',
+      run: scenarioLocalUndoCaptureApply,
     },
     {
       name: 'append/appendMany: idempotent + headLamport monotonic',
@@ -629,6 +634,86 @@ async function scenarioLocalOpsMaterializationWriteId(
     'bound local insert',
   );
   assertChangeSource(boundInsertEvents[0]!, boundNode, boundInsertOp!, 'bound local insert');
+}
+
+async function scenarioLocalUndoCaptureApply(ctx: TreecrdtEngineConformanceContext): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parentA = nodeIdFromInt(51);
+  const parentB = nodeIdFromInt(52);
+  const sibling = nodeIdFromInt(53);
+  const node = nodeIdFromInt(54);
+  const inserted = nodeIdFromInt(55);
+  const originalPayload = new TextEncoder().encode('original-payload');
+  const nextPayload = new TextEncoder().encode('next-payload');
+  const insertedPayload = new TextEncoder().encode('inserted-payload');
+
+  await engine.local.insert(replica, root, parentA, { type: 'last' }, null);
+  await engine.local.insert(replica, root, parentB, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, sibling, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, node, { type: 'last' }, originalPayload);
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'initial parentA');
+
+  const captured = await edits.capture(engine, replica, async (local) => {
+    const move = await local.move(node, parentB, { type: 'last' });
+    const payload = await local.payload(node, nextPayload);
+    return [move, payload];
+  });
+  assertEqual(captured.operations.length, 2, 'captured operation count');
+  assertEqual(captured.undo.actions.length, 2, 'captured undo action count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling], 'parentA after captured move');
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'parentB after captured move');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after captured write');
+
+  const undone = await edits.undo(engine, replica, captured);
+  assertEqual(undone.operations.length, 2, 'undo operation count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'parentA after undo');
+  assertArrayEqual(await engine.tree.children(parentB), [], 'parentB after undo');
+  assertBytesEqual(await engine.tree.getPayload(node), originalPayload, 'payload after undo');
+
+  const redone = await edits.redo(engine, replica, undone);
+  assertEqual(redone.operations.length, 2, 'redo operation count');
+  assertArrayEqual(await engine.tree.children(parentA), [sibling], 'parentA after redo');
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'parentB after redo');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after redo');
+
+  const insertCapture = await edits.capture(engine, replica, async (local) =>
+    local.insert(parentB, inserted, { type: 'last' }, insertedPayload),
+  );
+  assertEqual(insertCapture.operations.length, 1, 'insert capture operation count');
+  assertEqual(await engine.tree.exists(inserted), true, 'inserted exists before undo');
+
+  const insertUndone = await edits.undo(engine, replica, insertCapture);
+  assertEqual(insertUndone.operations.length, 1, 'insert undo operation count');
+  assertEqual(await engine.tree.exists(inserted), false, 'inserted hidden after undo');
+
+  await edits.redo(engine, replica, insertUndone);
+  assertEqual(await engine.tree.exists(inserted), true, 'inserted restored after redo');
+  assertBytesEqual(
+    await engine.tree.getPayload(inserted),
+    insertedPayload,
+    'inserted payload after redo',
+  );
+  assertArrayEqual(
+    await engine.tree.children(parentB),
+    [node, inserted],
+    'parentB after insert redo',
+  );
+
+  const deleteCapture = await edits.capture(engine, replica, async (local) => local.delete(node));
+  assertEqual(deleteCapture.operations.length, 1, 'delete capture operation count');
+  assertEqual(await engine.tree.exists(node), false, 'node hidden after delete');
+  assertArrayEqual(await engine.tree.children(parentB), [inserted], 'parentB after delete');
+
+  await edits.undo(engine, replica, deleteCapture);
+  assertEqual(await engine.tree.exists(node), true, 'node restored after delete undo');
+  assertArrayEqual(
+    await engine.tree.children(parentB),
+    [node, inserted],
+    'parentB after delete undo',
+  );
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after delete undo');
 }
 
 async function scenarioAppendIdempotentAndHeadLamportMonotonic(

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -166,6 +166,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioChildrenPagination,
     },
     {
+      name: 'tree: placement returns restore position',
+      run: scenarioTreePlacement,
+    },
+    {
       name: 'materialized tree: out-of-order ops rebuild correctly',
       run: scenarioOutOfOrderOpsRebuild,
     },
@@ -370,6 +374,23 @@ function assertBytesEqual(
   }
   for (let i = 0; i < actual.length; i++) {
     if (actual[i] !== expected[i]) throw new Error(`${message}: mismatch at byte ${i}`);
+  }
+}
+
+function assertPlacement(
+  actual: Awaited<ReturnType<NonNullable<TreecrdtEngine['tree']['placement']>>>,
+  expected: { parent: string; placement: { type: 'first' } | { type: 'after'; after: string } },
+  message: string,
+): void {
+  assert(actual, `${message}: expected placement`);
+  assertEqual(actual.parent, expected.parent, `${message} parent`);
+  assertEqual(actual.placement.type, expected.placement.type, `${message} placement type`);
+  if (expected.placement.type === 'after') {
+    assertEqual(
+      actual.placement.type === 'after' ? actual.placement.after : null,
+      expected.placement.after,
+      `${message} placement after`,
+    );
   }
 }
 
@@ -938,6 +959,54 @@ async function scenarioChildrenPagination(ctx: TreecrdtEngineConformanceContext)
     4,
   );
   assertEqual(p4.length, 0, 'childrenPage p4 length');
+}
+
+async function scenarioTreePlacement(ctx: TreecrdtEngineConformanceContext): Promise<void> {
+  const engine = ctx.engine;
+  if (!engine.tree.placement) return;
+
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parentA = nodeIdFromInt(61);
+  const parentB = nodeIdFromInt(62);
+  const first = nodeIdFromInt(63);
+  const second = nodeIdFromInt(64);
+  const third = nodeIdFromInt(65);
+  const missing = nodeIdFromInt(66);
+
+  await engine.local.insert(replica, root, parentA, { type: 'last' }, null);
+  await engine.local.insert(replica, root, parentB, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, first, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, second, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, third, { type: 'last' }, null);
+
+  assertPlacement(
+    await engine.tree.placement(first),
+    { parent: parentA, placement: { type: 'first' } },
+    'first child placement',
+  );
+  assertPlacement(
+    await engine.tree.placement(second),
+    { parent: parentA, placement: { type: 'after', after: first } },
+    'second child placement',
+  );
+  assertPlacement(
+    await engine.tree.placement(third),
+    { parent: parentA, placement: { type: 'after', after: second } },
+    'third child placement',
+  );
+
+  await engine.local.move(replica, third, parentB, { type: 'first' });
+  assertPlacement(
+    await engine.tree.placement(third),
+    { parent: parentB, placement: { type: 'first' } },
+    'moved first child placement',
+  );
+
+  await engine.local.delete(replica, second);
+  assertEqual(await engine.tree.placement(second), null, 'deleted node placement');
+  assertEqual(await engine.tree.placement(root), null, 'root node placement');
+  assertEqual(await engine.tree.placement(missing), null, 'missing node placement');
 }
 
 async function scenarioOutOfOrderOpsRebuild(ctx: TreecrdtEngineConformanceContext): Promise<void> {

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -7,6 +7,7 @@ import {
   decodeSqliteOpRefs,
   decodeSqliteOps,
   decodeSqliteTreeChildRows,
+  decodeSqliteTreePlacement,
   decodeSqliteTreeRows,
   type SqliteRunner,
   type TreecrdtSqlitePlacement,
@@ -167,6 +168,8 @@ export function createTreecrdtClient(
     );
   const treeChildrenImpl = async (parent: string) =>
     decodeSqliteNodeIds(await adapter.treeChildren(nodeIdToBytes16(parent)));
+  const treePlacementImpl = async (node: string) =>
+    decodeSqliteTreePlacement(await adapter.treePlacement!(nodeIdToBytes16(node)));
   const treeDumpImpl = async () => decodeSqliteTreeRows(await adapter.treeDump());
   const treeNodeCountImpl = async () => Number(await adapter.treeNodeCount());
   const treeParentImpl = async (node: string) => {
@@ -239,6 +242,7 @@ export function createTreecrdtClient(
         decodeSqliteTreeChildRows(
           await adapter.treeChildrenPage!(nodeIdToBytes16(parent), cursor, limit),
         ),
+      placement: treePlacementImpl,
       dump: treeDumpImpl,
       nodeCount: treeNodeCountImpl,
       parent: treeParentImpl,

--- a/packages/treecrdt-ts/package.json
+++ b/packages/treecrdt-ts/package.json
@@ -24,6 +24,10 @@
     "./engine": {
       "import": "./dist/src/engine.js",
       "types": "./dist/src/engine.d.ts"
+    },
+    "./edits": {
+      "import": "./dist/src/edits.js",
+      "types": "./dist/src/edits.d.ts"
     }
   },
   "files": [

--- a/packages/treecrdt-ts/src/adapter.ts
+++ b/packages/treecrdt-ts/src/adapter.ts
@@ -52,6 +52,13 @@ export interface TreecrdtAdapter {
     limit: number,
   ): Promise<unknown[]>;
   /**
+   * Fetch the current visible placement for a node.
+   *
+   * Returns raw JSON-decoded row `{ parent: string, after: string | null }`, or null for missing,
+   * tombstoned, or root nodes.
+   */
+  treePlacement?(node: Uint8Array): Promise<unknown | null>;
+  /**
    * Dump the full materialized tree state.
    *
    * Returns raw JSON-decoded rows (array of objects with byte fields).

--- a/packages/treecrdt-ts/src/edits.ts
+++ b/packages/treecrdt-ts/src/edits.ts
@@ -85,6 +85,16 @@ async function visiblePlacementBefore(
 }
 
 async function currentMoveUndoAction(tree: TreecrdtEngineTree, node: string): Promise<Action> {
+  const placement = await tree.placement?.(node);
+  if (placement) {
+    return {
+      type: 'move',
+      node,
+      parent: placement.parent,
+      placement: placement.placement,
+    };
+  }
+
   if (!(await tree.exists(node))) return { type: 'delete', node };
 
   const parent = await tree.parent(node);

--- a/packages/treecrdt-ts/src/edits.ts
+++ b/packages/treecrdt-ts/src/edits.ts
@@ -1,0 +1,210 @@
+import type { Operation, ReplicaId } from './index.js';
+import type { TreecrdtSqlitePlacement } from './sqlite.js';
+import type {
+  BoundTreecrdtEngineLocal,
+  LocalWriteOptions,
+  TreecrdtEngineLocal,
+  TreecrdtEngineTree,
+} from './engine.js';
+
+export type DeleteAction = {
+  type: 'delete';
+  node: string;
+};
+
+export type MoveAction = {
+  type: 'move';
+  node: string;
+  parent: string;
+  placement: TreecrdtSqlitePlacement;
+};
+
+export type PayloadAction = {
+  type: 'payload';
+  node: string;
+  payload: Uint8Array | null;
+};
+
+/**
+ * A forward local write that reverses a previously captured local write.
+ *
+ * These are intentionally not oplog rewinds. Applying a plan mints new local ops, so undo/redo
+ * remains mergeable with remote peers.
+ */
+export type Action = DeleteAction | MoveAction | PayloadAction;
+
+export type Plan = {
+  actions: Action[];
+};
+
+export type Target = {
+  tree: TreecrdtEngineTree;
+  local: TreecrdtEngineLocal;
+};
+
+export type Captured<T> = {
+  result: T;
+  operations: Operation[];
+  undo: Plan;
+};
+
+export type Undoable = {
+  undo: Plan;
+};
+
+export type Redoable = {
+  redo: Plan;
+};
+
+export type UndoResult = {
+  operations: Operation[];
+  redo: Plan;
+};
+
+export type RedoResult = {
+  operations: Operation[];
+  undo: Plan;
+};
+
+function cloneBytes(bytes: Uint8Array | null): Uint8Array | null {
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
+async function visiblePlacementBefore(
+  tree: TreecrdtEngineTree,
+  parent: string,
+  node: string,
+): Promise<TreecrdtSqlitePlacement> {
+  const siblings = await tree.children(parent);
+  const index = siblings.indexOf(node);
+  if (index < 0) {
+    throw new Error(`treecrdt: cannot capture undo position for non-visible node ${node}`);
+  }
+  if (index === 0) return { type: 'first' };
+  return { type: 'after', after: siblings[index - 1]! };
+}
+
+async function currentMoveUndoAction(tree: TreecrdtEngineTree, node: string): Promise<Action> {
+  if (!(await tree.exists(node))) return { type: 'delete', node };
+
+  const parent = await tree.parent(node);
+  if (parent === null) {
+    throw new Error(`treecrdt: cannot capture undo parent for root or missing node ${node}`);
+  }
+  return {
+    type: 'move',
+    node,
+    parent,
+    placement: await visiblePlacementBefore(tree, parent, node),
+  };
+}
+
+/**
+ * Capture the inverse of local writes performed through the supplied callback.
+ *
+ * The callback receives a bound local writer. Use that writer for every write that should be part
+ * of the undo plan. The returned plan is ordered for direct application.
+ */
+export async function capture<T>(
+  target: Target,
+  replica: ReplicaId,
+  fn: (local: BoundTreecrdtEngineLocal) => Promise<T>,
+  defaults: LocalWriteOptions = {},
+): Promise<Captured<T>> {
+  const base = target.local.forReplica(replica, defaults);
+  const operations: Operation[] = [];
+  const actions: Action[] = [];
+
+  const record = (op: Operation, action: Action) => {
+    operations.push(op);
+    actions.unshift(action);
+  };
+
+  const local: BoundTreecrdtEngineLocal = {
+    insert: async (parent, node, placement, payload, opts) => {
+      const op = await base.insert(parent, node, placement, payload, opts);
+      record(op, { type: 'delete', node });
+      return op;
+    },
+    move: async (node, newParent, placement, opts) => {
+      const undo = await currentMoveUndoAction(target.tree, node);
+      const op = await base.move(node, newParent, placement, opts);
+      record(op, undo);
+      return op;
+    },
+    delete: async (node, opts) => {
+      const undo = await currentMoveUndoAction(target.tree, node);
+      const op = await base.delete(node, opts);
+      record(op, undo);
+      return op;
+    },
+    payload: async (node, payload, opts) => {
+      const previous = await target.tree.getPayload(node);
+      const op = await base.payload(node, payload, opts);
+      record(op, { type: 'payload', node, payload: cloneBytes(previous) });
+      return op;
+    },
+  };
+
+  const result = await fn(local);
+  return { result, operations, undo: { actions } };
+}
+
+export async function applyToLocal(
+  local: BoundTreecrdtEngineLocal,
+  plan: Plan,
+  opts?: LocalWriteOptions,
+): Promise<Operation[]> {
+  const operations: Operation[] = [];
+  for (const action of plan.actions) {
+    switch (action.type) {
+      case 'delete':
+        operations.push(await local.delete(action.node, opts));
+        break;
+      case 'move':
+        operations.push(await local.move(action.node, action.parent, action.placement, opts));
+        break;
+      case 'payload':
+        operations.push(await local.payload(action.node, cloneBytes(action.payload), opts));
+        break;
+    }
+  }
+  return operations;
+}
+
+export function apply(
+  target: Target,
+  replica: ReplicaId,
+  plan: Plan,
+  opts?: LocalWriteOptions,
+): Promise<Operation[]> {
+  return applyToLocal(target.local.forReplica(replica), plan, opts);
+}
+
+export async function undo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Undoable,
+  opts?: LocalWriteOptions,
+): Promise<UndoResult> {
+  const applied = await capture(target, replica, (local) => applyToLocal(local, edit.undo, opts));
+  return { operations: applied.operations, redo: applied.undo };
+}
+
+export async function redo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Redoable,
+  opts?: LocalWriteOptions,
+): Promise<RedoResult> {
+  const applied = await capture(target, replica, (local) => applyToLocal(local, edit.redo, opts));
+  return { operations: applied.operations, undo: applied.undo };
+}
+
+export const edits = {
+  apply,
+  applyToLocal,
+  capture,
+  redo,
+  undo,
+};

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -159,6 +159,11 @@ export type TreecrdtEngineOpRefs = {
   children: (parent: string) => Promise<Uint8Array[]>;
 };
 
+export type TreecrdtNodePlacement = {
+  parent: string;
+  placement: TreecrdtSqlitePlacement;
+};
+
 export type TreecrdtEngineTree = {
   children: (parent: string) => Promise<string[]>;
   childrenPage?: (
@@ -166,6 +171,7 @@ export type TreecrdtEngineTree = {
     cursor: { orderKey: Uint8Array; node: Uint8Array } | null,
     limit: number,
   ) => Promise<SqliteTreeChildRow[]>;
+  placement?: (node: string) => Promise<TreecrdtNodePlacement | null>;
   dump: () => Promise<SqliteTreeRow[]>;
   nodeCount: () => Promise<number>;
   parent: (node: string) => Promise<string | null>;

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -46,6 +46,16 @@ async function sqliteGetJsonOrEmpty<T>(
   return JSON.parse(text) as T;
 }
 
+async function sqliteGetJsonOrNull<T>(
+  runner: SqliteRunner,
+  sql: string,
+  params?: SqlCall['params'],
+): Promise<T | null> {
+  const text = await runner.getText(sql, params);
+  if (text === null || text === undefined || text === '') return null;
+  return JSON.parse(text) as T;
+}
+
 async function sqliteGetNumber(
   runner: SqliteRunner,
   sql: string,
@@ -334,6 +344,7 @@ export function createTreecrdtSqliteAdapter(
     treeChildren: (parent) => treecrdtTreeChildren(runner, parent, emitOutcome),
     treeChildrenPage: (parent, cursor, limit) =>
       treecrdtTreeChildrenPage(runner, parent, cursor, limit, emitOutcome),
+    treePlacement: (node) => treecrdtTreePlacement(runner, node, emitOutcome),
     treeDump: () => treecrdtTreeDump(runner, emitOutcome),
     treeNodeCount: () => treecrdtTreeNodeCount(runner, emitOutcome),
     treeParent: (node) => treecrdtTreeParent(runner, node, emitOutcome),
@@ -463,6 +474,39 @@ async function treecrdtTreeChildrenPage(
        LIMIT ?4\
      )",
     [parent, afterOrderKey, afterNode, limit],
+  );
+}
+
+/**
+ * Fetch the current visible parent + sibling placement for a node without reading all siblings.
+ */
+async function treecrdtTreePlacement(
+  runner: SqliteRunner,
+  node: Uint8Array,
+  emitOutcome?: (outcome: MaterializationOutcome) => void,
+): Promise<unknown | null> {
+  await treecrdtEnsureMaterialized(runner, emitOutcome);
+  return sqliteGetJsonOrNull(
+    runner,
+    "SELECT json_object('parent', parent_hex, 'after', after_hex) \
+     FROM (\
+       SELECT \
+         lower(hex(current.parent)) AS parent_hex, \
+         (\
+           SELECT lower(hex(previous.node)) \
+           FROM tree_nodes AS previous \
+           WHERE previous.parent = current.parent \
+             AND previous.tombstone = 0 \
+             AND (previous.order_key < current.order_key \
+               OR (previous.order_key = current.order_key AND previous.node < current.node)) \
+           ORDER BY previous.order_key DESC, previous.node DESC \
+           LIMIT 1\
+         ) AS after_hex \
+       FROM tree_nodes AS current \
+       WHERE current.node = ?1 AND current.tombstone = 0 AND current.parent IS NOT NULL \
+       LIMIT 1\
+     )",
+    [node],
   );
 }
 
@@ -834,6 +878,22 @@ export function decodeSqliteTreeChildRows(raw: unknown): SqliteTreeChildRow[] {
             : Uint8Array.from(rawOrderKey as any);
     return { node, orderKey };
   });
+}
+
+export type SqliteTreePlacement = {
+  parent: string;
+  placement: TreecrdtSqlitePlacement;
+};
+
+export function decodeSqliteTreePlacement(raw: unknown): SqliteTreePlacement | null {
+  if (raw == null) return null;
+  const row = raw as any;
+  const parent = decodeNodeId(row.parent);
+  const after = row.after == null ? null : decodeNodeId(row.after);
+  return {
+    parent,
+    placement: after === null ? { type: 'first' } : { type: 'after', after },
+  };
 }
 
 export type SqliteTreeRow = {

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -6,6 +6,7 @@ import {
   decodeSqliteOpRefs,
   decodeSqliteOps,
   decodeSqliteTreeChildRows,
+  decodeSqliteTreePlacement,
   decodeSqliteTreeRows,
   type SqliteTreeChildRow,
   type SqliteRunner,
@@ -702,6 +703,10 @@ export async function buildDirectClient(
             limit,
           )) as any;
         }
+        case 'treePlacement': {
+          const [node] = params as RpcParams<'treePlacement'>;
+          return (await adapter.treePlacement!(nodeIdToBytes16(node))) as any;
+        }
         case 'treeDump':
           return (await adapter.treeDump()) as any;
         case 'treePayload': {
@@ -828,6 +833,8 @@ function makeTreecrdtClientFromCall(opts: {
       : null;
     return decodeSqliteTreeChildRows(await call('treeChildrenPage', [parent, rpcCursor, limit]));
   };
+  const treePlacementImpl = async (node: string) =>
+    decodeSqliteTreePlacement(await call('treePlacement', [node]));
   const treeDumpImpl = async () => decodeSqliteTreeRows(await call('treeDump', []));
   const treeNodeCountImpl = async () => Number(await call('treeNodeCount', []));
   const treeParentImpl = async (node: string) => {
@@ -941,6 +948,7 @@ function makeTreecrdtClientFromCall(opts: {
     tree: {
       children: treeChildrenImpl,
       childrenPage: treeChildrenPageImpl,
+      placement: treePlacementImpl,
       dump: treeDumpImpl,
       nodeCount: treeNodeCountImpl,
       parent: treeParentImpl,

--- a/packages/treecrdt-wa-sqlite/src/common-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/common-worker.ts
@@ -112,6 +112,10 @@ export class CommonWorkerSession {
     return await this.ensureApi().treeChildrenPage!(nodeIdToBytes16(parent), cursorBytes, limit);
   }
 
+  async treePlacement(node: string) {
+    return await this.ensureApi().treePlacement!(nodeIdToBytes16(node));
+  }
+
   async treeDump() {
     return await this.ensureApi().treeDump();
   }
@@ -160,6 +164,7 @@ export function createCommonWorkerRpcHandlers(session: CommonWorkerSession) {
       cursor: { orderKey: number[]; node: number[] } | null,
       limit: number,
     ) => session.treeChildrenPage(parent, cursor, limit),
+    treePlacement: (node: string) => session.treePlacement(node),
     treeDump: () => session.treeDump(),
     treeNodeCount: () => session.treeNodeCount(),
     treeParent: (node: string) => session.treeParent(node),

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -37,6 +37,7 @@ export type RpcSchema = {
     params: [parent: string, cursor: { orderKey: number[]; node: number[] } | null, limit: number];
     result: unknown[];
   };
+  treePlacement: { params: [node: string]; result: unknown | null };
   treeDump: { params: []; result: unknown[] };
   treeNodeCount: { params: []; result: number };
   treeParent: { params: [node: string]; result: Uint8Array | null };


### PR DESCRIPTION
## Summary

- add optional `tree.placement(node)` read API that returns a node's current parent plus restore placement
- implement the lookup in the shared SQLite adapter without reading all siblings
- expose it through sqlite-node and wa-sqlite RPC/direct clients
- make `edits.capture` use the targeted lookup when available, with the existing sibling-scan fallback for other backends
- add conformance coverage for first/after placement, moves, deletes, root, and missing nodes

## Stack note

This is an exploratory draft stacked on #173. The public undo API remains `edits.capture/undo/redo`; this PR only tries a lower-cost backend read so move/delete capture does not need `tree.children(parent)` on SQLite-backed runtimes.

## Verification

- `pnpm -C packages/treecrdt-ts run build`
- `pnpm -C packages/treecrdt-engine-conformance run build`
- `pnpm -C packages/treecrdt-wa-sqlite run build:ts`
- `pnpm -C packages/treecrdt-sqlite-node run test`

## Known local limitation

`pnpm -C packages/treecrdt-wa-sqlite run test` still fails in the vendor build with `No rule to make target tmp/obj/dist/sqlite3.o`, before Vitest runs. The wa-sqlite TypeScript/RPC path compiles.
