### PR TITLE
fix(auth): authorize structural writes from stable ancestry

### DIFF
--- a/.changeset/stable-local-auth-scope.md
+++ b/.changeset/stable-local-auth-scope.md
@@ -1,0 +1,7 @@
+---
+'@treecrdt/auth': patch
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+---
+
+Authorize structural writes against both their destination and the node's stable pre-write ancestry. SQLite local writes now carry explicit pre-write node state into auth, existing-node insert upserts cannot pull nodes across a subtree boundary, and genuinely new inserts remain supported.

--- a/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
+++ b/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
@@ -1,4 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
+import type { LocalWriteAuthContext, LocalWriteAuthPreState } from '@treecrdt/interface/engine';
 import {
   bytesToHex,
   nodeIdToBytes16,
@@ -20,6 +21,7 @@ import {
   type OpAuth,
   type OpRef,
   type SyncAuth,
+  type SyncAuthOpsContext,
   type SyncCapabilityMaterialStore,
 } from '@treecrdt/sync-protocol';
 
@@ -128,6 +130,12 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
   const allowUnsigned = opts.allowUnsigned ?? false;
   const requireProofRef = opts.requireProofRef ?? false;
   const includeAuthoredAt = opts.includeAuthoredAt ?? false;
+
+  const preWriteStateAt = (
+    ctx: SyncAuthOpsContext,
+    index: number,
+  ): LocalWriteAuthPreState | undefined =>
+    (ctx as SyncAuthOpsContext & LocalWriteAuthContext).preWriteState?.[index];
 
   const localTokens = opts.localCapabilityTokens ?? [];
   const localTokenIds = localTokens.map((t) => deriveTokenIdV1(t));
@@ -441,6 +449,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
     op: Operation;
     candidates: CapabilityGrant[];
     purpose: 'sign_op' | 'verify_op';
+    preWriteState?: LocalWriteAuthPreState;
   }): Promise<CapabilityGrant> => {
     const nowSec = now();
     let bestUnknown: CapabilityGrant | null = null;
@@ -466,6 +475,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
         docId: opts2.docId,
         op: opts2.op,
         scopeEvaluator: opts.scopeEvaluator,
+        preWriteState: opts2.preWriteState,
       });
       if (scopeRes === 'allow') return grant;
       if (scopeRes === 'unknown' && !bestUnknown) bestUnknown = grant;
@@ -664,6 +674,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
             op,
             candidates: currentLocalGrants,
             purpose: 'sign_op',
+            preWriteState: preWriteStateAt(ctx, i),
           });
           proofRef = selected.tokenId;
         }
@@ -772,6 +783,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
             op,
             candidates: orderedCandidates,
             purpose: 'verify_op',
+            preWriteState: preWriteStateAt(ctx, i),
           });
         }
 
@@ -790,6 +802,7 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
           docId: ctx.docId,
           op,
           scopeEvaluator: opts.scopeEvaluator,
+          preWriteState: preWriteStateAt(ctx, i),
         });
         if (scopeRes === 'deny') throw new Error('capability does not allow op');
 

--- a/packages/treecrdt-auth/src/internal/scope.ts
+++ b/packages/treecrdt-auth/src/internal/scope.ts
@@ -1,4 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
+import type { LocalWriteAuthPreState } from '@treecrdt/interface/engine';
 import { bytesToHex, nodeIdToBytes16, ROOT_NODE_ID_HEX } from '@treecrdt/interface/ids';
 
 import { getField, toNumber } from './claims.js';
@@ -9,11 +10,30 @@ type TreecrdtSubtreeScope = {
   exclude?: Uint8Array[];
 };
 
-export type TreecrdtScopeEvaluator = (opts: {
+export type TreecrdtScopeEvaluation = 'allow' | 'deny' | 'unknown' | 'absent';
+
+export type TreecrdtScopeEvaluatorInput = {
   docId: string;
   node: Uint8Array;
   scope: TreecrdtSubtreeScope;
-}) => 'allow' | 'deny' | 'unknown' | Promise<'allow' | 'deny' | 'unknown'>;
+};
+
+export type TreecrdtScopeEvaluator = ((
+  opts: TreecrdtScopeEvaluatorInput,
+) => TreecrdtScopeEvaluation | Promise<TreecrdtScopeEvaluation>) & {
+  /**
+   * Evaluate `node` through an explicit immediate parent instead of consulting
+   * the node's current materialized parent.
+   *
+   * Local SQLite authorization uses this after a structural write has been
+   * prepared so the decision is still based on the pre-write ancestry. An
+   * evaluator that cannot honor the override should omit this method; auth then
+   * fails closed with `unknown`.
+   */
+  evaluateWithParent?: (
+    opts: TreecrdtScopeEvaluatorInput & { parent: Uint8Array | null },
+  ) => TreecrdtScopeEvaluation | Promise<TreecrdtScopeEvaluation>;
+};
 
 export type ScopeTri = 'allow' | 'deny' | 'unknown';
 
@@ -59,21 +79,74 @@ function requiredActionsForOp(op: Operation): string[] {
   }
 }
 
-function getRequiredScopeChecks(op: Operation): Array<{ node: Uint8Array; actions: string[] }> {
+type RequiredScopeCheck = {
+  node: Uint8Array;
+  actions: string[];
+  allowAbsent?: boolean;
+  knownAbsent?: boolean;
+  parentBefore?: Uint8Array | null;
+};
+
+function checkedPreWriteState(
+  op: Operation,
+  preWriteState?: LocalWriteAuthPreState,
+): LocalWriteAuthPreState | undefined {
+  if (!preWriteState) return undefined;
+  if (
+    bytesToHex(nodeIdToBytes16(preWriteState.node)) !== bytesToHex(nodeIdToBytes16(op.kind.node))
+  ) {
+    throw new Error('pre-write auth state does not match operation node');
+  }
+  if (!preWriteState.existed && preWriteState.parent !== null) {
+    throw new Error('absent pre-write auth state cannot have a parent');
+  }
+  return preWriteState;
+}
+
+function sourceScopeCheck(
+  op: Operation,
+  actions: string[],
+  preWriteState?: LocalWriteAuthPreState,
+  opts: { allowAbsent: boolean } = { allowAbsent: false },
+): RequiredScopeCheck | null {
+  const pre = checkedPreWriteState(op, preWriteState);
+  const node = nodeIdToBytes16(op.kind.node);
+  if (!pre) return { node, actions, allowAbsent: opts.allowAbsent };
+  if (!pre.existed) {
+    return opts.allowAbsent ? null : { node, actions, knownAbsent: true };
+  }
+  return {
+    node,
+    actions,
+    parentBefore: pre.parent === null ? null : nodeIdToBytes16(pre.parent),
+  };
+}
+
+function getRequiredScopeChecks(
+  op: Operation,
+  preWriteState?: LocalWriteAuthPreState,
+): RequiredScopeCheck[] {
   const actions = requiredActionsForOp(op);
   switch (op.kind.type) {
-    case 'insert':
-      return [{ node: nodeIdToBytes16(op.kind.parent), actions }];
-    case 'move':
-      // v1: require authorization for both source (node) and destination (new_parent).
-      return [
-        { node: nodeIdToBytes16(op.kind.node), actions },
-        { node: nodeIdToBytes16(op.kind.newParent), actions },
-      ];
+    case 'insert': {
+      const checks: RequiredScopeCheck[] = [{ node: nodeIdToBytes16(op.kind.parent), actions }];
+      // Insert is an upsert/reparent. A new node has no source scope, but an
+      // existing node must be authorized at both its old and new locations.
+      const source = sourceScopeCheck(op, actions, preWriteState, { allowAbsent: true });
+      if (source) checks.push(source);
+      return checks;
+    }
+    case 'move': {
+      // Require authorization for both the pre-write source and destination.
+      const source = sourceScopeCheck(op, actions, preWriteState);
+      return [...(source ? [source] : []), { node: nodeIdToBytes16(op.kind.newParent), actions }];
+    }
     case 'delete':
     case 'tombstone':
-    case 'payload':
-      return [{ node: nodeIdToBytes16(op.kind.node), actions }];
+    case 'payload': {
+      const source = sourceScopeCheck(op, actions, preWriteState);
+      return source ? [source] : [];
+    }
     default: {
       const _exhaustive: never = op.kind;
       throw new Error(`unknown op kind: ${String((_exhaustive as any)?.type)}`);
@@ -118,6 +191,9 @@ export async function capAllowsNode(opts: {
   node: Uint8Array;
   requiredActions: readonly string[];
   scopeEvaluator?: TreecrdtScopeEvaluator;
+  allowAbsent?: boolean;
+  knownAbsent?: boolean;
+  parentBefore?: Uint8Array | null;
 }): Promise<ScopeTri> {
   const res = getField(opts.cap, 'res');
   const actions = getField(opts.cap, 'actions');
@@ -137,8 +213,22 @@ export async function capAllowsNode(opts: {
   if (nodeHex === rootHex) return 'allow';
   if (isDocWideScope(scope)) return 'allow';
 
+  if (opts.knownAbsent) return opts.allowAbsent ? 'allow' : 'unknown';
+
   if (!opts.scopeEvaluator) return 'unknown';
-  return await opts.scopeEvaluator({ docId: opts.docId, node: opts.node, scope });
+  const evaluation =
+    opts.parentBefore !== undefined
+      ? opts.scopeEvaluator.evaluateWithParent
+        ? await opts.scopeEvaluator.evaluateWithParent({
+            docId: opts.docId,
+            node: opts.node,
+            scope,
+            parent: opts.parentBefore,
+          })
+        : 'unknown'
+      : await opts.scopeEvaluator({ docId: opts.docId, node: opts.node, scope });
+  if (evaluation === 'absent') return opts.allowAbsent ? 'allow' : 'unknown';
+  return evaluation;
 }
 
 export async function capsAllowsNodeAccess(opts: {
@@ -173,10 +263,11 @@ export async function capsAllowsOp(opts: {
   docId: string;
   op: Operation;
   scopeEvaluator?: TreecrdtScopeEvaluator;
+  preWriteState?: LocalWriteAuthPreState;
 }): Promise<ScopeTri> {
   if (!Array.isArray(opts.caps)) throw new Error('capability token must be a v1 capability token');
 
-  const checks = getRequiredScopeChecks(opts.op);
+  const checks = getRequiredScopeChecks(opts.op, opts.preWriteState);
   let overall: ScopeTri = 'allow';
 
   for (const check of checks) {
@@ -190,6 +281,9 @@ export async function capsAllowsOp(opts: {
           node: check.node,
           requiredActions: check.actions,
           scopeEvaluator: opts.scopeEvaluator,
+          allowAbsent: check.allowAbsent,
+          knownAbsent: check.knownAbsent,
+          parentBefore: check.parentBefore,
         }),
       );
       if (best === 'allow') break;

--- a/packages/treecrdt-auth/src/session.ts
+++ b/packages/treecrdt-auth/src/session.ts
@@ -1,4 +1,5 @@
 import type { Operation } from '@treecrdt/interface';
+import type { LocalWriteAuthContext } from '@treecrdt/interface/engine';
 import type {
   Capability,
   Hello,
@@ -54,7 +55,8 @@ export type TreecrdtAuthSessionLocal = {
   revocationRecords?: Uint8Array[];
 };
 
-export type TreecrdtAuthSessionLocalAuthorizeOptions = Partial<SyncAuthOpsContext>;
+export type TreecrdtAuthSessionLocalAuthorizeOptions = Partial<SyncAuthOpsContext> &
+  LocalWriteAuthContext;
 
 export type TreecrdtAuthSessionOptions = Omit<
   TreecrdtCoseCwtAuthOptions,
@@ -167,10 +169,15 @@ export function createTreecrdtAuthSession(opts: TreecrdtAuthSessionOptions): Tre
     ctxOverrides = {},
   ) => {
     if (ops.length === 0) return [];
+    if (ctxOverrides.preWriteState && ctxOverrides.preWriteState.length !== ops.length) {
+      throw new Error(
+        `preWriteState has ${ctxOverrides.preWriteState.length} entries for ${ops.length} ops`,
+      );
+    }
     if (!syncAuth.signOps || !syncAuth.verifyOps) {
       throw new Error('auth session is missing local op signing/verification hooks');
     }
-    const ctx: SyncAuthOpsContext = {
+    const ctx: SyncAuthOpsContext & LocalWriteAuthContext = {
       docId,
       purpose: 'reconcile',
       filterId: '__local__',

--- a/packages/treecrdt-auth/src/sqlite.ts
+++ b/packages/treecrdt-auth/src/sqlite.ts
@@ -18,7 +18,8 @@ import type { TreecrdtScopeEvaluator } from './treecrdt-auth.js';
  * Semantics:
  * - returns `"allow"` if `node` is inside the subtree rooted at `scope.root`
  * - returns `"deny"` if `node` is definitely outside the subtree (or excluded)
- * - returns `"unknown"` if local context is insufficient (e.g. `tree_nodes` has no row for a needed ancestor)
+ * - returns `"absent"` if the requested node itself has no materialized row
+ * - returns `"unknown"` if local context is insufficient (e.g. a needed ancestor has no row)
  *
  * Known issues / tradeoffs:
  * - Performance: O(depth) per call with 1 SQL query per hop. For large sync batches this can be costly.
@@ -51,7 +52,10 @@ LEFT JOIN tree_nodes AS t ON t.node = ?1
 
   const maxHops = 100_000;
 
-  return async ({ node, scope }) => {
+  const evaluate = async (
+    { node, scope }: Parameters<TreecrdtScopeEvaluator>[0],
+    parentOverride?: { parent: Uint8Array | null },
+  ) => {
     const rootHex = bytesToHex(scope.root);
     const excludeHex = new Set((scope.exclude ?? []).map((b) => bytesToHex(b)));
     const maxDepth = scope.maxDepth;
@@ -73,10 +77,15 @@ LEFT JOIN tree_nodes AS t ON t.node = ?1
       // If we already traversed `maxDepth` edges without reaching `root`, the node cannot be within scope.
       if (maxDepth !== undefined && distance >= maxDepth) return 'deny';
 
-      const parentHex = await runner.getText(parentSql, [curBytes]);
+      const parentHex =
+        distance === 0 && parentOverride
+          ? parentOverride.parent === null
+            ? 'null'
+            : bytesToHex(parentOverride.parent)
+          : await runner.getText(parentSql, [curBytes]);
       if (!parentHex) throw new Error('scope evaluator query returned empty result');
 
-      if (parentHex === 'missing') return 'unknown';
+      if (parentHex === 'missing') return distance === 0 ? 'absent' : 'unknown';
       if (parentHex === 'null') return 'deny';
 
       // `tree_nodes.parent` is a NodeId (16 bytes).
@@ -88,4 +97,8 @@ LEFT JOIN tree_nodes AS t ON t.node = ?1
     // Defensive: cycles or extreme depth.
     return 'unknown';
   };
+
+  const evaluator: TreecrdtScopeEvaluator = (opts) => evaluate(opts);
+  evaluator.evaluateWithParent = ({ parent, ...opts }) => evaluate(opts, { parent });
+  return evaluator;
 }

--- a/packages/treecrdt-auth/src/treecrdt-auth.ts
+++ b/packages/treecrdt-auth/src/treecrdt-auth.ts
@@ -21,7 +21,11 @@ export {
 } from './internal/op-sig.js';
 export type { TreecrdtOpAuthClaimsV1 } from './internal/op-sig.js';
 
-export type { TreecrdtScopeEvaluator } from './internal/scope.js';
+export type {
+  TreecrdtScopeEvaluation,
+  TreecrdtScopeEvaluator,
+  TreecrdtScopeEvaluatorInput,
+} from './internal/scope.js';
 
 export {
   TREECRDT_REVOCATION_CAPABILITY,

--- a/packages/treecrdt-auth/tests/auth.test.ts
+++ b/packages/treecrdt-auth/tests/auth.test.ts
@@ -465,6 +465,99 @@ test('auth: v2 signs authoredAt and defensive-delete knownState', async () => {
   ).rejects.toThrow(/v1 does not authenticate defensive delete state/i);
 });
 
+test('auth: scoped insert cannot reparent an existing external node', async () => {
+  const docId = 'doc-auth-insert-upsert-source';
+  const root = '0'.repeat(32);
+  const scopeRoot = nodeIdFromInt(1);
+  const externalNode = nodeIdFromInt(2);
+  const newNode = nodeIdFromInt(3);
+
+  const issuerSk = ed25519Utils.randomSecretKey();
+  const issuerPk = await getPublicKey(issuerSk);
+  const writerSk = ed25519Utils.randomSecretKey();
+  const writerPk = await getPublicKey(writerSk);
+  const verifierSk = ed25519Utils.randomSecretKey();
+  const verifierPk = await getPublicKey(verifierSk);
+
+  const token = issueTreecrdtCapabilityTokenV1({
+    issuerPrivateKey: issuerSk,
+    subjectPublicKey: writerPk,
+    docId,
+    actions: ['write_structure'],
+    rootNodeId: scopeRoot,
+  });
+  const writerAuth = createTreecrdtCoseCwtAuth({
+    issuerPublicKeys: [issuerPk],
+    localPrivateKey: writerSk,
+    localPublicKey: writerPk,
+    localCapabilityTokens: [token],
+    requireProofRef: true,
+  });
+
+  const parentByNode = new Map<string, string | null>([
+    [root, null],
+    [scopeRoot, root],
+    [externalNode, root],
+  ]);
+  const scopeEvaluator = ({ node, scope }: { node: Uint8Array; scope: { root: Uint8Array } }) => {
+    const target = bytesToHex(node);
+    const scopedRoot = bytesToHex(scope.root);
+    let current = target;
+    for (let hops = 0; hops < 100; hops += 1) {
+      if (current === scopedRoot) return 'allow' as const;
+      if (current === root) return 'deny' as const;
+      const parent = parentByNode.get(current);
+      if (parent === undefined)
+        return current === target ? ('absent' as const) : ('unknown' as const);
+      if (parent === null) return 'deny' as const;
+      current = parent;
+    }
+    return 'unknown' as const;
+  };
+  const verifierAuth = createTreecrdtCoseCwtAuth({
+    issuerPublicKeys: [issuerPk],
+    localPrivateKey: verifierSk,
+    localPublicKey: verifierPk,
+    requireProofRef: true,
+    scopeEvaluator,
+  });
+  await verifierAuth.onHello?.(
+    {
+      capabilities: (await writerAuth.helloCapabilities?.({ docId })) ?? [],
+      filters: [],
+      maxLamport: 0n,
+    },
+    { docId },
+  );
+
+  const ctx = { docId, purpose: 'reconcile' as const, filterId: 'all' };
+  const makeAuth = async (op: Operation) => [
+    {
+      sig: await signTreecrdtOpV1({ docId, op, privateKey: writerSk }),
+      proofRef: deriveTokenIdV1(token),
+    },
+  ];
+  const stealingInsert = makeOp(writerPk, 1, 1, {
+    type: 'insert',
+    parent: scopeRoot,
+    node: externalNode,
+    orderKey: orderKeyFromPosition(0),
+  });
+  await expect(
+    verifierAuth.verifyOps?.([stealingInsert], await makeAuth(stealingInsert), ctx),
+  ).rejects.toThrow(/capability does not allow op/i);
+
+  const newInsert = makeOp(writerPk, 2, 2, {
+    type: 'insert',
+    parent: scopeRoot,
+    node: newNode,
+    orderKey: orderKeyFromPosition(0),
+  });
+  await expect(
+    verifierAuth.verifyOps?.([newInsert], await makeAuth(newInsert), ctx),
+  ).resolves.toBeUndefined();
+});
+
 test('auth ignores foreign peer capability tokens during hello and still verifies known authors', async () => {
   const docId = 'doc-auth-ignore-foreign-hello-cap';
   const root = '0'.repeat(32);

--- a/packages/treecrdt-auth/tests/subtree-scope.test.ts
+++ b/packages/treecrdt-auth/tests/subtree-scope.test.ts
@@ -279,7 +279,7 @@ test('subtree scope: pending_context ops are stored and later applied when conte
     let cur = nodeHex;
     for (let depth = 0; depth < 10_000; depth += 1) {
       const parent = b.getParentHex(cur);
-      if (!parent) return 'unknown' as const;
+      if (!parent) return cur === nodeHex ? ('absent' as const) : ('unknown' as const);
       if (parent === scopeRootHex) return 'allow' as const;
       if (parent === ROOT_NODE_ID_HEX || parent === TRASH_NODE_ID_HEX) return 'deny' as const;
       cur = parent;

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -635,6 +635,10 @@ where
         Ok(self.nodes.parent(node)?.filter(|&p| p != NodeId::TRASH))
     }
 
+    pub fn node_exists(&self, node: NodeId) -> Result<bool> {
+        self.nodes.exists(node)
+    }
+
     pub fn payload(&self, node: NodeId) -> Result<Option<Vec<u8>>> {
         self.payloads.payload(node)
     }

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -6,6 +6,7 @@ import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import type { Filter, OpRef, SyncBackend } from '@treecrdt/sync-protocol';
 import {
   createTreecrdtCoseCwtAuth,
+  createTreecrdtAuthSession,
   createTreecrdtSqliteSubtreeScopeEvaluator,
   getEd25519PublicKey,
   issueTreecrdtCapabilityTokenV1,
@@ -219,6 +220,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
     {
       name: 'auth: sqlite subtree evaluator allow/deny/unknown',
       run: scenarioAuthSqliteSubtreeEvaluator,
+    },
+    {
+      name: 'local auth: scoped structural writes use pre-write ancestry',
+      run: scenarioLocalAuthUsesPreWriteAncestry,
     },
     {
       name: 'sync auth: pending_context ops use sqlite sidecar + reprocess',
@@ -1484,6 +1489,8 @@ function createEngineScopeEvaluator(engine: TreecrdtEngine): TreecrdtScopeEvalua
     const rootHex = bytesToHex(opts.scope.root);
     const nodeHex = bytesToHex(opts.node);
 
+    if (!(await engine.tree.exists(nodeHex))) return 'absent';
+
     const depth = await findDepthBfs({ engine, root: rootHex, target: nodeHex });
     if (depth === null) return 'unknown';
     if (opts.scope.maxDepth !== undefined && depth > opts.scope.maxDepth) return 'deny';
@@ -1696,15 +1703,16 @@ async function scenarioAuthSqliteSubtreeEvaluator(
   const child = nodeIdFromInt(2);
   const unrelated = nodeIdFromInt(3);
 
-  // Missing node => unknown context.
+  // A missing target is distinct from incomplete ancestry. Insert auth uses
+  // this to allow genuinely new nodes without treating unknown context as safe.
   assertEqual(
     await evalScope({
       docId,
       node: nodeIdToBytes16(child),
       scope: { root: nodeIdToBytes16(subtreeRoot) },
     }),
-    'unknown',
-    'sqlite scope evaluator: missing node should be unknown',
+    'absent',
+    'sqlite scope evaluator: missing target should be absent',
   );
 
   // Insert child under subtreeRoot (root node itself need not exist as a row).
@@ -1747,6 +1755,125 @@ async function scenarioAuthSqliteSubtreeEvaluator(
     }),
     'deny',
     'sqlite scope evaluator: expected unrelated node to be outside subtree',
+  );
+}
+
+async function scenarioLocalAuthUsesPreWriteAncestry(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const runner = engineRunnerOrNull(ctx.engine);
+  if (!runner) return;
+
+  const engine = ctx.engine;
+  const root = nodeIdFromInt(0);
+  const scopeRoot = nodeIdFromInt(1);
+  const scopeParent = nodeIdFromInt(2);
+  const inScopeNode = nodeIdFromInt(3);
+  const externalNode = nodeIdFromInt(4);
+  const freshNode = nodeIdFromInt(5);
+  const seedReplica = replicaFromLabel('scope-seed');
+
+  await engine.local.insert(seedReplica, root, scopeRoot, { type: 'last' }, null);
+  await engine.local.insert(seedReplica, scopeRoot, scopeParent, { type: 'last' }, null);
+  await engine.local.insert(seedReplica, scopeRoot, inScopeNode, { type: 'last' }, null);
+  await engine.local.insert(seedReplica, root, externalNode, { type: 'last' }, null);
+
+  const issuerSk = randomEd25519SecretKey();
+  const issuerPk = await getEd25519PublicKey(issuerSk);
+  const writerSk = randomEd25519SecretKey();
+  const writerPk = await getEd25519PublicKey(writerSk);
+  const token = issueTreecrdtCapabilityTokenV1({
+    issuerPrivateKey: issuerSk,
+    subjectPublicKey: writerPk,
+    docId: ctx.docId,
+    actions: ['write_structure'],
+    rootNodeId: scopeRoot,
+  });
+  const authSession = createTreecrdtAuthSession({
+    docId: ctx.docId,
+    trust: { issuerPublicKeys: [issuerPk] },
+    local: {
+      privateKey: writerSk,
+      publicKey: writerPk,
+      capabilityTokens: [token],
+    },
+    backend: {
+      scopeEvaluator: createTreecrdtSqliteSubtreeScopeEvaluator(runner),
+    },
+    requireProofRef: true,
+  });
+  await authSession.ready;
+
+  // A genuinely new insert has no source location and only needs its
+  // destination to be in scope.
+  await engine.local.insert(writerPk, scopeRoot, freshNode, { type: 'last' }, null, {
+    authSession,
+  });
+  assertEqual(await engine.tree.parent(freshNode), scopeRoot, 'authorized new insert parent');
+
+  // An existing in-scope node can still move within the authorized subtree.
+  await engine.local.move(
+    writerPk,
+    inScopeNode,
+    scopeParent,
+    { type: 'last' },
+    {
+      authSession,
+    },
+  );
+  assertEqual(
+    await engine.tree.parent(inScopeNode),
+    scopeParent,
+    'authorized in-scope move parent',
+  );
+
+  const opCountBeforeRejectedWrites = (await engine.ops.all()).length;
+  const expectRejected = async (write: () => Promise<unknown>, label: string) => {
+    let error: unknown;
+    try {
+      await write();
+    } catch (err) {
+      error = err;
+    }
+    assert(error, `${label}: expected authorization rejection`);
+    assert(
+      /capability does not allow op|missing subtree context/i.test(
+        String((error as any)?.message ?? error),
+      ),
+      `${label}: unexpected error: ${String((error as any)?.message ?? error)}`,
+    );
+  };
+
+  // Insert is an upsert. It must not be usable to pull an existing external
+  // node into scope merely because the destination parent is authorized.
+  await expectRejected(
+    () =>
+      engine.local.insert(writerPk, scopeRoot, externalNode, { type: 'last' }, null, {
+        authSession,
+      }),
+    'cross-scope insert upsert',
+  );
+  assertEqual(
+    await engine.tree.parent(externalNode),
+    root,
+    'rejected insert preserves external parent',
+  );
+
+  // Move uses the same stable pre-write ancestry and cannot bypass the source
+  // check by observing its own post-move placement.
+  await expectRejected(
+    () => engine.local.move(writerPk, externalNode, scopeRoot, { type: 'last' }, { authSession }),
+    'cross-scope move',
+  );
+  assertEqual(
+    await engine.tree.parent(externalNode),
+    root,
+    'rejected move preserves external parent',
+  );
+  assertEqual(
+    (await engine.ops.all()).length,
+    opCountBeforeRejectedWrites,
+    'rejected structural writes do not persist operations',
   );
 }
 

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -32,6 +32,14 @@ struct JsonOp {
 struct JsonLocalOpResult {
     op: JsonOp,
     outcome: JsonMaterializationOutcome,
+    pre_write_state: JsonLocalOpPreWriteState,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonLocalOpPreWriteState {
+    existed: bool,
+    parent: Option<[u8; 16]>,
 }
 
 type LocalCrdt = TreeCrdt<SqliteOpStorage, LamportClock, SqliteNodeStore, SqlitePayloadStore>;
@@ -204,6 +212,7 @@ fn finish_local_core_op(
     mut session: LocalOpSession,
     op: Operation,
     plan: LocalFinalizePlan,
+    pre_write_state: JsonLocalOpPreWriteState,
 ) -> Result<JsonLocalOpResult, c_int> {
     let mut post_materialization_ok = true;
     let mut head_seq = 0u64;
@@ -282,6 +291,7 @@ fn finish_local_core_op(
     Ok(JsonLocalOpResult {
         op,
         outcome: json_outcome_from_core(&outcome),
+        pre_write_state,
     })
 }
 
@@ -300,11 +310,31 @@ where
         Ok(v) => v,
         Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
     };
+    let source_node = match &prepared.op.kind {
+        OperationKind::Insert { node, .. }
+        | OperationKind::Move { node, .. }
+        | OperationKind::Delete { node }
+        | OperationKind::Tombstone { node }
+        | OperationKind::Payload { node, .. } => *node,
+    };
+    let existed = match session.crdt.node_exists(source_node) {
+        Ok(v) => v,
+        Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
+    };
+    let parent = if existed {
+        match session.crdt.parent(source_node) {
+            Ok(parent) => parent.map(|node| node.0.to_be_bytes()),
+            Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
+        }
+    } else {
+        None
+    };
+    let pre_write_state = JsonLocalOpPreWriteState { existed, parent };
     let (op, plan) = match session.crdt.commit_prepared_local(prepared) {
         Ok(v) => v,
         Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
     };
-    finish_local_core_op(session, op, plan)
+    finish_local_core_op(session, op, plan, pre_write_state)
 }
 
 pub(super) unsafe extern "C" fn treecrdt_local_insert(

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -96,6 +96,14 @@ struct JsonOperationId {
 struct JsonLocalOpResult {
     op: JsonOp,
     outcome: JsonMaterializationOutcome,
+    pre_write_state: JsonLocalOpPreWriteState,
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonLocalOpPreWriteState {
+    existed: bool,
+    parent: Option<[u8; 16]>,
 }
 
 fn node_bytes_from_id(node: NodeId) -> Vec<u8> {
@@ -522,6 +530,10 @@ fn local_insert_returns_appended_insert_op() {
         )
         .unwrap();
 
+    let result: JsonLocalOpResult = serde_json::from_str(&json).unwrap();
+    assert!(!result.pre_write_state.existed);
+    assert_eq!(result.pre_write_state.parent, None);
+
     let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
@@ -553,6 +565,21 @@ fn local_insert_returns_appended_insert_op() {
     assert_eq!(head_replica, b"r1".to_vec());
     assert_eq!(head_counter, 1);
     assert_eq!(head_seq, 1);
+
+    let next_parent = node_bytes(2);
+    let upsert_json: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'first', NULL, NULL)",
+            rusqlite::params![replica, next_parent, node],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let upsert: JsonLocalOpResult = serde_json::from_str(&upsert_json).unwrap();
+    assert!(upsert.pre_write_state.existed);
+    assert_eq!(
+        upsert.pre_write_state.parent,
+        Some(<[u8; 16]>::try_from(parent.as_slice()).unwrap())
+    );
 }
 
 #[test]

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -128,8 +128,26 @@ export type WriteOptions = {
   writeId?: string;
 };
 
+/**
+ * Materialized location of an operation's target node immediately before a
+ * local SQLite write was applied.
+ *
+ * Entries are aligned with the operations passed to `authorizeLocalOps`.
+ * Keeping this explicit prevents structural authorization from accidentally
+ * consulting the node after an insert/move/delete has changed its ancestry.
+ */
+export type LocalWriteAuthPreState = {
+  node: string;
+  existed: boolean;
+  parent: string | null;
+};
+
+export type LocalWriteAuthContext = {
+  preWriteState?: readonly LocalWriteAuthPreState[];
+};
+
 export type LocalWriteAuthSession = {
-  authorizeLocalOps: (ops: readonly Operation[]) => Promise<unknown>;
+  authorizeLocalOps: (ops: readonly Operation[], opts?: LocalWriteAuthContext) => Promise<unknown>;
 };
 
 export type LocalWriteOptions = {

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -1,6 +1,7 @@
 import type { SerializeNodeId, SerializeReplica, TreecrdtAdapter } from './adapter.js';
 import { addMaterializationWriteId, emptyMaterializationOutcome } from './engine.js';
 import type {
+  LocalWriteAuthPreState,
   LocalWriteOptions,
   MaterializationEvent,
   MaterializationOutcome,
@@ -67,12 +68,34 @@ let localAuthSavepointCounter = 0;
 function decodeLocalOpResult(
   raw: any,
   sql: string,
-): { op: Operation; outcome: MaterializationOutcome } {
+): {
+  op: Operation;
+  outcome: MaterializationOutcome;
+  preWriteState?: LocalWriteAuthPreState;
+} {
   const ops = decodeSqliteOps([raw.op]);
   if (ops.length !== 1) throw new Error(`expected exactly 1 op from query: ${sql}`);
+  const op = ops[0]!;
+  const rawPreWriteState = raw.preWriteState;
+  let preWriteState: LocalWriteAuthPreState | undefined;
+  if (rawPreWriteState !== undefined) {
+    if (!rawPreWriteState || typeof rawPreWriteState.existed !== 'boolean') {
+      throw new Error(`invalid pre-write state from query: ${sql}`);
+    }
+    const parent = rawPreWriteState.parent == null ? null : decodeNodeId(rawPreWriteState.parent);
+    if (!rawPreWriteState.existed && parent !== null) {
+      throw new Error(`absent pre-write state has a parent from query: ${sql}`);
+    }
+    preWriteState = {
+      node: op.kind.node,
+      existed: rawPreWriteState.existed,
+      parent,
+    };
+  }
   return {
-    op: ops[0]!,
+    op,
     outcome: decodeSqliteMaterializationOutcome(raw.outcome),
+    ...(preWriteState ? { preWriteState } : {}),
   };
 }
 
@@ -631,11 +654,16 @@ export function createTreecrdtSqliteWriter(
     let released = false;
     await sqliteExec(runner, `SAVEPOINT ${savepoint}`);
     try {
-      const { op, outcome } = decodeLocalOpResult(
+      const { op, outcome, preWriteState } = decodeLocalOpResult(
         await sqliteGetJson<any>(runner, sql, params),
         sql,
       );
-      await authSession.authorizeLocalOps([op]);
+      if (!preWriteState) {
+        throw new Error(
+          'treecrdt: local authorization requires pre-write state from the SQLite extension',
+        );
+      }
+      await authSession.authorizeLocalOps([op], { preWriteState: [preWriteState] });
       await sqliteExec(runner, `RELEASE ${savepoint}`);
       released = true;
       emitLocalOutcome(outcome, opts.onMaterialized, writeOpts?.writeId);


### PR DESCRIPTION
## Stack

Stacked on #157. Merge #157 first, then retarget this PR to `main`.

## In one sentence

Authorize structural writes against the node's stable source ancestry as well as its destination, so a scoped writer cannot pull an external node into its subtree.

## What was wrong?

TreeCRDT `insert` is also an upsert: if the node already exists, it detaches the node from its current parent and attaches it to the requested parent.

Auth checked only the insert destination. A writer scoped to subtree A could therefore submit `insert(existingExternalNode, parent=A)` and steal a node from outside its grant.

SQLite local writes had a second version of the bypass. The extension prepared/applied the structural change before JavaScript awaited authorization inside the outer savepoint. A normal scope evaluator then saw the node at its new in-scope location instead of its old external location.

## What changes?

- Existing-node insert checks both the source node and destination parent.
- A genuinely absent node is distinguished from missing ancestry and remains a valid new insert.
- The SQLite extension returns the target node's existence and parent captured before the prepared write is committed.
- Local auth evaluates the source through that explicit prior parent; it does not trust post-write ancestry.
- Move, delete, tombstone, and payload authorization use the same stable source-state path.
- An old extension that does not return pre-write state fails closed when local auth is enabled.
- A custom evaluator that cannot honor an explicit prior parent also fails closed.

## Why the extra `absent` result?

Before this PR, a missing target and an incomplete ancestor chain both returned `unknown`. Insert needs to tell those apart: a missing target has no source grant to check, while incomplete ancestry must never be treated as authorization.

## Size and debloat

The PR is +497/-32 across 14 files:

- production: approximately +239/-28
- regressions and shared conformance: +251/-4
- changeset: 7 lines

Pre-write state is captured from the already-open native CRDT session and returned with the existing local-op result; it does not add a separate preflight query/round trip.

## Validation

- auth: 47/47 tests
- SQLite-node: 35/35 tests
- native extension: 20/20 tests
- TypeScript builds for protocol, interface, auth, sync-sqlite, conformance, and sqlite-node
- strict workspace Clippy and feature-specific extension Clippy
- SQLite static-link check
- Rustfmt, Prettier, and diff checks

Regressions cover remote insert stealing, local insert/move cross-scope rejection, valid new inserts, valid in-scope moves, rollback, and native pre-state serialization.

## Important remaining transaction issue

This fixes which tree state authorization evaluates. It does **not** remove the pre-existing arbitrary async authorization wait inside the outer SQLite savepoint. Concurrent use of the same runner can still interleave unrelated writes into that savepoint and an auth rejection can roll them back. That transaction-isolation redesign remains a separate critical PR rather than being hidden inside this scope patch.
