### PR TITLE
fix: base defensive deletion on effective payload state

### DIFF
--- a/.changeset/effective-payload-delete.md
+++ b/.changeset/effective-payload-delete.md
@@ -1,0 +1,5 @@
+---
+"@treecrdt/wa-sqlite": minor
+---
+
+Base defensive deletion on structural subtree history and each node's current LWW payload writer, so superseded payload writes no longer restore deleted nodes. Existing materialized development databases must be reset or replayed once.

--- a/docs/defensive-deletion/defensive-deletion.md
+++ b/docs/defensive-deletion/defensive-deletion.md
@@ -24,10 +24,11 @@ Defensive deletion uses a three-phase approach: **Capture**, **Tombstone**, and 
 
 When a delete operation is created:
 
-1. **Calculate Subtree Version Vector**: The system recursively calculates all operations affecting the node and its entire subtree
-   - Includes the node's own operations
+1. **Calculate Subtree Version Vector**: The system recursively calculates the operations that contribute to the node's current effective subtree
+   - Includes gap-aware structural history
+   - Includes each node's current LWW payload writer
+   - Excludes superseded payload writes, since they no longer represent surviving content
    - Recursively includes all children's subtree version vectors
-   - Represents "all operations that affect this subtree"
 
 2. **Store as Known State**: The calculated version vector is stored as `known_state` in the delete operation
    - This captures "what we knew about this subtree when we deleted it"

--- a/docs/defensive-deletion/version-vectors.md
+++ b/docs/defensive-deletion/version-vectors.md
@@ -77,9 +77,9 @@ Version vectors are used in several key places in the TreeCRDT implementation:
 
 Each node in the tree maintains version vector information:
 
-- **`last_change`**: Version vector tracking the last operation that modified this node
-  - Updated when insert, move, or delete operations affect the node
-  - Represents "what operations have modified this node"
+- **`last_change`**: Version vector tracking structural operations that affected this node
+  - Updated when insert or move operations affect the node
+  - Payload history is tracked separately by the payload store
 
 - **`deleted_at`**: Optional version vector storing delete operation awareness
   - Set when a delete operation is applied
@@ -158,10 +158,14 @@ After merge:
 This is critical for defensive deletion. When calculating what operations affect a subtree:
 
 **Process**:
-1. Start with the node's own `last_change` version vector
-2. For each child, recursively calculate its subtree version vector
-3. Merge each child's subtree version vector into the parent's
-4. Result: A version vector representing all operations affecting this node and all its descendants
+1. Start with the node's structural `last_change` version vector
+2. Add the operation dot for the node's current LWW payload writer, if any
+3. Repeat for every physical child
+4. Merge the results
+
+Only the current payload writer contributes because older payload writes have been superseded and
+no longer represent surviving content. This also applies when the current writer clears a payload.
+The older operations remain in the operation log for synchronization and replay.
 
 **Example**:
 ```
@@ -217,7 +221,11 @@ Check: Is delete aware?
 - Calculate subtree version vector → store as `known_state` in operation
 - Create delete operation's version vector
 - Merge operation VV with `known_state` → store in node's `deleted_at`
-- Update node's `last_change` version vector (if not already updated)
+
+### Payload Operations
+- Persist every operation in the operation log
+- Select the current payload with LWW ordering
+- Include only the current writer's operation dot in subtree deletion awareness
 
 ## How Version Vectors Are Sent Between Clients
 

--- a/packages/treecrdt-core/src/traits.rs
+++ b/packages/treecrdt-core/src/traits.rs
@@ -129,27 +129,6 @@ pub trait NodeStore {
         Ok(Some((self.parent(node)?, self.has_deleted_at(node)?)))
     }
 
-    /// Return structural history for this node and its physical descendants.
-    ///
-    /// This deliberately excludes payload writers. Use [`crate::TreeCrdt::subtree_version_vector`]
-    /// when calculating defensive-deletion awareness.
-    fn structural_subtree_version_vector(&self, node: NodeId) -> Result<VersionVector> {
-        let mut subtree_vv = VersionVector::new();
-        let mut pending = vec![node];
-        let mut visited = HashSet::new();
-
-        while let Some(current) = pending.pop() {
-            if !visited.insert(current) || !self.exists(current)? {
-                continue;
-            }
-
-            subtree_vv.merge(&self.last_change(current)?);
-            pending.extend(self.children(current)?);
-        }
-
-        Ok(subtree_vv)
-    }
-
     fn all_nodes(&self) -> Result<Vec<NodeId>>;
 }
 

--- a/packages/treecrdt-core/src/traits.rs
+++ b/packages/treecrdt-core/src/traits.rs
@@ -108,6 +108,10 @@ pub trait NodeStore {
     fn tombstone(&self, node: NodeId) -> Result<bool>;
     fn set_tombstone(&mut self, node: NodeId, tombstone: bool) -> Result<()>;
 
+    /// Gap-aware structural history for this node.
+    ///
+    /// Payload winner state is stored separately by [`PayloadStore`]. Tree-level defensive
+    /// deletion combines this structural history with the current LWW payload writer.
     fn last_change(&self, node: NodeId) -> Result<VersionVector>;
     fn merge_last_change(&mut self, node: NodeId, delta: &VersionVector) -> Result<()>;
 
@@ -125,15 +129,22 @@ pub trait NodeStore {
         Ok(Some((self.parent(node)?, self.has_deleted_at(node)?)))
     }
 
-    fn subtree_version_vector(&self, node: NodeId) -> Result<VersionVector> {
-        if !self.exists(node)? {
-            return Ok(VersionVector::new());
-        }
+    /// Return structural history for this node and its physical descendants.
+    ///
+    /// This deliberately excludes payload writers. Use [`crate::TreeCrdt::subtree_version_vector`]
+    /// when calculating defensive-deletion awareness.
+    fn structural_subtree_version_vector(&self, node: NodeId) -> Result<VersionVector> {
+        let mut subtree_vv = VersionVector::new();
+        let mut pending = vec![node];
+        let mut visited = HashSet::new();
 
-        let mut subtree_vv = self.last_change(node)?;
-        for child_id in self.children(node)? {
-            let child_vv = self.subtree_version_vector(child_id)?;
-            subtree_vv.merge(&child_vv);
+        while let Some(current) = pending.pop() {
+            if !visited.insert(current) || !self.exists(current)? {
+                continue;
+            }
+
+            subtree_vv.merge(&self.last_change(current)?);
+            pending.extend(self.children(current)?);
         }
 
         Ok(subtree_vv)

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -676,10 +676,6 @@ where
     /// current LWW writer. Superseded payload writes do not represent surviving content and
     /// therefore cannot veto a defensive deletion.
     pub fn subtree_version_vector(&self, node: NodeId) -> Result<VersionVector> {
-        if !self.nodes.exists(node)? {
-            return Ok(VersionVector::new());
-        }
-
         let mut subtree_vv = VersionVector::new();
         let mut pending = vec![node];
         let mut visited = HashSet::new();
@@ -690,7 +686,7 @@ where
             }
 
             subtree_vv.merge(&self.nodes.last_change(current)?);
-            if let Some((_lamport, writer)) = self.payloads.last_writer(current)? {
+            if let Some((_, writer)) = self.payloads.last_writer(current)? {
                 subtree_vv.observe(&writer.replica, writer.counter);
             }
             pending.extend(self.nodes.children(current)?);

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -250,7 +250,7 @@ where
     pub fn prepare_local_delete(&mut self, node: NodeId) -> Result<PreparedLocalOp> {
         let old_parent = self.parent(node)?;
         let (replica, counter, lamport, _seed) = self.next_op_meta();
-        let known_state = Some(self.nodes.subtree_version_vector(node)?);
+        let known_state = Some(self.subtree_version_vector(node)?);
         let op = Operation::delete(&replica, counter, lamport, node, known_state);
         Ok(PreparedLocalOp {
             op,
@@ -650,7 +650,7 @@ where
         let Some(deleted_vv) = self.nodes.deleted_at(node)? else {
             return Ok(false);
         };
-        let subtree_vv = self.nodes.subtree_version_vector(node)?;
+        let subtree_vv = self.subtree_version_vector(node)?;
         Ok(deleted_vv.is_aware_of(&subtree_vv))
     }
 
@@ -670,8 +670,33 @@ where
         Ok(pairs)
     }
 
+    /// Return the operations that contribute to the subtree's current effective state.
+    ///
+    /// Structural history is gap-aware, while payload history contributes only each node's
+    /// current LWW writer. Superseded payload writes do not represent surviving content and
+    /// therefore cannot veto a defensive deletion.
     pub fn subtree_version_vector(&self, node: NodeId) -> Result<VersionVector> {
-        self.nodes.subtree_version_vector(node)
+        if !self.nodes.exists(node)? {
+            return Ok(VersionVector::new());
+        }
+
+        let mut subtree_vv = VersionVector::new();
+        let mut pending = vec![node];
+        let mut visited = HashSet::new();
+
+        while let Some(current) = pending.pop() {
+            if !visited.insert(current) || !self.nodes.exists(current)? {
+                continue;
+            }
+
+            subtree_vv.merge(&self.nodes.last_change(current)?);
+            if let Some((_lamport, writer)) = self.payloads.last_writer(current)? {
+                subtree_vv.observe(&writer.replica, writer.counter);
+            }
+            pending.extend(self.nodes.children(current)?);
+        }
+
+        Ok(subtree_vv)
     }
 
     pub fn export_nodes(&self) -> Result<Vec<NodeExport>> {
@@ -831,8 +856,8 @@ where
         nodes.ensure_node(node)?;
         nodes.detach(node)?;
         nodes.attach(node, parent, order_key)?;
-        Self::update_last_change(nodes, op, node)?;
-        Self::update_last_change(nodes, op, parent)?;
+        Self::update_structural_last_change(nodes, op, node)?;
+        Self::update_structural_last_change(nodes, op, parent)?;
         Ok(())
     }
 
@@ -859,14 +884,14 @@ where
         nodes.detach(node)?;
         nodes.attach(node, new_parent, order_key)?;
 
-        Self::update_last_change(nodes, op, node)?;
+        Self::update_structural_last_change(nodes, op, node)?;
         if let Some(old_p) = old_parent {
             if old_p != NodeId::TRASH {
-                Self::update_last_change(nodes, op, old_p)?;
+                Self::update_structural_last_change(nodes, op, old_p)?;
             }
         }
         if new_parent != NodeId::TRASH {
-            Self::update_last_change(nodes, op, new_parent)?;
+            Self::update_structural_last_change(nodes, op, new_parent)?;
         }
         Ok(())
     }
@@ -915,7 +940,6 @@ where
             payload.map(|bytes| bytes.to_vec()),
             (op.meta.lamport, op.meta.id.clone()),
         )?;
-        Self::update_last_change(nodes, op, node)?;
         Ok(())
     }
 
@@ -925,12 +949,8 @@ where
         vv
     }
 
-    fn update_last_change(nodes: &mut N, op: &Operation, node: NodeId) -> Result<()> {
-        nodes.merge_last_change(node, &Self::operation_version_vector(op))?;
-        if let Some(known_state) = &op.meta.known_state {
-            nodes.merge_last_change(node, known_state)?;
-        }
-        Ok(())
+    fn update_structural_last_change(nodes: &mut N, op: &Operation, node: NodeId) -> Result<()> {
+        nodes.merge_last_change(node, &Self::operation_version_vector(op))
     }
 
     fn introduces_cycle(nodes: &N, node: NodeId, potential_parent: NodeId) -> Result<bool> {

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -11,6 +11,7 @@ pub struct NodeExport {
     pub node: NodeId,
     pub parent: Option<NodeId>,
     pub children: Vec<NodeId>,
+    /// Gap-aware structural history. Effective payload awareness is derived from its LWW writer.
     pub last_change: VersionVector,
     pub deleted_at: Option<VersionVector>,
 }

--- a/packages/treecrdt-core/tests/defensive_delete.rs
+++ b/packages/treecrdt-core/tests/defensive_delete.rs
@@ -442,6 +442,106 @@ fn defensive_delete_parent_then_payload_change_no_restoration_when_aware() {
 }
 
 #[test]
+fn defensive_delete_ignores_unseen_superseded_payload_write() {
+    let mut structure = TreeCrdt::new(
+        ReplicaId::new(b"structure"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut payload_writer = TreeCrdt::new(
+        ReplicaId::new(b"payload"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut deleter = TreeCrdt::new(
+        ReplicaId::new(b"deleter"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+
+    let parent = NodeId(1);
+    let (parent_op, _) = structure
+        .local_insert(NodeId::ROOT, parent, LocalPlacement::First, None)
+        .unwrap();
+    payload_writer.apply_remote(parent_op.clone()).unwrap();
+    deleter.apply_remote(parent_op).unwrap();
+
+    let (superseded_payload_op, _) =
+        payload_writer.local_payload(parent, Some(b"old".to_vec())).unwrap();
+    let (winning_payload_op, _) =
+        payload_writer.local_payload(parent, Some(b"current".to_vec())).unwrap();
+
+    // The deleter sees the current LWW payload, but not the older write it supersedes.
+    deleter.apply_remote(winning_payload_op).unwrap();
+    let (delete_op, _) = deleter.local_delete(parent).unwrap();
+    payload_writer.apply_remote(delete_op).unwrap();
+
+    assert!(deleter.is_tombstoned(parent).unwrap());
+    assert!(payload_writer.is_tombstoned(parent).unwrap());
+
+    // Receiving the superseded write later changes no surviving state, so it must not restore
+    // the node.
+    deleter.apply_remote(superseded_payload_op).unwrap();
+
+    assert!(deleter.is_tombstoned(parent).unwrap());
+    assert!(payload_writer.is_tombstoned(parent).unwrap());
+    assert_eq!(deleter.payload(parent).unwrap(), Some(b"current".to_vec()));
+    assert_eq!(
+        payload_writer.payload(parent).unwrap(),
+        Some(b"current".to_vec())
+    );
+
+    assert_eq!(deleter.nodes().unwrap(), payload_writer.nodes().unwrap());
+    deleter.validate_invariants().unwrap();
+    payload_writer.validate_invariants().unwrap();
+}
+
+#[test]
+fn defensive_delete_counts_a_payload_clear_as_the_current_writer() {
+    let mut structure = TreeCrdt::new(
+        ReplicaId::new(b"structure"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut payload_writer = TreeCrdt::new(
+        ReplicaId::new(b"payload"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let mut deleter = TreeCrdt::new(
+        ReplicaId::new(b"deleter"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+
+    let parent = NodeId(1);
+    let (parent_op, _) = structure
+        .local_insert(NodeId::ROOT, parent, LocalPlacement::First, None)
+        .unwrap();
+    payload_writer.apply_remote(parent_op.clone()).unwrap();
+    deleter.apply_remote(parent_op).unwrap();
+
+    payload_writer.local_payload(parent, Some(b"value".to_vec())).unwrap();
+    let (clear_payload_op, _) = payload_writer.local_payload(parent, None).unwrap();
+
+    // A clear has no payload bytes, but its writer is still the effective LWW payload state.
+    deleter.apply_remote(clear_payload_op).unwrap();
+    let (delete_op, _) = deleter.local_delete(parent).unwrap();
+    payload_writer.apply_remote(delete_op).unwrap();
+
+    assert!(deleter.is_tombstoned(parent).unwrap());
+    assert!(payload_writer.is_tombstoned(parent).unwrap());
+    assert_eq!(deleter.payload(parent).unwrap(), None);
+    assert_eq!(payload_writer.payload(parent).unwrap(), None);
+}
+
+#[test]
 fn defensive_delete_later_delete_unaware_restores_parent() {
     let mut crdt_a = TreeCrdt::new(
         ReplicaId::new(b"a"),

--- a/packages/treecrdt-core/tests/subtree_version_vector.rs
+++ b/packages/treecrdt-core/tests/subtree_version_vector.rs
@@ -1,0 +1,46 @@
+use treecrdt_core::{MemoryNodeStore, NodeId, NodeStore, ReplicaId, VersionVector};
+
+fn version(replica: &ReplicaId, counter: u64) -> VersionVector {
+    let mut vv = VersionVector::new();
+    vv.observe(replica, counter);
+    vv
+}
+
+#[test]
+fn structural_subtree_walk_terminates_on_cycle_and_merges_each_node() {
+    let replica_a = ReplicaId::new(b"a");
+    let replica_b = ReplicaId::new(b"b");
+    let node_a = NodeId(1);
+    let node_b = NodeId(2);
+    let mut nodes = MemoryNodeStore::default();
+
+    nodes.attach(node_a, node_b, vec![0x10]).unwrap();
+    nodes.attach(node_b, node_a, vec![0x20]).unwrap();
+    nodes.merge_last_change(node_a, &version(&replica_a, 1)).unwrap();
+    nodes.merge_last_change(node_b, &version(&replica_b, 2)).unwrap();
+
+    let subtree = nodes.structural_subtree_version_vector(node_a).unwrap();
+
+    assert_eq!(subtree.get(&replica_a), 1);
+    assert_eq!(subtree.get(&replica_b), 2);
+}
+
+#[test]
+fn structural_subtree_walk_handles_a_deep_chain_without_recursion() {
+    const DEPTH: u64 = 50_000;
+
+    let replica = ReplicaId::new(b"deep-chain");
+    let mut nodes = MemoryNodeStore::default();
+    let mut parent = NodeId::ROOT;
+
+    for counter in 1..=DEPTH {
+        let child = NodeId(counter as u128);
+        nodes.attach(child, parent, vec![0x10]).unwrap();
+        nodes.merge_last_change(child, &version(&replica, counter)).unwrap();
+        parent = child;
+    }
+
+    let subtree = nodes.structural_subtree_version_vector(NodeId::ROOT).unwrap();
+
+    assert_eq!(subtree.frontier(&replica), DEPTH);
+}

--- a/packages/treecrdt-core/tests/subtree_version_vector.rs
+++ b/packages/treecrdt-core/tests/subtree_version_vector.rs
@@ -1,4 +1,7 @@
-use treecrdt_core::{MemoryNodeStore, NodeId, NodeStore, ReplicaId, VersionVector};
+use treecrdt_core::{
+    LamportClock, MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId, NodeStore, ReplicaId,
+    TreeCrdt, VersionVector,
+};
 
 fn version(replica: &ReplicaId, counter: u64) -> VersionVector {
     let mut vv = VersionVector::new();
@@ -7,7 +10,7 @@ fn version(replica: &ReplicaId, counter: u64) -> VersionVector {
 }
 
 #[test]
-fn structural_subtree_walk_terminates_on_cycle_and_merges_each_node() {
+fn subtree_walk_terminates_on_cycle_and_merges_each_node() {
     let replica_a = ReplicaId::new(b"a");
     let replica_b = ReplicaId::new(b"b");
     let node_a = NodeId(1);
@@ -19,14 +22,22 @@ fn structural_subtree_walk_terminates_on_cycle_and_merges_each_node() {
     nodes.merge_last_change(node_a, &version(&replica_a, 1)).unwrap();
     nodes.merge_last_change(node_b, &version(&replica_b, 2)).unwrap();
 
-    let subtree = nodes.structural_subtree_version_vector(node_a).unwrap();
+    let tree = TreeCrdt::with_stores(
+        ReplicaId::new(b"tree"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+        nodes,
+        MemoryPayloadStore::default(),
+    )
+    .unwrap();
+    let subtree = tree.subtree_version_vector(node_a).unwrap();
 
     assert_eq!(subtree.get(&replica_a), 1);
     assert_eq!(subtree.get(&replica_b), 2);
 }
 
 #[test]
-fn structural_subtree_walk_handles_a_deep_chain_without_recursion() {
+fn subtree_walk_handles_a_deep_chain_without_recursion() {
     const DEPTH: u64 = 50_000;
 
     let replica = ReplicaId::new(b"deep-chain");
@@ -40,7 +51,15 @@ fn structural_subtree_walk_handles_a_deep_chain_without_recursion() {
         parent = child;
     }
 
-    let subtree = nodes.structural_subtree_version_vector(NodeId::ROOT).unwrap();
+    let tree = TreeCrdt::with_stores(
+        ReplicaId::new(b"tree"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+        nodes,
+        MemoryPayloadStore::default(),
+    )
+    .unwrap();
+    let subtree = tree.subtree_version_vector(NodeId::ROOT).unwrap();
 
     assert_eq!(subtree.frontier(&replica), DEPTH);
 }

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -255,6 +255,14 @@ fn postgres_backend_deferred_recovery_from_replay_frontier_catches_up_on_ensure(
 }
 
 #[test]
+fn postgres_backend_superseded_payload_gap_does_not_restore_after_replay() {
+    let Some(harness) = setup_conformance_harness() else {
+        return;
+    };
+    materialization_conformance::superseded_payload_gap_does_not_restore_after_replay(&harness);
+}
+
+#[test]
 fn postgres_backend_out_of_order_delete_suffix_falls_back_and_restores_parent() {
     let Some(harness) = setup_conformance_harness() else {
         return;

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -610,6 +610,12 @@ fn remote_deferred_recovery_from_replay_frontier_catches_up_on_ensure() {
 }
 
 #[test]
+fn remote_superseded_payload_gap_does_not_restore_after_replay() {
+    let harness = setup_conformance_harness();
+    materialization_conformance::superseded_payload_gap_does_not_restore_after_replay(&harness);
+}
+
+#[test]
 fn remote_append_out_of_order_delete_suffix_falls_back_and_restores_parent() {
     let harness = setup_conformance_harness();
     materialization_conformance::out_of_order_delete_suffix_falls_back_and_restores_parent(

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -326,6 +326,50 @@ pub fn deferred_recovery_from_replay_frontier_catches_up_on_ensure<
     assert_eq!(harness.op_ref_counters_for_parent(NodeId::ROOT), vec![1, 2]);
 }
 
+pub fn superseded_payload_gap_does_not_restore_after_replay<
+    H: MaterializationConformanceHarness,
+>(
+    harness: &H,
+) {
+    let structure_replica = ReplicaId::new(b"structure");
+    let payload_replica = ReplicaId::new(b"payload");
+    let delete_replica = ReplicaId::new(b"delete");
+    let parent = node(1);
+
+    let insert_parent = Operation::insert(
+        &structure_replica,
+        1,
+        1,
+        NodeId::ROOT,
+        parent,
+        order_key_from_position(0),
+    );
+    let superseded_payload =
+        Operation::set_payload(&payload_replica, 1, 2, parent, b"old".to_vec());
+    let winning_payload = Operation::clear_payload(&payload_replica, 2, 3, parent);
+
+    let mut known_state = treecrdt_core::VersionVector::new();
+    known_state.observe(&structure_replica, 1);
+    known_state.observe(&payload_replica, 2);
+    let delete_parent = Operation::delete(&delete_replica, 1, 4, parent, Some(known_state));
+
+    // The delete sees the current payload writer but has a receipt gap for its predecessor.
+    harness.append_ops(&[insert_parent, winning_payload, delete_parent]);
+    assert_eq!(harness.visible_children(NodeId::ROOT), Vec::<NodeId>::new());
+
+    // The late predecessor is an LWW no-op. Incremental materialization and a canonical replay
+    // must agree that it cannot restore the node.
+    harness.append_ops(&[superseded_payload]);
+    assert_eq!(harness.visible_children(NodeId::ROOT), Vec::<NodeId>::new());
+    harness.force_replay_from_start();
+    harness.ensure_materialized();
+
+    assert_replay_cleared(harness);
+    assert_eq!(harness.head_seq(), 4);
+    assert_eq!(harness.visible_children(NodeId::ROOT), Vec::<NodeId>::new());
+    assert_eq!(harness.payload(parent), None);
+}
+
 pub fn out_of_order_delete_suffix_falls_back_and_restores_parent<
     H: MaterializationConformanceHarness,
 >(


### PR DESCRIPTION
## Why

A delete could be undone by a late payload write even when that write was already superseded by the payload winner the deleter had seen. The late write changes no surviving content, so it should not veto deletion.

## What changes

- Keep `last_change` structural and derive payload awareness from each node’s current LWW writer, including clears.
- Preserve restoration when a delete misses the current payload winner or surviving structural work.
- Make subtree traversal iterative and cycle-safe.
- Cover the semantics in core, SQLite, and PostgreSQL replay tests.

Existing development databases materialized with the old payload-history rule must be reset or replayed.

## Stack

Foundation for #226.