### PR TITLE
feat(wa-sqlite): add an experimental multi-connection OPFS mode

### DIFF
--- a/.changeset/opfs-writeahead-vfs.md
+++ b/.changeset/opfs-writeahead-vfs.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': minor
+---
+
+Add experimental `storage.writeMode: 'opfs-write-ahead'` for wa-sqlite's `OPFSWriteAheadVFS`.

--- a/packages/treecrdt-wa-sqlite/README.md
+++ b/packages/treecrdt-wa-sqlite/README.md
@@ -54,6 +54,17 @@ runtimes reject this mode. It uses wa-sqlite's `AccessHandlePoolVFS`, which is n
 filesystem-transparent; use the default OPFS mode for multi-tab ownership or direct file
 import/export.
 
+### OPFS write-ahead VFS mode
+
+`writeMode: 'opfs-write-ahead'` enables wa-sqlite's experimental
+`OPFSWriteAheadVFS`. It is intended for browser experiments that need multiple
+connections to the same OPFS file and currently requires Chromium support for
+OPFS `readwrite-unsafe` access handles. Like the single-owner WAL mode, it requires
+a dedicated-worker runtime; the regular OPFS mode remains the default fast path.
+Transactions opened through `client.runner` must use `BEGIN IMMEDIATE` or
+`BEGIN EXCLUSIVE`; deferred transactions are rejected because this VFS cannot
+safely upgrade them after a read.
+
 ## Node usage (in-memory WASM)
 
 On Node, `createTreecrdtClient()` runs wa-sqlite in-process with an in-memory database. OPFS and worker runtimes are not supported.

--- a/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
@@ -12,6 +12,9 @@ export type LifecycleRuntime = 'direct' | 'dedicated-worker';
 const rootId = '0'.repeat(32);
 const parentId = nodeIdFromInt(901);
 const childId = nodeIdFromInt(902);
+const authRollbackNodeId = nodeIdFromInt(903);
+const outerRollbackNodeId = nodeIdFromInt(904);
+const authSuccessNodeId = nodeIdFromInt(905);
 const replica = replicaFromLabel('lifecycle');
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -136,6 +139,106 @@ export async function readLifecycleTree(opts: LifecycleOptions): Promise<Lifecyc
   }
 }
 
+export async function writeAheadTwoClientLifecycle(opts: LifecycleOptions): Promise<{
+  stateFromAAfterBWrite: LifecycleState;
+  stateFromBAfterAWrite: LifecycleState;
+}> {
+  const prior = openClient;
+  openClient = null;
+  await prior?.close().catch(() => {});
+
+  const clientA = await createOpfsLifecycleClient(opts);
+  const clientB = await createOpfsLifecycleClient(opts);
+  try {
+    await clientA.local.insert(
+      replica,
+      rootId,
+      parentId,
+      { type: 'last' },
+      textEncoder.encode('browser lifecycle parent'),
+    );
+    const stateFromBAfterAWrite = await summarizeLifecycleState(clientB);
+
+    await clientB.local.insert(
+      replica,
+      parentId,
+      childId,
+      { type: 'last' },
+      textEncoder.encode('browser lifecycle child'),
+    );
+    const stateFromAAfterBWrite = await summarizeLifecycleState(clientA);
+
+    return { stateFromAAfterBWrite, stateFromBAfterAWrite };
+  } finally {
+    await clientA.close().catch(() => {});
+    await clientB.close().catch(() => {});
+  }
+}
+
+export async function writeAheadTransactionOwnershipLifecycle(opts: LifecycleOptions): Promise<{
+  authRollback: { exists: boolean; opCount: number; eventCount: number };
+  outerRollback: { exists: boolean; opCount: number };
+  authSuccess: { exists: boolean; opCount: number; eventCount: number };
+}> {
+  const prior = openClient;
+  openClient = null;
+  await prior?.close().catch(() => {});
+
+  const client = await createOpfsLifecycleClient(opts);
+  const events: unknown[] = [];
+  const unsubscribe = client.onMaterialized((event) => events.push(event));
+  try {
+    await client.local
+      .insert(replica, rootId, authRollbackNodeId, { type: 'last' }, null, {
+        authSession: {
+          authorizeLocalOps: async () => {
+            throw new Error('local auth denied');
+          },
+        },
+      })
+      .then(() => {
+        throw new Error('expected local auth denial');
+      })
+      .catch((err) => {
+        if (!(err instanceof Error) || !err.message.includes('local auth denied')) throw err;
+      });
+
+    const authRollback = {
+      exists: await client.tree.exists(authRollbackNodeId),
+      opCount: (await client.ops.all()).length,
+      eventCount: events.length,
+    };
+
+    await client.runner.exec('SAVEPOINT treecrdt_e2e_outer');
+    try {
+      await client.local.insert(replica, rootId, outerRollbackNodeId, { type: 'last' }, null);
+      await client.runner.exec('ROLLBACK TO treecrdt_e2e_outer');
+    } finally {
+      await client.runner.exec('RELEASE treecrdt_e2e_outer');
+    }
+
+    const outerRollback = {
+      exists: await client.tree.exists(outerRollbackNodeId),
+      opCount: (await client.ops.all()).length,
+    };
+
+    events.length = 0;
+    await client.local.insert(replica, rootId, authSuccessNodeId, { type: 'last' }, null, {
+      authSession: { authorizeLocalOps: async () => undefined },
+    });
+    const authSuccess = {
+      exists: await client.tree.exists(authSuccessNodeId),
+      opCount: (await client.ops.all()).length,
+      eventCount: events.length,
+    };
+
+    return { authRollback, outerRollback, authSuccess };
+  } finally {
+    unsubscribe();
+    await client.close().catch(() => {});
+  }
+}
+
 declare global {
   interface Window {
     __treecrdtLifecycle?: {
@@ -143,6 +246,8 @@ declare global {
       drop: typeof dropLifecycleStore;
       write: typeof writeLifecycleTree;
       read: typeof readLifecycleTree;
+      writeAheadTwoClient: typeof writeAheadTwoClientLifecycle;
+      writeAheadTransactionOwnership: typeof writeAheadTransactionOwnershipLifecycle;
     };
   }
 }
@@ -153,5 +258,7 @@ if (typeof window !== 'undefined') {
     drop: dropLifecycleStore,
     write: writeLifecycleTree,
     read: readLifecycleTree,
+    writeAheadTwoClient: writeAheadTwoClientLifecycle,
+    writeAheadTransactionOwnership: writeAheadTransactionOwnershipLifecycle,
   };
 }

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from '@playwright/test';
 
 type LifecycleHarness = NonNullable<Window['__treecrdtLifecycle']>;
 type LifecycleRuntime = 'direct' | 'dedicated-worker';
-type LifecycleWriteMode = 'default' | 'single-owner-wal';
+type LifecycleWriteMode = 'default' | 'single-owner-wal' | 'opfs-write-ahead';
 
 const scenarios: Array<{
   runtime: LifecycleRuntime;
@@ -108,6 +108,52 @@ function expectReloadedTree(
   expect(state.childParent).toBe(state.parentId);
 }
 
+function isWriteAheadUnsupportedError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.toLowerCase().includes('readwrite-unsafe');
+}
+
+type WriteAheadLifecycleOptions = {
+  docId: string;
+  filename: string;
+  runtime: 'dedicated-worker';
+  writeMode: 'opfs-write-ahead';
+};
+
+async function withWriteAheadStore(
+  page: Page,
+  name: string,
+  run: (opts: WriteAheadLifecycleOptions) => Promise<void>,
+): Promise<void> {
+  if (test.info().project.name !== 'chromium-dev') test.skip();
+  test.setTimeout(120_000);
+  page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));
+
+  const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+  const opts = {
+    docId: `${name}-${suffix}`,
+    filename: `/${name}-${suffix}.db`,
+    runtime: 'dedicated-worker',
+    writeMode: 'opfs-write-ahead',
+  } as const;
+
+  await waitForHarness(page);
+  const opfsSupport = await support(page);
+  if (!opfsSupport.available) test.skip(true, `OPFS unavailable: ${opfsSupport.reason}`);
+
+  try {
+    await drop(page, opts);
+    await run(opts);
+  } catch (err) {
+    if (isWriteAheadUnsupportedError(err)) {
+      test.skip(true, `OPFSWriteAheadVFS unsupported: ${err instanceof Error ? err.message : err}`);
+    }
+    throw err;
+  } finally {
+    await drop(page, opts).catch(() => {});
+  }
+}
+
 test.describe('browser OPFS lifecycle', () => {
   for (const scenario of scenarios) {
     for (const reloadCase of reloadCases) {
@@ -187,5 +233,65 @@ test.describe('browser OPFS lifecycle', () => {
     } finally {
       await drop(page, opts).catch(() => {});
     }
+  });
+
+  test('opens dedicated-worker OPFS store in write-ahead VFS mode', async ({ page }) => {
+    await withWriteAheadStore(page, 'lifecycle-write-ahead', async (opts) => {
+      const written = await write(page, { ...opts, closeBeforeReload: true });
+      expectReloadedTree(written, { mode: 'worker', runtime: 'dedicated-worker' });
+
+      expectReloadedTree(await read(page, opts), {
+        mode: 'worker',
+        runtime: 'dedicated-worker',
+      });
+    });
+  });
+
+  test('opens the same write-ahead OPFS store from two dedicated-worker clients', async ({
+    page,
+  }) => {
+    await withWriteAheadStore(page, 'lifecycle-write-ahead-two-client', async (opts) => {
+      const result = await page.evaluate(async (twoClientOpts) => {
+        const harness = window.__treecrdtLifecycle;
+        if (!harness) throw new Error('__treecrdtLifecycle not available');
+        return await harness.writeAheadTwoClient(twoClientOpts);
+      }, opts);
+
+      expect(result.stateFromBAfterAWrite).toMatchObject({
+        mode: 'worker',
+        runtime: 'dedicated-worker',
+        storage: 'opfs',
+        headLamport: 1,
+        parentExists: true,
+        childExists: false,
+        parentPayload: 'browser lifecycle parent',
+      });
+      expect(result.stateFromBAfterAWrite.rootChildren).toEqual([
+        result.stateFromBAfterAWrite.parentId,
+      ]);
+
+      expectReloadedTree(result.stateFromAAfterBWrite, {
+        mode: 'worker',
+        runtime: 'dedicated-worker',
+      });
+    });
+  });
+
+  test('write-ahead mode preserves auth and outer-savepoint transaction ownership', async ({
+    page,
+  }) => {
+    await withWriteAheadStore(page, 'lifecycle-write-ahead-transactions', async (opts) => {
+      const result = await page.evaluate(async (transactionOpts) => {
+        const harness = window.__treecrdtLifecycle;
+        if (!harness) throw new Error('__treecrdtLifecycle not available');
+        return await harness.writeAheadTransactionOwnership(transactionOpts);
+      }, opts);
+
+      expect(result).toEqual({
+        authRollback: { exists: false, opCount: 0, eventCount: 0 },
+        outerRollback: { exists: false, opCount: 0 },
+        authSuccess: { exists: true, opCount: 1, eventCount: 1 },
+      });
+    });
   });
 });

--- a/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
+++ b/packages/treecrdt-wa-sqlite/scripts/copy-opfs-vfs.mjs
@@ -40,6 +40,24 @@ const sources = [
       content.replace('../FacadeVFS.js', './FacadeVFS.js').replace('../VFS.js', './VFS.js'),
   },
   {
+    src: path.join(vendorRoot, 'src/examples/OPFSWriteAheadVFS.js'),
+    name: 'OPFSWriteAheadVFS.js',
+    transform: (content) =>
+      content.replace('../FacadeVFS.js', './FacadeVFS.js').replace('../VFS.js', './VFS.js'),
+  },
+  {
+    src: path.join(vendorRoot, 'src/examples/WriteAhead.js'),
+    name: 'WriteAhead.js',
+  },
+  {
+    src: path.join(vendorRoot, 'src/examples/LazyLock.js'),
+    name: 'LazyLock.js',
+  },
+  {
+    src: path.join(vendorRoot, 'src/examples/Lock.js'),
+    name: 'Lock.js',
+  },
+  {
     src: path.join(vendorRoot, 'src/examples/OPFSCoopSyncVFS.js'),
     name: 'OPFSCoopSyncVFS.js',
     transform: (content) =>

--- a/packages/treecrdt-wa-sqlite/src/adapter.ts
+++ b/packages/treecrdt-wa-sqlite/src/adapter.ts
@@ -2,18 +2,41 @@ import type { TreecrdtAdapter } from '@treecrdt/interface';
 import { createTreecrdtSqliteAdapter, type SqliteRunner } from '@treecrdt/interface/sqlite';
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
 import { dbGetText } from './sql.js';
-import type { Database } from './types.js';
+import type { Database, OpfsWriteMode } from './types.js';
+import { createOpfsWriteAheadExecutor } from './opfs-write-ahead.js';
 
-function createRunner(db: Database): SqliteRunner {
-  return {
+export function createWaSqliteRunner(db: Database, opfsWriteMode?: OpfsWriteMode): SqliteRunner {
+  const direct: SqliteRunner = {
     exec: (sql) => db.exec(sql),
     getText: (sql, params = []) => dbGetText(db, sql, params ?? []),
   };
+  if (opfsWriteMode !== 'opfs-write-ahead') return direct;
+
+  const run = createOpfsWriteAheadExecutor({
+    exec: direct.exec,
+    getAutocommit: () => db.getAutocommit(),
+  });
+  return {
+    exec: async (sql) => {
+      await run(sql, () => direct.exec(sql), { allowTransactionControlBatch: true });
+    },
+    getText: (sql, params = []) => run(sql, () => direct.getText(sql, params)),
+  };
+}
+
+export function createWaSqliteApiFromRunner(
+  runner: SqliteRunner,
+  opts: { onMaterialized?: (event: MaterializationEvent) => void } = {},
+): TreecrdtAdapter {
+  return createTreecrdtSqliteAdapter(runner, opts);
 }
 
 export function createWaSqliteApi(
   db: Database,
-  opts: { maxBulkOps?: number; onMaterialized?: (event: MaterializationEvent) => void } = {},
+  opts: {
+    onMaterialized?: (event: MaterializationEvent) => void;
+    opfsWriteMode?: OpfsWriteMode;
+  } = {},
 ): TreecrdtAdapter {
-  return createTreecrdtSqliteAdapter(createRunner(db), opts);
+  return createWaSqliteApiFromRunner(createWaSqliteRunner(db, opts.opfsWriteMode), opts);
 }

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -29,7 +29,6 @@ import {
   createMaterializationDispatcher,
   createTreecrdtEngineLocal,
 } from '@treecrdt/interface/engine';
-import { dbGetText } from './sql.js';
 import {
   rpcBinaryResult,
   type RpcMethod,
@@ -68,7 +67,10 @@ const APPEND_MANY_RPC_CHUNK_SIZE = 2500;
 function normalizeOpfsWriteMode(value: unknown): OpfsWriteMode {
   if (value === undefined || value === 'default') return 'default';
   if (value === 'single-owner-wal') return 'single-owner-wal';
-  throw new Error('createTreecrdtClient storage.writeMode must be "default" or "single-owner-wal"');
+  if (value === 'opfs-write-ahead') return 'opfs-write-ahead';
+  throw new Error(
+    'createTreecrdtClient storage.writeMode must be "default", "single-owner-wal", or "opfs-write-ahead"',
+  );
 }
 
 function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
@@ -176,11 +178,11 @@ export async function createTreecrdtClient(opts: ClientOptions = {}): Promise<Tr
 
   if (
     shouldUseOpfs &&
-    storage.opfsWriteMode === 'single-owner-wal' &&
+    storage.opfsWriteMode !== 'default' &&
     resolvedRuntime !== 'dedicated-worker'
   ) {
     throw new Error(
-      'OPFS storage.writeMode "single-owner-wal" requires runtime "dedicated-worker" or runtime "auto"',
+      `OPFS storage.writeMode "${storage.opfsWriteMode}" requires runtime "dedicated-worker" or runtime "auto"`,
     );
   }
 
@@ -691,10 +693,7 @@ export async function buildDirectClient(
     materialized.enableCrossTab({ docId: opts.docId, filename });
   }
   const adapter = opened.api;
-  const runner: SqliteRunner = {
-    exec: (sql) => db.exec(sql),
-    getText: (sql, params = []) => dbGetText(db, sql, params),
-  };
+  const runner = opened.runner;
   const wrapError = (stage: string, err: unknown) =>
     new Error(
       JSON.stringify({
@@ -720,12 +719,12 @@ export async function buildDirectClient(
       switch (method) {
         case 'sqlExec': {
           const [sql] = params as RpcParams<'sqlExec'>;
-          await db.exec(sql);
+          await runner.exec(sql);
           return undefined as any;
         }
         case 'sqlGetText': {
           const [sql, rawParams] = params as RpcParams<'sqlGetText'>;
-          return dbGetText(db, sql, (rawParams ?? []) as unknown[]) as any;
+          return runner.getText(sql, rawParams ?? []) as any;
         }
         case 'append': {
           const [op] = params as RpcParams<'append'>;

--- a/packages/treecrdt-wa-sqlite/src/common-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/common-worker.ts
@@ -1,8 +1,8 @@
-import { dbGetText } from './sql.js';
 import type { Database } from './types.js';
 import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
 import type { Operation } from '@treecrdt/interface';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
+import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import type { OpenTreecrdtDbResult } from './open.js';
 import { clearOpfsStorage, type OpfsVfsKind } from './opfs.js';
 import { rpcBinaryResult, type RpcInitResult, type RpcSqlParams } from './rpc.js';
@@ -20,6 +20,7 @@ export function openedToRpcInitResult(opened: OpenTreecrdtDbResult): RpcInitResu
 export class CommonWorkerSession {
   db: Database | null = null;
   api: TreecrdtAdapter | null = null;
+  runner: SqliteRunner | null = null;
   storedFilename: string | undefined;
   storedStorage: 'memory' | 'opfs' = 'memory';
   storedOpfsVfsKind: OpfsVfsKind | undefined;
@@ -30,6 +31,7 @@ export class CommonWorkerSession {
   applyOpened(opened: OpenTreecrdtDbResult): void {
     this.db = opened.db;
     this.api = opened.api;
+    this.runner = opened.runner;
     this.storedFilename = opened.filename;
     this.storedStorage = opened.storage;
     this.storedOpfsVfsKind = opened.opfsVfsKind;
@@ -40,6 +42,7 @@ export class CommonWorkerSession {
     const db = this.db;
     this.db = null;
     this.api = null;
+    this.runner = null;
     this.storedFilename = undefined;
     this.storedStorage = 'memory';
     this.storedOpfsVfsKind = undefined;
@@ -70,13 +73,18 @@ export class CommonWorkerSession {
     return this.db;
   }
 
+  ensureRunner(): SqliteRunner {
+    if (!this.runner) throw new Error('db not initialized');
+    return this.runner;
+  }
+
   async sqlExec(sql: string): Promise<null> {
-    await this.ensureDb().exec(sql);
+    await this.ensureRunner().exec(sql);
     return null;
   }
 
   async sqlGetText(sql: string, params?: RpcSqlParams): Promise<string | null> {
-    return dbGetText(this.ensureDb(), sql, params ?? []);
+    return this.ensureRunner().getText(sql, params ?? []);
   }
 
   async append(op: Operation) {

--- a/packages/treecrdt-wa-sqlite/src/db.ts
+++ b/packages/treecrdt-wa-sqlite/src/db.ts
@@ -28,6 +28,7 @@ export function makeDbAdapter(sqlite3: any, handle: number): Database {
     column_text: async (stmt: number, index: number) => sqlite3.column_text(stmt, index),
     finalize: async (stmt: number) => sqlite3.finalize(stmt),
     exec: async (sql: string) => sqlite3.exec(handle, sql),
+    getAutocommit: () => sqlite3.get_autocommit(handle) !== 0,
     close: async () => sqlite3.close(handle),
   } as unknown as Database;
 }

--- a/packages/treecrdt-wa-sqlite/src/open-core.ts
+++ b/packages/treecrdt-wa-sqlite/src/open-core.ts
@@ -1,10 +1,11 @@
 import { accessHandlePoolVfsNameForFilename, createOpfsVfs, type OpfsVfsKind } from './opfs.js';
-import { createWaSqliteApi } from './adapter.js';
+import { createWaSqliteApiFromRunner, createWaSqliteRunner } from './adapter.js';
 import type { Database, OpfsWriteMode } from './types.js';
 import { makeDbAdapter } from './db.js';
 import { dbGetText } from './sql.js';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import type { MaterializationEvent } from '@treecrdt/interface/engine';
+import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import { initializeTreecrdtExtension } from './extension.js';
 
 export type OpenTreecrdtDbOptions = {
@@ -21,6 +22,7 @@ export type OpenTreecrdtDbOptions = {
 export type OpenTreecrdtDbResult = {
   db: Database;
   api: TreecrdtAdapter;
+  runner: SqliteRunner;
   storage: 'memory' | 'opfs';
   filename: string;
   opfsVfsKind?: OpfsVfsKind;
@@ -55,14 +57,36 @@ async function closeIgnoringErrors(close: (() => Promise<void> | void) | undefin
   }
 }
 
+async function initializeTreecrdtExtensionWithWriteMode(
+  module: any,
+  handle: number,
+  db: Database,
+  mode: OpfsWriteMode,
+): Promise<void> {
+  if (mode !== 'opfs-write-ahead') {
+    await initializeTreecrdtExtension(module, handle);
+    return;
+  }
+
+  await db.exec('BEGIN IMMEDIATE');
+  try {
+    await initializeTreecrdtExtension(module, handle);
+    await db.exec('COMMIT');
+  } catch (err) {
+    await closeIgnoringErrors(() => db.exec('ROLLBACK'));
+    throw err;
+  }
+}
+
 async function openInitializedDatabase(
   sqlite3: any,
   module: any,
   filename: string,
   opts: OpenTreecrdtDbOptions,
   vfsName?: string,
+  opfsWriteMode: OpfsWriteMode = 'default',
   beforeExtensionInit?: (db: Database) => Promise<void>,
-): Promise<{ db: Database; api: TreecrdtAdapter }> {
+): Promise<{ db: Database; api: TreecrdtAdapter; runner: SqliteRunner }> {
   let db: Database | undefined;
   try {
     const handle = vfsName
@@ -70,10 +94,11 @@ async function openInitializedDatabase(
       : await sqlite3.open_v2(filename);
     db = makeDbAdapter(sqlite3, handle);
     await beforeExtensionInit?.(db);
-    await initializeTreecrdtExtension(module, handle);
-    const api = createWaSqliteApi(db, { onMaterialized: opts.onMaterialized });
+    await initializeTreecrdtExtensionWithWriteMode(module, handle, db, opfsWriteMode);
+    const runner = createWaSqliteRunner(db, opfsWriteMode);
+    const api = createWaSqliteApiFromRunner(runner, { onMaterialized: opts.onMaterialized });
     await api.setDocId(opts.docId);
-    return { db, api };
+    return { db, api, runner };
   } catch (err) {
     await closeIgnoringErrors(db?.close ? () => db!.close!() : undefined);
     throw err;
@@ -81,7 +106,7 @@ async function openInitializedDatabase(
 }
 
 async function configureOpfsWriteMode(db: Database, mode: OpfsWriteMode): Promise<void> {
-  if (mode === 'default') return;
+  if (mode !== 'single-owner-wal') return;
 
   const lockingMode = await dbGetText(db, 'PRAGMA locking_mode=EXCLUSIVE');
   const currentJournalMode = await dbGetText(db, 'PRAGMA journal_mode');
@@ -135,7 +160,11 @@ export async function openTreecrdtDbFromLoaded(
     let vfs: { close?: () => Promise<void> | void } | undefined;
     try {
       const opfsVfsKind: OpfsVfsKind =
-        opfsWriteMode === 'single-owner-wal' ? 'access-handle-pool' : (opts.opfsVfs ?? 'coop-sync');
+        opfsWriteMode === 'single-owner-wal'
+          ? 'access-handle-pool'
+          : opfsWriteMode === 'opfs-write-ahead'
+            ? 'write-ahead'
+            : (opts.opfsVfs ?? 'coop-sync');
       const opfsVfsName =
         opfsVfsKind === 'access-handle-pool'
           ? await accessHandlePoolVfsNameForFilename(requestedFilename)
@@ -152,6 +181,7 @@ export async function openTreecrdtDbFromLoaded(
         requestedFilename,
         opts,
         opfsVfsName,
+        opfsWriteMode,
         (db) => configureOpfsWriteMode(db, opfsWriteMode),
       );
       return {

--- a/packages/treecrdt-wa-sqlite/src/opfs.ts
+++ b/packages/treecrdt-wa-sqlite/src/opfs.ts
@@ -35,7 +35,7 @@ export function detectOpfsSupport(): OpfsSupport {
       };
 }
 
-const DB_RELATED_FILE_SUFFIXES = ['', '-journal', '-wal'];
+const DB_RELATED_FILE_SUFFIXES = ['', '-journal', '-wal', '-wa0', '-wa1'];
 
 export type ClearOpfsStorageOptions = {
   vfsKind?: OpfsVfsKind;
@@ -150,7 +150,7 @@ export async function opfsStorageExists(filename: string): Promise<boolean> {
   return false;
 }
 
-export type OpfsVfsKind = 'coop-sync' | 'any-context' | 'access-handle-pool';
+export type OpfsVfsKind = 'coop-sync' | 'any-context' | 'access-handle-pool' | 'write-ahead';
 
 export type OpfsVfsOptions = {
   name?: string;
@@ -167,6 +167,12 @@ export async function createOpfsVfs(module: any, opts: OpfsVfsOptions = {}): Pro
     // @ts-ignore vendored module lacks type declarations
     const { AccessHandlePoolVFS } = await import('./vendor/AccessHandlePoolVFS.js');
     return AccessHandlePoolVFS.create(name, module);
+  }
+
+  if (opts.kind === 'write-ahead') {
+    // @ts-ignore vendored module lacks type declarations
+    const { OPFSWriteAheadVFS } = await import('./vendor/OPFSWriteAheadVFS.js');
+    return OPFSWriteAheadVFS.create(name, module);
   }
 
   if (opts.kind === 'any-context') {

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -4,7 +4,7 @@ import type { MaterializationEvent, MaterializationOutcome } from '@treecrdt/int
 export const SHARED_WORKER_DROPPED_ERROR = 'TreeCRDT shared database was dropped';
 
 export type RpcStorageMode = 'memory' | 'opfs';
-export type RpcOpfsWriteMode = 'default' | 'single-owner-wal';
+export type RpcOpfsWriteMode = 'default' | 'single-owner-wal' | 'opfs-write-ahead';
 
 export type RpcSqlParam = number | string | null | Uint8Array;
 export type RpcSqlParams = RpcSqlParam[];

--- a/packages/treecrdt-wa-sqlite/src/types.ts
+++ b/packages/treecrdt-wa-sqlite/src/types.ts
@@ -12,13 +12,14 @@ export type Database = {
   column_text(stmt: number, index: number): Promise<string> | string;
   finalize(stmt: number): Promise<void> | void;
   exec(sql: string): Promise<void> | void;
+  getAutocommit(): Promise<boolean> | boolean;
   close?(): Promise<void> | void;
 };
 
 export type StorageMode = 'memory' | 'opfs';
 export type ClientMode = 'direct' | 'worker';
 export type RuntimeMode = 'direct' | 'dedicated-worker' | 'shared-worker';
-export type OpfsWriteMode = 'default' | 'single-owner-wal';
+export type OpfsWriteMode = 'default' | 'single-owner-wal' | 'opfs-write-ahead';
 export type TreecrdtStorage =
   | { type: 'memory' }
   | {
@@ -26,8 +27,13 @@ export type TreecrdtStorage =
       filename?: string;
       fallback?: 'throw' | 'memory';
       /**
-       * Enables WAL with exclusive locking. The application must guarantee that
-       * one dedicated worker is the only owner of this OPFS database.
+       * `single-owner-wal` enables WAL with exclusive locking. The application
+       * must guarantee that one dedicated worker is the only owner of this OPFS
+       * database.
+       *
+       * `opfs-write-ahead` enables upstream wa-sqlite's experimental
+       * OPFSWriteAheadVFS for multiple connections to the same file. It currently
+       * requires Chromium support for `readwrite-unsafe` OPFS access handles.
        */
       writeMode?: OpfsWriteMode;
     }

--- a/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
@@ -37,6 +37,7 @@ function createFakeSqlite(
   const statementText = new Map<number, string | null>();
   let nextHandle = 1;
   let nextStatement = 100;
+  let autocommit = true;
 
   return {
     vfs_register: vi.fn(),
@@ -67,7 +68,12 @@ function createFakeSqlite(
     }),
     column_text: vi.fn((statement: number) => statementText.get(statement)),
     finalize: vi.fn(),
-    exec: vi.fn(),
+    exec: vi.fn(async (_handle: number, sql: string) => {
+      opts.events?.push(`exec:${sql}`);
+      if (sql === 'BEGIN IMMEDIATE') autocommit = false;
+      if (sql === 'COMMIT' || sql === 'ROLLBACK') autocommit = true;
+    }),
+    get_autocommit: vi.fn(() => (autocommit ? 1 : 0)),
     close: vi.fn(),
   };
 }
@@ -92,6 +98,7 @@ test('keeps the memory path single-pass without creating an OPFS VFS', async () 
   expect(sqlite3.open_v2).toHaveBeenCalledWith(':memory:');
   expect(sqlite3.vfs_register).not.toHaveBeenCalled();
   expect(createOpfsVfs).not.toHaveBeenCalled();
+  expect(sqlite3.get_autocommit).not.toHaveBeenCalled();
   expect(loadFresh).not.toHaveBeenCalled();
 });
 
@@ -264,6 +271,7 @@ test('keeps the successful OPFS path single-pass and closes its database and VFS
   expect(sqlite3.statements.mock.calls.some(([, sql]) => String(sql).startsWith('PRAGMA'))).toBe(
     false,
   );
+  expect(sqlite3.get_autocommit).not.toHaveBeenCalled();
   expect(loadFresh).not.toHaveBeenCalled();
 
   await opened.db.close?.();
@@ -310,6 +318,41 @@ test('configures WAL before extension initialization and selects the VFS explici
   expect(events.indexOf('prepare:PRAGMA locking_mode=EXCLUSIVE')).toBeLessThan(
     events.indexOf('extension-init'),
   );
+  expect(sqlite3.get_autocommit).not.toHaveBeenCalled();
+});
+
+test('selects write-ahead VFS explicitly and initializes the extension in an immediate transaction', async () => {
+  const events: string[] = [];
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite({ events });
+  const filename = '/write-ahead.db';
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename,
+      docId: 'write-ahead',
+      requireOpfs: true,
+      opfsWriteMode: 'opfs-write-ahead',
+    },
+    { sqlite3, module: createFakeModule(0, events) },
+    vi.fn(),
+  );
+
+  expect(opened.opfsVfsKind).toBe('write-ahead');
+  expect(opened.opfsVfsName).toBe('opfs');
+  expect(createOpfsVfs).toHaveBeenCalledWith(expect.anything(), {
+    name: 'opfs',
+    kind: 'write-ahead',
+  });
+  expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
+  expect(sqlite3.open_v2).toHaveBeenCalledWith(filename, undefined, 'opfs');
+  expect(events.slice(0, 3)).toEqual(['exec:BEGIN IMMEDIATE', 'extension-init', 'exec:COMMIT']);
+  expect(events.filter((event) => event === 'exec:BEGIN IMMEDIATE')).toHaveLength(2);
+  expect(events.filter((event) => event === 'exec:COMMIT')).toHaveLength(2);
+  expect(sqlite3.get_autocommit).toHaveBeenCalledOnce();
+  expect(events.some((event) => event.startsWith('prepare:PRAGMA'))).toBe(false);
 });
 
 test('required OPFS closes the VFS and does not attempt memory fallback', async () => {

--- a/packages/treecrdt-wa-sqlite/tests/shared-worker-lifecycle.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/shared-worker-lifecycle.test.ts
@@ -47,9 +47,13 @@ function opened(close = vi.fn(async () => undefined)) {
   const api = {
     headLamport: vi.fn(async () => 7),
   };
+  const runner = {
+    exec: vi.fn(async () => undefined),
+    getText: vi.fn(async () => null),
+  };
   return {
     close,
-    result: { db: { close }, api, storage: 'memory' as const, filename: ':memory:' },
+    result: { db: { close }, api, runner, storage: 'memory' as const, filename: ':memory:' },
   };
 }
 

--- a/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
@@ -123,22 +123,25 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test('single-owner WAL rejects direct and shared-worker runtimes before startup', async () => {
-  vi.stubGlobal('window', { crossOriginIsolated: true });
-  vi.stubGlobal('navigator', { storage: { getDirectory: vi.fn() } });
-  vi.stubGlobal('SharedWorker', class {});
+test.each(['single-owner-wal', 'opfs-write-ahead'] as const)(
+  '%s rejects direct and shared-worker runtimes before startup',
+  async (writeMode) => {
+    vi.stubGlobal('window', { crossOriginIsolated: true });
+    vi.stubGlobal('navigator', { storage: { getDirectory: vi.fn() } });
+    vi.stubGlobal('SharedWorker', class {});
 
-  for (const runtime of ['direct', 'shared-worker'] as const) {
-    await expect(
-      createTreecrdtClient({
-        storage: { type: 'opfs', writeMode: 'single-owner-wal' },
-        runtime: { type: runtime },
-      }),
-    ).rejects.toThrow(
-      'OPFS storage.writeMode "single-owner-wal" requires runtime "dedicated-worker" or runtime "auto"',
-    );
-  }
-});
+    for (const runtime of ['direct', 'shared-worker'] as const) {
+      await expect(
+        createTreecrdtClient({
+          storage: { type: 'opfs', writeMode },
+          runtime: { type: runtime },
+        }),
+      ).rejects.toThrow(
+        `OPFS storage.writeMode "${writeMode}" requires runtime "dedicated-worker" or runtime "auto"`,
+      );
+    }
+  },
+);
 
 for (const runtime of ['dedicated-worker', 'shared-worker'] as const) {
   test(`${runtime} cleans up after rejected initialization`, async () => {


### PR DESCRIPTION
## Why

The default cooperative OPFS VFS is conservative, but some applications need multiple independent browser connections to one OPFS database. This draft adds an experimental `opfs-write-ahead` mode backed by upstream OPFSWriteAheadVFS.

TreeCRDT writes use `SELECT treecrdt_*`, so SQLite cannot infer write intent. #211 owns the transaction state machine needed to acquire the correct lock safely.

## Usage

```ts
const client = await createTreecrdtClient({
  storage: {
    type: 'opfs',
    filename: '/treecrdt.db',
    fallback: 'throw',
    writeMode: 'opfs-write-ahead',
  },
  runtime: { type: 'dedicated-worker' },
});
```

## What changes

- Select OPFSWriteAheadVFS and initialize TreeCRDT inside an immediate transaction.
- Reuse #211's executor for adapter and raw-SQL calls.
- Support the mode only in dedicated workers.
- Require SQLite autocommit state on the internal `Database` contract.
- Remove `-wa0`/`-wa1` files during normal drop cleanup.
- Cover reopen/drop, two-client visibility, auth, and savepoint rollback.

## Fast paths left

- `default` and `single-owner-wal` return the direct runner: no parser, queue, autocommit read, or injected SQL.
- Caller-owned immediate/exclusive transactions remain caller-owned.
- Ordinary `INSERT`/`UPDATE` stays direct.
- Adapter and raw-SQL calls share one runner and one ownership state.

Deferred transactions are rejected in this mode; use immediate/exclusive transactions or savepoints through `client.runner`.

## Clean-slate/debloat

- `Database.getAutocommit` is required; no optional-method bridge remains.
- The extracted adapter APIs do not accept the obsolete `maxBulkOps` option.
- The default-mode bypass exists only in `createWaSqliteRunner`; #211 does not duplicate it.
- Generated submodule artifacts and the old benchmark harness remain omitted.
- Incremental diff: 17 files, +421/-51.

## Verification

- TypeScript and Prettier pass
- Executor tests: 8/8
- Integrated lifecycle/write-ahead tests: 33/33
