### PR TITLE
fix: emit net materialization catch-up changes

### DIFF
--- a/.changeset/net-materialization-outcomes.md
+++ b/.changeset/net-materialization-outcomes.md
@@ -1,0 +1,6 @@
+---
+"@treecrdt/interface": patch
+"@treecrdt/wa-sqlite": patch
+---
+
+Emit only the net node-backed changes produced by canonical catch-up. Replay transitions that cancel before the final state no longer trigger materialization events, and catch-up-derived changes may omit operation provenance. Failed incremental writes are rolled back before canonical repair so catch-up outcomes retain exact before/after semantics.

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::affected::coalesce_materialization_changes;
 use crate::ops::{cmp_op_key, cmp_ops, Operation};
@@ -173,7 +173,7 @@ pub struct CatchUpResult {
 pub struct PersistedRemoteApplyResult {
     /// Number of ops from the input batch that were actually inserted by adapter-side dedupe.
     pub inserted_count: u64,
-    /// Structured changes produced by core materialization when replay succeeded.
+    /// Structured changes produced when materialization advanced.
     ///
     /// This is empty when nothing was inserted or when the helper could not advance
     /// materialization immediately and had to hand catch-up work back to the caller.
@@ -486,13 +486,6 @@ impl MaterializationOutcome {
             changes: coalesce_materialization_changes(changes),
         }
     }
-
-    fn merge(head_seq: u64, outcomes: impl IntoIterator<Item = MaterializationOutcome>) -> Self {
-        Self::from_changes(
-            head_seq,
-            outcomes.into_iter().flat_map(|outcome| outcome.changes).collect(),
-        )
-    }
 }
 
 /// Apply an incremental batch and return both head metadata and the structured materialization delta.
@@ -722,6 +715,7 @@ where
         mut index,
     } = stores;
 
+    let before = snapshot_visible_state(&nodes, |node| payloads.payload(node))?;
     index.truncate_from(truncate_from)?;
     rewind_existing_payload_suffix_in_place(
         &mut payloads,
@@ -736,13 +730,15 @@ where
         replay.apply_sorted(&mut crdt, &mut index, op)?;
     }
     let run = replay.finish();
+    let after = snapshot_visible_state(crdt.node_store(), |node| crdt.payload(node))?;
+    let visible_changes = visible_changes_between(&before, &after);
 
     flush_nodes(crdt.node_store_mut())?;
     flush_index(&mut index)?;
 
     Ok(Some(CatchUpResult {
         head: run.head.as_ref().map(|head| MaterializationHead::from_op(head, run.seq)),
-        outcome: run.outcome,
+        outcome: MaterializationOutcome::from_changes(run.seq, visible_changes),
     }))
 }
 
@@ -789,53 +785,157 @@ fn validate_rebuilt_state<M: MaterializationCursor>(
     Ok(())
 }
 
-fn repair_visibility_changes<N: NodeStore>(
-    rebuilt: &mut RebuiltMaterialization,
-    persisted_nodes: &[NodeId],
+struct VisibleNodeState {
+    parent: Option<NodeId>,
+    order_key: Option<Vec<u8>>,
+    tombstone: bool,
+    payload: Option<Vec<u8>>,
+}
+
+fn snapshot_visible_state<N: NodeStore>(
     nodes: &N,
-) -> Result<Vec<MaterializationChange>> {
+    mut payload: impl FnMut(NodeId) -> Result<Option<Vec<u8>>>,
+) -> Result<HashMap<NodeId, VisibleNodeState>> {
+    let mut snapshot = HashMap::new();
+    for node in nodes.all_nodes()? {
+        snapshot.insert(
+            node,
+            VisibleNodeState {
+                parent: nodes.parent(node)?,
+                order_key: nodes.order_key(node)?,
+                tombstone: nodes.tombstone(node)?,
+                payload: payload(node)?,
+            },
+        );
+    }
+    Ok(snapshot)
+}
+
+fn visible_parent(state: &VisibleNodeState) -> Option<NodeId> {
+    state.parent.filter(|parent| *parent != NodeId::TRASH)
+}
+
+fn payload_change_between(
+    node: NodeId,
+    before: Option<&VisibleNodeState>,
+    after: Option<&VisibleNodeState>,
+) -> Option<MaterializationChange> {
+    let previous_payload = before.and_then(|state| state.payload.as_ref());
+    let final_payload = after.and_then(|state| state.payload.as_ref());
+    (previous_payload != final_payload).then(|| MaterializationChange::Payload {
+        node,
+        payload: final_payload.cloned(),
+        source: None,
+    })
+}
+
+fn node_change_between(
+    node: NodeId,
+    before: Option<&VisibleNodeState>,
+    after: Option<&VisibleNodeState>,
+) -> Option<MaterializationChange> {
+    match (before, after) {
+        (Some(previous), Some(final_state)) if previous.tombstone && !final_state.tombstone => {
+            Some(MaterializationChange::Restore {
+                node,
+                parent_after: visible_parent(final_state),
+                payload: final_state.payload.clone(),
+                source: None,
+            })
+        }
+        (Some(previous), Some(final_state)) if !previous.tombstone && final_state.tombstone => {
+            Some(MaterializationChange::Delete {
+                node,
+                parent_before: visible_parent(previous),
+                source: None,
+            })
+        }
+        (None, Some(final_state)) if final_state.tombstone => {
+            Some(MaterializationChange::Payload {
+                node,
+                payload: final_state.payload.clone(),
+                source: None,
+            })
+        }
+        (None, Some(final_state)) => Some(match final_state.parent {
+            Some(parent_after) => MaterializationChange::Insert {
+                node,
+                parent_after,
+                payload: final_state.payload.clone(),
+                source: None,
+            },
+            None => MaterializationChange::Payload {
+                node,
+                payload: final_state.payload.clone(),
+                source: None,
+            },
+        }),
+        (Some(previous), None) if previous.tombstone => Some(MaterializationChange::Payload {
+            node,
+            payload: None,
+            source: None,
+        }),
+        (Some(previous), None) => Some(MaterializationChange::Delete {
+            node,
+            parent_before: visible_parent(previous),
+            source: None,
+        }),
+        (Some(previous), Some(final_state)) if !previous.tombstone && !final_state.tombstone => {
+            match (previous.parent, final_state.parent) {
+                (None, Some(parent_after)) => Some(MaterializationChange::Insert {
+                    node,
+                    parent_after,
+                    payload: final_state.payload.clone(),
+                    source: None,
+                }),
+                (Some(parent_before), None) => Some(MaterializationChange::Delete {
+                    node,
+                    parent_before: (parent_before != NodeId::TRASH).then_some(parent_before),
+                    source: None,
+                }),
+                (Some(parent_before), Some(parent_after))
+                    if parent_before != parent_after
+                        || previous.order_key != final_state.order_key =>
+                {
+                    Some(MaterializationChange::Move {
+                        node,
+                        parent_before: (parent_before != NodeId::TRASH).then_some(parent_before),
+                        parent_after,
+                        source: None,
+                    })
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+fn visible_changes_between(
+    before: &HashMap<NodeId, VisibleNodeState>,
+    after: &HashMap<NodeId, VisibleNodeState>,
+) -> Vec<MaterializationChange> {
+    let mut all_nodes: Vec<_> = before.keys().chain(after.keys()).copied().collect();
+    all_nodes.sort();
+    all_nodes.dedup();
+
     let mut changes = Vec::new();
-    for node in persisted_nodes {
-        if *node == NodeId::ROOT || *node == NodeId::TRASH {
+    for node in all_nodes {
+        if node == NodeId::ROOT || node == NodeId::TRASH {
+            changes.extend(payload_change_between(
+                node,
+                before.get(&node),
+                after.get(&node),
+            ));
             continue;
         }
 
-        let previous_parent = nodes.parent(*node)?;
-        let previous_tombstone = nodes.tombstone(*node)?;
-        if rebuilt.crdt.node_store_mut().exists(*node)? {
-            let final_parent = rebuilt.crdt.node_store_mut().parent(*node)?;
-            let final_tombstone = rebuilt.crdt.node_store_mut().tombstone(*node)?;
-            match (previous_tombstone, final_tombstone) {
-                (true, false) => changes.push(MaterializationChange::Restore {
-                    node: *node,
-                    parent_after: final_parent.filter(|parent| *parent != NodeId::TRASH),
-                    payload: rebuilt.crdt.payload(*node)?,
-                    source: None,
-                }),
-                (false, true) => changes.push(MaterializationChange::Delete {
-                    node: *node,
-                    parent_before: previous_parent.filter(|parent| *parent != NodeId::TRASH),
-                    source: None,
-                }),
-                _ => {}
-            }
-        } else if !previous_tombstone {
-            changes.push(MaterializationChange::Delete {
-                node: *node,
-                parent_before: previous_parent.filter(|parent| *parent != NodeId::TRASH),
-                source: None,
-            });
-        }
+        let before_state = before.get(&node);
+        let after_state = after.get(&node);
+        changes.extend(node_change_between(node, before_state, after_state));
+        changes.extend(payload_change_between(node, before_state, after_state));
     }
-    Ok(changes)
-}
-
-fn visibility_transition_key(change: &MaterializationChange) -> Option<(NodeId, bool)> {
-    match change {
-        MaterializationChange::Delete { node, .. } => Some((*node, false)),
-        MaterializationChange::Restore { node, .. } => Some((*node, true)),
-        _ => None,
-    }
+    changes
 }
 
 fn rebuild_derived_state<N, P, I>(
@@ -890,6 +990,11 @@ where
 
 /// Catch backend materialized state up from a replay frontier by rebuilding derived stores from
 /// the canonical operation log.
+///
+/// The returned outcome is the exact node-backed application-visible delta between persisted state
+/// before the rebuild and canonical final state. Transient replay changes that cancel are omitted.
+/// Payload-only orphan rows are still repaired, but cannot be reported because [`PayloadStore`]
+/// does not expose key enumeration.
 pub fn catch_up_materialized_state<S, C, N, P, I, M, FlushNodes, FlushIndex>(
     storage: S,
     stores: PersistedRemoteStores<C, N, P, I>,
@@ -928,25 +1033,17 @@ where
         mut index,
     } = stores;
 
-    let (mut rebuilt, replay_outcome) =
+    let (mut rebuilt, _replay_outcome) =
         replay_canonical_log_in_memory(&storage, frontier, &replica_id)?;
     validate_rebuilt_state(meta, frontier, &rebuilt)?;
 
-    // Public materialization changes intentionally describe only visible application state. They
-    // are not a safe proxy for rows whose internal CRDT metadata changed: a non-dominating delete,
-    // for example, can update `deleted_at` without emitting a visible delete event. Rebuild every
-    // derived store from the authoritative oplog so metadata and orphan rows converge too.
-    let persisted_nodes = nodes.all_nodes()?;
-    let mut repair_changes = repair_visibility_changes(&mut rebuilt, &persisted_nodes, &nodes)?;
-    // Replay describes the invalidated suffix, while repair changes describe persisted-before to
-    // rebuilt-final visibility. The same transition can appear in both views; feeding duplicates
-    // to the parity-based coalescer would incorrectly cancel a real Restore/Delete.
-    let replayed_visibility: HashSet<_> =
-        replay_outcome.changes.iter().filter_map(visibility_transition_key).collect();
-    repair_changes.retain(|repair| match visibility_transition_key(repair) {
-        Some(transition) => !replayed_visibility.contains(&transition),
-        None => true,
-    });
+    // Replay operations can contain transient moves/restores that leave the externally visible
+    // state unchanged. Snapshot both sides so the public outcome describes only the committed net
+    // delta, while the rebuild below still repairs every piece of derived metadata.
+    let before = snapshot_visible_state(&nodes, |node| payloads.payload(node))?;
+    let after =
+        snapshot_visible_state(rebuilt.crdt.node_store(), |node| rebuilt.crdt.payload(node))?;
+    let visible_changes = visible_changes_between(&before, &after);
 
     rebuild_derived_state(&mut rebuilt, &mut nodes, &mut payloads, &mut index)?;
 
@@ -958,22 +1055,17 @@ where
             .head
             .as_ref()
             .map(|head| MaterializationHead::from_op(head, rebuilt.seq)),
-        outcome: MaterializationOutcome::merge(
-            rebuilt.seq,
-            [
-                replay_outcome,
-                MaterializationOutcome::from_changes(rebuilt.seq, repair_changes),
-            ],
-        ),
+        outcome: MaterializationOutcome::from_changes(rebuilt.seq, visible_changes),
     })
 }
 
 /// Apply already-persisted inserted remote ops and commit adapter-owned metadata writes.
 ///
 /// Adapters own persistence + dedupe and pass only the inserted subset here. If the materialized
-/// doc is already behind a replay frontier, or if incremental materialization / metadata updates
-/// fail, this records a replay frontier and returns control to the caller. Callers can then either
-/// catch up immediately in the same append flow or defer catch-up to a later read/recovery path.
+/// doc is already behind a replay frontier, or if incremental materialization fails, this records
+/// a frontier and returns control to the caller. Adapters must make failed incremental writes
+/// atomic so catch-up observes the state from before the attempt. Metadata-write failures are
+/// returned so the adapter's enclosing transaction can roll back.
 pub fn apply_persisted_remote_ops_with_delta<M, E>(
     meta: &M,
     inserted_ops: Vec<Operation>,
@@ -1009,18 +1101,11 @@ where
                 ));
             };
 
-            if update_head(&head).is_ok() {
-                Ok(PersistedRemoteApplyResult::applied(
-                    inserted_count,
-                    result.outcome,
-                ))
-            } else {
-                schedule_replay(&start_replay_frontier())?;
-                Ok(PersistedRemoteApplyResult::needs_catch_up(
-                    inserted_count,
-                    head_seq,
-                ))
-            }
+            update_head(&head)?;
+            Ok(PersistedRemoteApplyResult::applied(
+                inserted_count,
+                result.outcome,
+            ))
         }
         Err(_) => {
             schedule_replay(&start_replay_frontier())?;
@@ -1390,5 +1475,34 @@ mod tests {
         .unwrap();
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn tombstoned_row_appearance_and_removal_preserve_payload_changes() {
+        let node = NodeId(9);
+        let mut state = VisibleNodeState {
+            parent: Some(NodeId::TRASH),
+            order_key: Some(Vec::new()),
+            tombstone: true,
+            payload: Some(vec![1]),
+        };
+        let payload = |payload| MaterializationChange::Payload {
+            node,
+            payload,
+            source: None,
+        };
+        assert_eq!(
+            node_change_between(node, None, Some(&state)),
+            Some(payload(Some(vec![1])))
+        );
+        assert_eq!(
+            node_change_between(node, Some(&state), None),
+            Some(payload(None))
+        );
+        state.payload = None;
+        assert_eq!(
+            node_change_between(node, None, Some(&state)),
+            Some(payload(None))
+        );
     }
 }

--- a/packages/treecrdt-core/src/types.rs
+++ b/packages/treecrdt-core/src/types.rs
@@ -153,7 +153,8 @@ impl MaterializationChange {
 /// The result of one materialization pass.
 ///
 /// `head_seq` is the materialized op-log frontier after the pass. Empty `changes` means the pass
-/// did not change any visible materialized state and should not emit a public event.
+/// did not change any visible materialized state and should not emit a public event. Outcomes are
+/// not an operation log: `head_seq` can advance without a change.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -3,11 +3,12 @@ use std::rc::Rc;
 use treecrdt_core::NodeStore;
 use treecrdt_core::{
     apply_incremental_ops_with_delta, apply_persisted_remote_ops_with_delta,
-    catch_up_materialized_state, materialize_persisted_remote_ops_with_delta, Lamport,
-    LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationChange, MaterializationCursor,
-    MaterializationHead, MaterializationKey, MaterializationOutcome, MaterializationState,
-    MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId, NoopParentOpIndex, Operation,
-    OperationId, ParentOpIndex, PersistedRemoteStores, ReplicaId, Storage, TreeCrdt, VersionVector,
+    catch_up_materialized_state, materialize_persisted_remote_ops_with_delta, CatchUpResult,
+    Lamport, LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationChange,
+    MaterializationCursor, MaterializationHead, MaterializationKey, MaterializationOutcome,
+    MaterializationState, MemoryNodeStore, MemoryPayloadStore, MemoryStorage, NodeId,
+    NoopParentOpIndex, Operation, OperationId, ParentOpIndex, PayloadStore, PersistedRemoteStores,
+    ReplicaId, Storage, TreeCrdt, VersionVector,
 };
 
 #[derive(Default)]
@@ -59,6 +60,28 @@ impl MaterializationCursor for Cursor {
 
         MaterializationState { head, replay_from }
     }
+}
+
+fn catch_up_memory(
+    storage: MemoryStorage,
+    nodes: MemoryNodeStore,
+    payloads: MemoryPayloadStore,
+    meta: &Cursor,
+) -> CatchUpResult {
+    catch_up_materialized_state(
+        storage,
+        PersistedRemoteStores {
+            replica_id: ReplicaId::new(b"adapter"),
+            clock: LamportClock::default(),
+            nodes,
+            payloads,
+            index: NoopParentOpIndex,
+        },
+        meta,
+        |_| Ok(()),
+        |_| Ok(()),
+    )
+    .unwrap()
 }
 
 impl ParentOpIndex for RecordingIndex {
@@ -403,7 +426,7 @@ fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing()
 }
 
 #[test]
-fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
+fn apply_persisted_remote_ops_propagates_update_head_failure() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
     let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
@@ -444,13 +467,34 @@ fn apply_persisted_remote_ops_schedules_full_replay_when_update_head_fails() {
             scheduled_replay += 1;
             Ok::<(), ()>(())
         },
-    )
-    .unwrap();
+    );
 
-    assert_eq!(scheduled_replay, 1);
-    assert_eq!(result.inserted_count, 1);
-    assert!(result.outcome.changes.is_empty());
+    assert!(result.is_err());
+    assert_eq!(scheduled_replay, 0);
+}
+
+#[test]
+fn apply_persisted_remote_ops_schedules_repair_after_materialization_failure() {
+    let cursor = Cursor::default();
+    let replica = ReplicaId::new(b"remote");
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let mut scheduled_replay = 0u64;
+
+    let result = apply_persisted_remote_ops_with_delta(
+        &cursor,
+        vec![op],
+        |_| Err::<treecrdt_core::IncrementalApplyResult, _>("materialization failed"),
+        |_| Ok(()),
+        |_| {
+            scheduled_replay += 1;
+            Ok(())
+        },
+    );
+
+    let result = result.unwrap();
     assert!(result.catch_up_needed);
+    assert!(result.outcome.changes.is_empty());
+    assert_eq!(scheduled_replay, 1);
 }
 
 #[test]
@@ -632,7 +676,7 @@ fn catch_up_materialized_state_scans_storage_once() {
 }
 
 #[test]
-fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
+fn catch_up_materialized_state_reports_only_net_visible_changes() {
     let replica = ReplicaId::new(b"suffix-only");
     let prefix = NodeId(1);
     let suffix = NodeId(2);
@@ -697,7 +741,129 @@ fn catch_up_materialized_state_reports_only_invalidated_suffix_changes() {
 }
 
 #[test]
-fn catch_up_materialized_state_reports_rows_restored_by_canonical_rebuild() {
+fn catch_up_reports_net_delete() {
+    let creator = ReplicaId::new(b"net-delete-creator");
+    let deleter = ReplicaId::new(b"net-delete-writer");
+    let node = NodeId(7);
+    let unrelated = NodeId(8);
+    let insert = Operation::insert(&creator, 1, 1, NodeId::ROOT, node, vec![0x10]);
+    let mut known_state = VersionVector::new();
+    known_state.observe(&creator, 1);
+    let delete = Operation::delete(&deleter, 1, 2, node, Some(known_state));
+    let head_op = Operation::insert(&creator, 2, 3, NodeId::ROOT, unrelated, vec![0x20]);
+
+    let mut storage = MemoryStorage::default();
+    for op in [&insert, &delete, &head_op] {
+        storage.apply(op.clone()).unwrap();
+    }
+    let mut nodes = MemoryNodeStore::default();
+    nodes.attach(node, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(unrelated, NodeId::ROOT, vec![0x20]).unwrap();
+    let meta = Cursor {
+        head_lamport: head_op.meta.lamport,
+        head_replica: head_op.meta.id.replica.as_bytes().to_vec(),
+        head_counter: head_op.meta.id.counter,
+        head_seq: 2,
+        replay_lamport: Some(delete.meta.lamport),
+        replay_replica: Some(delete.meta.id.replica.as_bytes().to_vec()),
+        replay_counter: Some(delete.meta.id.counter),
+    };
+
+    let result = catch_up_memory(storage, nodes, MemoryPayloadStore::default(), &meta);
+
+    assert_eq!(
+        result.outcome.changes,
+        vec![MaterializationChange::Delete {
+            node,
+            parent_before: Some(NodeId::ROOT),
+            source: None,
+        }]
+    );
+}
+
+#[test]
+fn catch_up_reports_payload_changes_for_root_and_tombstoned_nodes() {
+    let creator = ReplicaId::new(b"payload-creator");
+    let deleter = ReplicaId::new(b"payload-deleter");
+    let node = NodeId(5);
+    let unrelated = NodeId(6);
+    let root_payload = Operation::set_payload(&creator, 1, 1, NodeId::ROOT, vec![1]);
+    let insert =
+        Operation::insert_with_payload(&creator, 2, 2, NodeId::ROOT, node, vec![0x10], vec![1]);
+    let late_root_payload = Operation::clear_payload(&creator, 3, 3, NodeId::ROOT);
+    let late_node_payload = Operation::set_payload(&creator, 4, 4, node, vec![2]);
+    let mut known_state = VersionVector::new();
+    for counter in 1..=4 {
+        known_state.observe(&creator, counter);
+    }
+    let delete = Operation::delete(&deleter, 1, 5, node, Some(known_state.clone()));
+    let head_op = Operation::insert(&creator, 5, 6, NodeId::ROOT, unrelated, vec![0x20]);
+
+    let mut storage = MemoryStorage::default();
+    for op in [
+        &root_payload,
+        &insert,
+        &late_root_payload,
+        &late_node_payload,
+        &delete,
+        &head_op,
+    ] {
+        storage.apply(op.clone()).unwrap();
+    }
+
+    let mut nodes = MemoryNodeStore::default();
+    nodes.attach(node, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(unrelated, NodeId::ROOT, vec![0x20]).unwrap();
+    let mut deleted_at = known_state;
+    deleted_at.observe(&deleter, 1);
+    nodes.merge_deleted_at(node, &deleted_at).unwrap();
+    nodes.set_tombstone(node, true).unwrap();
+    let mut payloads = MemoryPayloadStore::default();
+    payloads
+        .set_payload(
+            NodeId::ROOT,
+            Some(vec![1]),
+            (root_payload.meta.lamport, root_payload.meta.id.clone()),
+        )
+        .unwrap();
+    payloads
+        .set_payload(
+            node,
+            Some(vec![1]),
+            (insert.meta.lamport, insert.meta.id.clone()),
+        )
+        .unwrap();
+
+    let meta = Cursor {
+        head_lamport: head_op.meta.lamport,
+        head_replica: head_op.meta.id.replica.as_bytes().to_vec(),
+        head_counter: head_op.meta.id.counter,
+        head_seq: 4,
+        replay_lamport: Some(late_root_payload.meta.lamport),
+        replay_replica: Some(late_root_payload.meta.id.replica.as_bytes().to_vec()),
+        replay_counter: Some(late_root_payload.meta.id.counter),
+    };
+    let result = catch_up_memory(storage, nodes, payloads, &meta);
+
+    assert_eq!(
+        result.outcome.changes,
+        vec![
+            MaterializationChange::Payload {
+                node: NodeId::ROOT,
+                payload: None,
+                source: None,
+            },
+            MaterializationChange::Payload {
+                node,
+                payload: Some(vec![2]),
+                source: None,
+            },
+        ]
+    );
+}
+
+#[test]
+fn catch_up_materialized_state_reports_net_restore_from_rebuilt_state() {
     let author = ReplicaId::new(b"author");
     let deleter = ReplicaId::new(b"deleter");
     let parent = NodeId(10);
@@ -757,7 +923,7 @@ fn catch_up_materialized_state_reports_rows_restored_by_canonical_rebuild() {
             payload: None,
             source: None,
         }),
-        "catch-up must report rows restored while rebuilding stale backend state"
+        "catch-up must report a real persisted-before to rebuilt-final restore"
     );
     assert_eq!(
         result.outcome.affected_nodes(),
@@ -766,7 +932,7 @@ fn catch_up_materialized_state_reports_rows_restored_by_canonical_rebuild() {
 }
 
 #[test]
-fn catch_up_does_not_cancel_restore_reported_by_replay_and_repair() {
+fn catch_up_reports_real_restore_once() {
     let author = ReplicaId::new(b"author");
     let child_author = ReplicaId::new(b"child-author");
     let parent = NodeId(20);
@@ -833,10 +999,7 @@ fn catch_up_does_not_cancel_restore_reported_by_replay_and_repair() {
             )
         })
         .count();
-    assert_eq!(
-        restores, 1,
-        "the replayed restore must be emitted exactly once"
-    );
+    assert_eq!(restores, 1, "the net restore must be emitted exactly once");
 }
 
 #[test]

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1367,10 +1367,10 @@ async function scenarioSyncKnownStatePropagation(
   const eventsOnB = await captureMaterializationEvents(b, async () => {
     await b.ops.appendMany(await a.ops.all());
   });
-  assert(eventsOnB.length > 0, 'sync known_state should emit a materialization event on B');
-  assertEventNodeRefsSortedUnique(
-    materializationEventNodeRefs(eventsOnB[eventsOnB.length - 1]!),
-    'sync known_state: materialization event node refs shape',
+  assertEqual(
+    eventsOnB.length,
+    0,
+    'sync known_state should omit replay-only events when visible state is unchanged',
   );
 
   assertArrayEqual(await b.tree.children(root), [parent], 'parent restored after sync delete');

--- a/packages/treecrdt-postgres-rs/src/store/append.rs
+++ b/packages/treecrdt-postgres-rs/src/store/append.rs
@@ -30,6 +30,26 @@ fn persisted_remote_stores(ctx: &PgCtx) -> PgPersistedRemoteStores {
     }
 }
 
+fn with_materialization_savepoint(
+    client: &Rc<RefCell<Client>>,
+    run: impl FnOnce() -> Result<treecrdt_core::IncrementalApplyResult>,
+) -> Result<treecrdt_core::IncrementalApplyResult> {
+    client
+        .borrow_mut()
+        .batch_execute("SAVEPOINT treecrdt_incremental_materialization")
+        .map_err(storage_debug)?;
+    let result = run();
+    if !matches!(&result, Ok(result) if result.head.is_some()) {
+        client
+            .borrow_mut()
+            .batch_execute("ROLLBACK TO SAVEPOINT treecrdt_incremental_materialization")
+            .map_err(storage_debug)?;
+    }
+    // The outer append transaction releases the savepoint. Keeping it open avoids another
+    // PostgreSQL round trip on the successful hot path.
+    result
+}
+
 fn materialize_inserted_ops(
     ctx: PgCtx,
     meta: &dyn MaterializationCursor,
@@ -37,20 +57,22 @@ fn materialize_inserted_ops(
 ) -> Result<treecrdt_core::IncrementalApplyResult> {
     // At this point treecrdt_ops already contains the inserted operations. This temporary
     // TreeCrdt exists only to replay those ops through core semantics and update derived tables.
-    materialize_persisted_remote_ops_with_delta(
-        persisted_remote_stores(&ctx),
-        &meta,
-        ops,
-        |nodes, ops| {
-            if ops.iter().any(|op| matches!(op.kind, OperationKind::Payload { .. })) {
-                // Payload ops can depend on the current node row, so front-load the reads here.
-                nodes.preload_for_ops(ops)?;
-            }
-            Ok(())
-        },
-        |nodes| nodes.flush_last_change(),
-        |index| index.flush(),
-    )
+    with_materialization_savepoint(&ctx.client, || {
+        materialize_persisted_remote_ops_with_delta(
+            persisted_remote_stores(&ctx),
+            &meta,
+            ops,
+            |nodes, ops| {
+                if ops.iter().any(|op| matches!(op.kind, OperationKind::Payload { .. })) {
+                    // Payload ops can depend on the current node row, so front-load the reads here.
+                    nodes.preload_for_ops(ops)?;
+                }
+                Ok(())
+            },
+            |nodes| nodes.flush_last_change(),
+            |index| index.flush(),
+        )
+    })
 }
 
 pub fn append_ops(client: &Rc<RefCell<Client>>, doc_id: &str, ops: &[Operation]) -> Result<u64> {

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -256,6 +256,21 @@ fn postgres_backend_out_of_order_losing_payload_rebuilds_parent_index() {
 }
 
 #[test]
+fn postgres_backend_net_catch_up_outcomes() {
+    let scenarios: [fn(&PgConformanceHarness); 3] = [
+        materialization_conformance::catch_up_reports_same_parent_reorder_as_move,
+        materialization_conformance::catch_up_omits_replay_only_move,
+        materialization_conformance::catch_up_omits_replay_only_restore,
+    ];
+    for scenario in scenarios {
+        let Some(harness) = setup_conformance_harness() else {
+            return;
+        };
+        scenario(&harness);
+    }
+}
+
+#[test]
 fn postgres_backend_out_of_order_move_with_later_payload_catches_up_immediately() {
     let Some(harness) = setup_conformance_harness() else {
         return;

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/materialize.rs
@@ -259,6 +259,28 @@ fn prepare_persisted_remote_stores(
     })
 }
 
+fn with_materialization_savepoint(
+    db: *mut sqlite3,
+    run: impl FnOnce() -> Result<treecrdt_core::IncrementalApplyResult, c_int>,
+) -> Result<treecrdt_core::IncrementalApplyResult, c_int> {
+    const BEGIN: &[u8] = b"SAVEPOINT treecrdt_incremental_materialization\0";
+    const ROLLBACK: &[u8] = b"ROLLBACK TO treecrdt_incremental_materialization\0";
+
+    let rc = sqlite_exec(db, BEGIN.as_ptr().cast(), None, null_mut(), null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(rc);
+    }
+    let result = run();
+    if !matches!(&result, Ok(result) if result.head.is_some()) {
+        let rc = sqlite_exec(db, ROLLBACK.as_ptr().cast(), None, null_mut(), null_mut());
+        if rc != SQLITE_OK as c_int {
+            return Err(rc);
+        }
+    }
+    // Releasing the outer append savepoint also releases this nested one.
+    result
+}
+
 fn materialize_inserted_ops(
     db: *mut sqlite3,
     doc_id: &[u8],
@@ -267,15 +289,17 @@ fn materialize_inserted_ops(
 ) -> Result<treecrdt_core::IncrementalApplyResult, c_int> {
     use treecrdt_core::materialize_persisted_remote_ops_with_delta;
 
-    materialize_persisted_remote_ops_with_delta(
-        prepare_persisted_remote_stores(db, doc_id)?,
-        &meta,
-        ops,
-        |_, _| Ok(()),
-        |_| Ok(()),
-        |_| Ok(()),
-    )
-    .map_err(|_| SQLITE_ERROR as c_int)
+    with_materialization_savepoint(db, || {
+        materialize_persisted_remote_ops_with_delta(
+            prepare_persisted_remote_stores(db, doc_id)?,
+            &meta,
+            ops,
+            |_, _| Ok(()),
+            |_| Ok(()),
+            |_| Ok(()),
+        )
+        .map_err(|_| SQLITE_ERROR as c_int)
+    })
 }
 
 pub(super) fn ensure_materialized(db: *mut sqlite3) -> Result<MaterializationOutcome, c_int> {

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -695,6 +695,18 @@ fn remote_losing_payload_uses_suffix_replay_without_resetting_nodes() {
 }
 
 #[test]
+fn remote_net_catch_up_outcomes() {
+    let scenarios: [fn(&SqliteConformanceHarness); 3] = [
+        materialization_conformance::catch_up_reports_same_parent_reorder_as_move,
+        materialization_conformance::catch_up_omits_replay_only_move,
+        materialization_conformance::catch_up_omits_replay_only_restore,
+    ];
+    for scenario in scenarios {
+        scenario(&setup_conformance_harness());
+    }
+}
+
+#[test]
 fn remote_append_out_of_order_move_with_later_payload_catches_up_immediately() {
     let harness = setup_conformance_harness();
     materialization_conformance::out_of_order_move_with_later_payload_catches_up_immediately(
@@ -1577,11 +1589,13 @@ fn find_extension() -> Option<PathBuf> {
         .unwrap_or_else(|_| manifest.join("..").join("..").join("target"));
 
     let (name, alt_name) = extension_filenames();
+    // `cargo test` builds the feature-matched extension in deps; a top-level artifact left by
+    // `cargo rustc` may be stale after switching branches.
     let candidates = [
-        target_dir.join("debug").join(&name),
         target_dir.join("debug").join("deps").join(&name),
-        target_dir.join("debug").join(&alt_name),
         target_dir.join("debug").join("deps").join(&alt_name),
+        target_dir.join("debug").join(&name),
+        target_dir.join("debug").join(&alt_name),
     ];
     candidates.into_iter().find(|p| p.exists())
 }

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -169,10 +169,7 @@ pub fn out_of_order_append_catches_up_immediately_from_frontier<
 
     harness.append_ops(&[second]);
     let outcome = harness.append_ops_with_materialization_outcome(slice::from_ref(&first));
-    assert_eq!(
-        changed_nodes(&outcome),
-        vec![NodeId::ROOT, node(1), node(2)]
-    );
+    assert_eq!(changed_nodes(&outcome), vec![NodeId::ROOT, node(1)]);
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 2);
     assert_eq!(
@@ -199,7 +196,9 @@ pub fn out_of_order_losing_payload_rebuilds_parent_index<H: MaterializationConfo
     let losing_payload = Operation::set_payload(&replica, 2, 2, payload_node, vec![4]);
 
     harness.append_ops(&[insert, winning_payload]);
-    harness.append_ops(&[losing_payload]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[losing_payload]);
+    assert!(outcome.changes.is_empty());
+    assert_eq!(outcome.head_seq, 3);
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 3);
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![payload_node]);
@@ -208,6 +207,94 @@ pub fn out_of_order_losing_payload_rebuilds_parent_index<H: MaterializationConfo
         harness.op_ref_counters_for_parent(NodeId::ROOT),
         vec![1, 2, 3]
     );
+
+    let cleared_node = node(88);
+    let delayed_clear = Operation::clear_payload(&replica, 4, 5, cleared_node);
+    let later_payload = Operation::set_payload(&replica, 5, 6, payload_node, vec![10]);
+    harness.append_ops(&[later_payload]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[delayed_clear]);
+
+    assert_eq!(
+        outcome.changes,
+        vec![MaterializationChange::Payload {
+            node: cleared_node,
+            payload: None,
+            source: None,
+        }]
+    );
+    assert_eq!(outcome.head_seq, 5);
+    assert_replay_cleared(harness);
+    assert_eq!(harness.node_state(cleared_node).parent, None);
+}
+
+pub fn catch_up_reports_same_parent_reorder_as_move<H: MaterializationConformanceHarness>(
+    harness: &H,
+) {
+    let replica = ReplicaId::new(b"same-parent-reorder");
+    let first = node(9);
+    let second = node(10);
+    let insert_first = Operation::insert(
+        &replica,
+        1,
+        1,
+        NodeId::ROOT,
+        first,
+        order_key_from_position(1),
+    );
+    let insert_second = Operation::insert(
+        &replica,
+        2,
+        2,
+        NodeId::ROOT,
+        second,
+        order_key_from_position(2),
+    );
+    let delayed_reorder = Operation::move_node(
+        &replica,
+        3,
+        3,
+        second,
+        NodeId::ROOT,
+        order_key_from_position(0),
+    );
+    let later_payload = Operation::set_payload(&replica, 4, 4, first, vec![7]);
+
+    harness.append_ops(&[insert_first, insert_second, later_payload]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[delayed_reorder]);
+
+    assert_eq!(
+        outcome.changes,
+        vec![MaterializationChange::Move {
+            node: second,
+            parent_before: Some(NodeId::ROOT),
+            parent_after: NodeId::ROOT,
+            source: None,
+        }]
+    );
+    assert_eq!(outcome.head_seq, 4);
+    assert_replay_cleared(harness);
+    assert_eq!(harness.visible_children(NodeId::ROOT), vec![second, first]);
+    assert_eq!(harness.payload(first), Some(vec![7]));
+
+    let delayed_trash_move =
+        Operation::move_node(&replica, 5, 5, second, NodeId::TRASH, Vec::new());
+    let later_payload = Operation::set_payload(&replica, 6, 6, first, vec![8]);
+    harness.append_ops(&[later_payload]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[delayed_trash_move]);
+
+    assert_eq!(
+        outcome.changes,
+        vec![MaterializationChange::Move {
+            node: second,
+            parent_before: Some(NodeId::ROOT),
+            parent_after: NodeId::TRASH,
+            source: None,
+        }]
+    );
+    assert_eq!(outcome.head_seq, 6);
+    assert_replay_cleared(harness);
+    assert_eq!(harness.visible_children(NodeId::ROOT), vec![first]);
+    assert_eq!(harness.node_state(second).parent, Some(NodeId::TRASH));
 }
 
 pub fn out_of_order_move_with_later_payload_catches_up_immediately<
@@ -230,7 +317,22 @@ pub fn out_of_order_move_with_later_payload_catches_up_immediately<
     harness.append_ops(&[insert_p1, insert_p2, insert_child, earlier_payload]);
     let outcome =
         harness.append_ops_with_materialization_outcome(&[later_payload, out_of_order_move]);
-    assert_eq!(changed_nodes(&outcome), vec![p1, p2, child]);
+    assert_eq!(
+        outcome.changes,
+        vec![
+            MaterializationChange::Move {
+                node: child,
+                parent_before: Some(p1),
+                parent_after: p2,
+                source: None,
+            },
+            MaterializationChange::Payload {
+                node: child,
+                payload: Some(vec![9]),
+                source: None,
+            },
+        ]
+    );
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 6);
     assert_eq!(harness.visible_children(p1), Vec::<NodeId>::new());
@@ -291,10 +393,7 @@ pub fn replay_from_start_frontier_catches_up_immediately<H: MaterializationConfo
     harness.force_replay_from_start();
 
     let outcome = harness.append_ops_with_materialization_outcome(&[second]);
-    assert_eq!(
-        changed_nodes(&outcome),
-        vec![NodeId::ROOT, node(1), node(2)]
-    );
+    assert_eq!(changed_nodes(&outcome), vec![NodeId::ROOT, node(2)]);
     assert_replay_cleared(harness);
     assert_eq!(
         harness.visible_children(NodeId::ROOT),
@@ -392,27 +491,55 @@ pub fn out_of_order_delete_suffix_falls_back_and_restores_parent<
     let parent = node(1);
     let child = node(2);
 
-    let insert_parent = Operation::insert(
+    let insert_parent = Operation::insert_with_payload(
         &replica,
         1,
         1,
         NodeId::ROOT,
         parent,
         order_key_from_position(0),
+        vec![7],
     );
-    let insert_child = Operation::insert(&replica, 2, 2, parent, child, order_key_from_position(0));
+    let insert_child = Operation::insert_with_payload(
+        &replica,
+        2,
+        2,
+        parent,
+        child,
+        order_key_from_position(0),
+        vec![8],
+    );
 
     let mut vv = treecrdt_core::VersionVector::new();
     vv.observe(&replica, 1);
     let delete_parent = Operation::delete(&replica, 3, 3, parent, Some(vv));
 
     harness.append_ops(&[insert_parent, delete_parent]);
-    let _ = harness.append_ops_with_materialization_outcome(&[insert_child]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[insert_child]);
+    assert_eq!(
+        outcome.changes,
+        vec![
+            MaterializationChange::Insert {
+                node: child,
+                parent_after: parent,
+                payload: Some(vec![8]),
+                source: None,
+            },
+            MaterializationChange::Restore {
+                node: parent,
+                parent_after: Some(NodeId::ROOT),
+                payload: Some(vec![7]),
+                source: None,
+            },
+        ]
+    );
 
     assert_replay_cleared(harness);
     assert_eq!(harness.head_seq(), 3);
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![parent]);
     assert_eq!(harness.visible_children(parent), vec![child]);
+    assert_eq!(harness.payload(parent), Some(vec![7]));
+    assert_eq!(harness.payload(child), Some(vec![8]));
 }
 
 fn assert_parent_chain_acyclic<H: MaterializationConformanceHarness>(harness: &H, start: NodeId) {
@@ -549,7 +676,10 @@ pub fn out_of_order_concurrent_delete_converges_internal_node_metadata<
         later_payload.clone(),
     ]);
     out_of_order.append_ops(&[insert_parent, insert_child, later_payload]);
-    out_of_order.append_ops(&[concurrent_delete]);
+    let outcome =
+        out_of_order.append_ops_with_materialization_outcome(slice::from_ref(&concurrent_delete));
+    assert!(outcome.changes.is_empty());
+    assert_eq!(outcome.head_seq, 4);
 
     let canonical_state = canonical.node_state(parent);
     let out_of_order_state = out_of_order.node_state(parent);
@@ -573,4 +703,55 @@ pub fn out_of_order_concurrent_delete_converges_internal_node_metadata<
     assert_eq!(out_of_order.head_seq(), 4);
     assert_replay_cleared(canonical);
     assert_replay_cleared(out_of_order);
+}
+
+pub fn catch_up_omits_replay_only_move<H: MaterializationConformanceHarness>(harness: &H) {
+    let creator = ReplicaId::new(b"net-move-creator");
+    let late = ReplicaId::new(b"net-move-late");
+    let winner = ReplicaId::new(b"net-move-winner");
+    let p1 = node(11);
+    let p2 = node(12);
+    let child = node(13);
+
+    let insert_p1 = Operation::insert(&creator, 1, 1, NodeId::ROOT, p1, order_key_from_position(0));
+    let insert_p2 = Operation::insert(&creator, 2, 2, NodeId::ROOT, p2, order_key_from_position(1));
+    let insert_child = Operation::insert(&creator, 3, 3, p1, child, order_key_from_position(0));
+    let late_move = Operation::move_node(&late, 1, 4, child, p2, order_key_from_position(0));
+    let winning_move = Operation::move_node(&winner, 1, 5, child, p2, order_key_from_position(0));
+
+    harness.append_ops(&[insert_p1, insert_p2, insert_child, winning_move]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[late_move]);
+
+    assert!(outcome.changes.is_empty());
+    assert_eq!(outcome.head_seq, 5);
+    assert_eq!(harness.visible_children(p1), Vec::<NodeId>::new());
+    assert_eq!(harness.visible_children(p2), vec![child]);
+    assert_replay_cleared(harness);
+}
+
+pub fn catch_up_omits_replay_only_restore<H: MaterializationConformanceHarness>(harness: &H) {
+    let creator = ReplicaId::new(b"net-restore-creator");
+    let deleter = ReplicaId::new(b"net-restore-deleter");
+    let late = ReplicaId::new(b"net-restore-late");
+    let winner = ReplicaId::new(b"net-restore-winner");
+    let parent = node(21);
+    let child = node(22);
+    let key = order_key_from_position(0);
+
+    let insert_parent = Operation::insert(&creator, 1, 1, NodeId::ROOT, parent, key.clone());
+    let insert_child = Operation::insert(&creator, 2, 2, parent, child, key.clone());
+    let mut known_state = VersionVector::new();
+    known_state.observe(&creator, 2);
+    let delete_parent = Operation::delete(&deleter, 1, 3, parent, Some(known_state));
+    let late_move = Operation::move_node(&late, 1, 4, child, parent, key.clone());
+    let winning_move = Operation::move_node(&winner, 1, 5, child, parent, key);
+
+    harness.append_ops(&[insert_parent, insert_child, delete_parent, winning_move]);
+    let outcome = harness.append_ops_with_materialization_outcome(&[late_move]);
+
+    assert!(outcome.changes.is_empty());
+    assert_eq!(outcome.head_seq, 5);
+    assert_eq!(harness.visible_children(NodeId::ROOT), vec![parent]);
+    assert_eq!(harness.visible_children(parent), vec![child]);
+    assert_replay_cleared(harness);
 }

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -59,7 +59,9 @@ export type Change =
  * Coalesced result of advancing materialized state to `headSeq`.
  *
  * This is intentionally not a raw op list. Replays and batched appends collapse multiple writes for
- * the same node into final visible changes before adapters emit events.
+ * the same node before adapters emit events. Conservative catch-up reports the exact node-backed
+ * visible before/after delta, so replay-only transitions that cancel are omitted. `headSeq` can
+ * therefore advance with no changes; outcomes are not an operation log or audit stream.
  */
 export type MaterializationOutcome = {
   headSeq: number;


### PR DESCRIPTION
## Why

Canonical repair can replay transient materialization changes that cancel each other. Consumers should observe the final committed difference, not the internal replay trace.

## What changes

- Compare persisted node-backed state with the canonical rebuilt state.
- Emit only net Insert, Move, Delete, Restore, and Payload changes.
- Preserve same-parent reorder, Trash, root, tombstone, unattached-node, and payload-clear semantics.
- Roll back failed incremental derived writes before canonical repair.
- Document materialization outcomes as state notifications rather than an oplog or audit stream.

Payload-only orphan rows are repaired silently because PayloadStore cannot enumerate keys; normal writes create the node row first.

## Stack

Merge order: #177 → #226 → #180 → #178.

#177 defines defensive-delete semantics, #226 performs canonical repair, and #180 makes SQLite cursor reads safe across concurrent writers. This PR completes the stack by defining the public outcome of that repair.