### PR TITLE
fix: remove unenforced capability CWT auth

### DIFF
--- a/.changeset/fail-closed-capability-cwt.md
+++ b/.changeset/fail-closed-capability-cwt.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/sync-server-postgres-node': patch
+---
+
+Remove capability-CWT authentication because the server does not enforce token grants or signed operation authorship end to end.

--- a/packages/sync-protocol/server/postgres-node/README.md
+++ b/packages/sync-protocol/server/postgres-node/README.md
@@ -53,7 +53,6 @@ Environment variables:
 - `TREECRDT_IDLE_CLOSE_MS` (default: `30000`)
 - `TREECRDT_MAX_PAYLOAD_BYTES` (default: `10485760`)
 - `TREECRDT_SYNC_AUTH_TOKEN` (optional static token, accepted as `Authorization: Bearer ...` or `?token=...`)
-- `TREECRDT_SYNC_CWT_ISSUER_PUBKEYS` (optional comma-separated base64url Ed25519 issuer public keys, enables CWT capability auth)
 - `TREECRDT_DOC_ID_PATTERN` (optional regex; deny docs that do not match)
 - `TREECRDT_ALLOW_DOC_CREATE` (default: `true`; when `false`, unknown `docId` values are denied)
 - `TREECRDT_PG_NOTIFY_ENABLED` (default: `true`; enables LISTEN/NOTIFY fanout across server instances)

--- a/packages/sync-protocol/server/postgres-node/package.json
+++ b/packages/sync-protocol/server/postgres-node/package.json
@@ -20,7 +20,6 @@
     "test": "pnpm --filter @treecrdt/sync-server-postgres-node^... run build && pnpm run build && vitest run"
   },
   "dependencies": {
-    "@treecrdt/auth": "workspace:*",
     "@treecrdt/interface": "workspace:*",
     "@treecrdt/sync-protocol": "workspace:*",
     "@treecrdt/sync-postgres": "workspace:*",

--- a/packages/sync-protocol/server/postgres-node/src/cli.ts
+++ b/packages/sync-protocol/server/postgres-node/src/cli.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { base64urlDecode } from '@treecrdt/auth';
 import { installHelloTraceSink, type HelloTraceRecord } from '@treecrdt/sync-protocol';
 
 import { startSyncServer } from './server.js';
@@ -16,24 +15,6 @@ function parseBooleanEnv(name: string, fallback: boolean): boolean {
   if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
   if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
   throw new Error(`${name} must be a boolean (true/false), got: ${raw}`);
-}
-
-function parseIssuerPublicKeysEnv(name: string): Uint8Array[] {
-  const raw = process.env[name];
-  if (!raw || raw.trim().length === 0) return [];
-  return raw
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0)
-    .map((entry) => {
-      try {
-        return base64urlDecode(entry);
-      } catch (err) {
-        throw new Error(
-          `${name} has invalid base64url key "${entry}": ${err instanceof Error ? err.message : String(err)}`,
-        );
-      }
-    });
 }
 
 function buildPostgresUrlFromParts(): string | undefined {
@@ -99,9 +80,6 @@ async function main() {
     process.env.TREECRDT_MAX_PAYLOAD_BYTES ?? String(10 * 1024 * 1024),
   );
   const authToken = process.env.TREECRDT_SYNC_AUTH_TOKEN?.trim() || undefined;
-  const authCapabilityIssuerPublicKeys = parseIssuerPublicKeysEnv(
-    'TREECRDT_SYNC_CWT_ISSUER_PUBKEYS',
-  );
   const docIdPattern = process.env.TREECRDT_DOC_ID_PATTERN?.trim() || undefined;
   const allowDocCreate = parseBooleanEnv('TREECRDT_ALLOW_DOC_CREATE', true);
   const enablePgNotify = parseBooleanEnv('TREECRDT_PG_NOTIFY_ENABLED', true);
@@ -160,7 +138,6 @@ async function main() {
       maxPayloadBytes,
       backendModule,
       authToken,
-      authCapabilityIssuerPublicKeys,
       docIdPattern,
       allowDocCreate,
       enablePgNotify,
@@ -182,11 +159,7 @@ async function main() {
     console.log(`- backend module: ${handle.backendModule}`);
     if (packageVersion) console.log(`- version: ${packageVersion}`);
     if (gitSha) console.log(`- git sha: ${gitSha}${gitDirty ? ' (dirty)' : ''}`);
-    if (authCapabilityIssuerPublicKeys.length > 0) {
-      console.log(
-        `- auth: capability CWT enabled (${authCapabilityIssuerPublicKeys.length} issuer keys)`,
-      );
-    } else if (authToken) {
+    if (authToken) {
       console.log('- auth: static token enabled (bearer token or ?token=...)');
     }
     if (docIdPattern) console.log(`- docId policy: ${docIdPattern}`);

--- a/packages/sync-protocol/server/postgres-node/src/server.ts
+++ b/packages/sync-protocol/server/postgres-node/src/server.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
-import { base64urlDecode, describeTreecrdtCapabilityTokenV1 } from '@treecrdt/auth';
 import type { Operation } from '@treecrdt/interface';
 import { createReplayOnlySyncAuth, deriveOpRefV0 } from '@treecrdt/sync-protocol';
 import type { SyncBackend, SyncPeer, SyncPeerOptions } from '@treecrdt/sync-protocol';
@@ -47,7 +46,6 @@ export type SyncServerOptions = {
   idleCloseMs?: number;
   maxPayloadBytes?: number;
   authToken?: string;
-  authCapabilityIssuerPublicKeys?: Uint8Array[];
   docIdPattern?: string | RegExp;
   allowDocCreate?: boolean;
   enablePgNotify?: boolean;
@@ -112,11 +110,7 @@ function ensurePostgresChannelName(value: string): string {
   return trimmed;
 }
 
-function describeAuthMode(
-  authToken: string | undefined,
-  issuerPublicKeys: Uint8Array[],
-): 'none' | 'static_token' | 'capability_cwt' {
-  if (issuerPublicKeys.length > 0) return 'capability_cwt';
+function describeAuthMode(authToken: string | undefined): 'none' | 'static_token' {
   if (authToken) return 'static_token';
   return 'none';
 }
@@ -268,36 +262,6 @@ function createStaticTokenAuthHook(expectedToken: string): WebSocketSyncServerUp
       statusCode: 401,
       body: 'missing or invalid auth token',
     };
-  };
-}
-
-function createCapabilityTokenAuthHook(
-  issuerPublicKeys: Uint8Array[],
-): WebSocketSyncServerUpgradeHook {
-  return async (ctx) => {
-    const token = extractAuthToken(ctx);
-    if (!token) {
-      return {
-        allow: false,
-        statusCode: 401,
-        body: 'missing capability token',
-      };
-    }
-    try {
-      const tokenBytes = base64urlDecode(token);
-      await describeTreecrdtCapabilityTokenV1({
-        tokenBytes,
-        issuerPublicKeys,
-        docId: ctx.docId,
-      });
-      return { allow: true };
-    } catch (err) {
-      return {
-        allow: false,
-        statusCode: 401,
-        body: `invalid capability token: ${err instanceof Error ? err.message : String(err)}`,
-      };
-    }
   };
 }
 
@@ -609,9 +573,6 @@ export async function startSyncServer(opts: SyncServerOptions): Promise<SyncServ
     typeof opts.authToken === 'string' && opts.authToken.trim().length > 0
       ? opts.authToken.trim()
       : undefined;
-  const authCapabilityIssuerPublicKeys = (opts.authCapabilityIssuerPublicKeys ?? []).filter(
-    (value): value is Uint8Array => value instanceof Uint8Array && value.length > 0,
-  );
   const docIdPattern = parseDocIdRegex(opts.docIdPattern);
   const allowDocCreate = opts.allowDocCreate ?? true;
   const enablePgNotify = opts.enablePgNotify ?? true;
@@ -708,12 +669,7 @@ export async function startSyncServer(opts: SyncServerOptions): Promise<SyncServ
     throw err;
   }
 
-  const builtInAuthHook =
-    authCapabilityIssuerPublicKeys.length > 0
-      ? createCapabilityTokenAuthHook(authCapabilityIssuerPublicKeys)
-      : authToken
-        ? createStaticTokenAuthHook(authToken)
-        : undefined;
+  const builtInAuthHook = authToken ? createStaticTokenAuthHook(authToken) : undefined;
 
   const builtInAuthorizeHook = combineUpgradeHooks(
     docIdPattern ? createDocIdPatternHook(docIdPattern) : undefined,
@@ -776,7 +732,7 @@ export async function startSyncServer(opts: SyncServerOptions): Promise<SyncServ
             startedAt,
             uptimeMs: Number.isFinite(startedAtMs) ? Math.max(0, Date.now() - startedAtMs) : null,
             backendModule,
-            authMode: describeAuthMode(authToken, authCapabilityIssuerPublicKeys),
+            authMode: describeAuthMode(authToken),
             pgNotifyEnabled: Boolean(docUpdateBus),
             pgNotifyChannel: docUpdateBus ? pgNotifyChannel : null,
             docIdPattern: docIdPattern?.source ?? null,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,9 +224,6 @@ importers:
 
   packages/sync-protocol/server/postgres-node:
     dependencies:
-      '@treecrdt/auth':
-        specifier: workspace:*
-        version: link:../../../treecrdt-auth
       '@treecrdt/interface':
         specifier: workspace:*
         version: link:../../../treecrdt-ts


### PR DESCRIPTION
## Problem

The PostgreSQL sync server accepted capability CWTs during the WebSocket upgrade, but the resulting sync session did not enforce the token actions, subtree scope, subject, or signed operation authorship. A valid read-only or scoped token could therefore become full-document read/write access.

## Fix

Remove capability-CWT configuration and the unsafe upgrade verifier from this server until authorization is enforced end to end. Because TreeCRDT has no deployed users, this does not retain deprecated options or environment-variable compatibility shims.

- Remove the CWT parser and upgrade hook.
- Remove `authCapabilityIssuerPublicKeys` from the programmatic API.
- Remove `TREECRDT_SYNC_CWT_ISSUER_PUBKEYS` from the documented CLI surface.
- Remove the now-unused `@treecrdt/auth` dependency.
- Keep static shared-token auth unchanged.