### PR TITLE
fix: reject operation ID equivocation atomically

### DIFF
--- a/.changeset/reject-operation-id-equivocation.md
+++ b/.changeset/reject-operation-id-equivocation.md
@@ -1,0 +1,10 @@
+---
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+---
+
+Reject operation-id equivocation at memory, SQLite, and PostgreSQL storage boundaries. Exact duplicate operations remain idempotent, while reusing a replica/counter id with different contents now fails without committing any part of the batch.
+
+SQLite and wa-sqlite `appendMany` calls now use one atomic bulk-extension call. The generic per-operation retry and cross-worker chunking have been removed because they could commit a prefix before returning a validation error. As before, the SQLite adapter requires the matching extension with `treecrdt_append_ops`; the old-extension compatibility fallback had already stopped working once it was changed to retry through that same function.
+
+This closes silent divergence when conflicting operation bodies reach the same storage boundary. A future content-bound op-ref protocol version is still needed to detect Byzantine peers that never exchange both conflicting bodies.

--- a/packages/treecrdt-core/src/traits.rs
+++ b/packages/treecrdt-core/src/traits.rs
@@ -1,5 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::error::{Error, Result};
 use crate::ids::{Lamport, NodeId, OperationId, ReplicaId};
@@ -209,16 +209,23 @@ impl AccessControl for AllowAllAccess {
 #[derive(Default)]
 pub struct MemoryStorage {
     ops: Vec<Operation>,
-    ids: HashSet<OperationId>,
+    ids: HashMap<OperationId, usize>,
 }
 
 impl Storage for MemoryStorage {
     fn apply(&mut self, op: Operation) -> Result<bool> {
         op.validate()?;
-        if self.ids.contains(&op.meta.id) {
-            return Ok(false);
+        if let Some(&index) = self.ids.get(&op.meta.id) {
+            if self.ops.get(index) == Some(&op) {
+                return Ok(false);
+            }
+            return Err(Error::InvalidOperation(format!(
+                "operation id {:?}:{} has conflicting contents",
+                op.meta.id.replica.as_bytes(),
+                op.meta.id.counter
+            )));
         }
-        self.ids.insert(op.meta.id.clone());
+        self.ids.insert(op.meta.id.clone(), self.ops.len());
         self.ops.push(op);
         Ok(true)
     }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -407,13 +407,13 @@ where
         op: Operation,
     ) -> Result<Option<(ApplyDelta, ApplyEffects)>> {
         op.validate()?;
+        let inserted = self.storage.apply(op.clone())?;
         self.clock.observe(op.meta.lamport);
         self.version_vector.observe(&op.meta.id.replica, op.meta.id.counter);
         if op.meta.id.replica == self.replica_id {
             self.counter = self.counter.max(op.meta.id.counter);
         }
-
-        if !self.storage.apply(op.clone())? {
+        if !inserted {
             return Ok(None);
         }
 
@@ -905,8 +905,9 @@ where
         op: Operation,
     ) -> Result<(Operation, bool, ForwardApply, Vec<TombstoneDelta>)> {
         op.validate()?;
+        let inserted = self.storage.apply(op.clone())?;
         self.version_vector.observe(&self.replica_id, op.meta.id.counter);
-        if !self.storage.apply(op.clone())? {
+        if !inserted {
             // A duplicate local retry must not call `snapshot`: that helper intentionally ensures
             // the target row for a newly accepted op. Read an existing row only, so a storage-only
             // duplicate cannot mutate derived state while reporting an empty finalize plan.

--- a/packages/treecrdt-core/tests/operation_id_equivocation.rs
+++ b/packages/treecrdt-core/tests/operation_id_equivocation.rs
@@ -1,0 +1,111 @@
+use treecrdt_core::{
+    LamportClock, LocalPlacement, MemoryStorage, NodeId, Operation, OperationKind, ReplicaId,
+    Storage, TreeCrdt, VersionVector,
+};
+
+fn assert_conflict(storage: &mut MemoryStorage, op: Operation) {
+    let err = storage.apply(op).expect_err("conflicting operation id must fail");
+    assert!(err.to_string().contains("conflicting contents"));
+}
+
+#[test]
+fn memory_storage_only_deduplicates_identical_operations() {
+    let replica = ReplicaId::new(b"replica");
+    let original = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 1]);
+    let mut storage = MemoryStorage::default();
+
+    assert!(storage.apply(original.clone()).unwrap());
+    assert!(!storage.apply(original.clone()).unwrap());
+
+    let mut conflicts = Vec::new();
+
+    let mut changed = original.clone();
+    changed.meta.lamport = 2;
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let OperationKind::Insert { parent, .. } = &mut changed.kind {
+        *parent = NodeId(2);
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let OperationKind::Insert { node, .. } = &mut changed.kind {
+        *node = NodeId(2);
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let OperationKind::Insert { order_key, .. } = &mut changed.kind {
+        *order_key = vec![0, 2];
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let OperationKind::Insert { payload, .. } = &mut changed.kind {
+        *payload = Some(Vec::new());
+    }
+    conflicts.push(changed);
+
+    let mut changed = Operation::move_node(
+        &replica,
+        original.meta.id.counter,
+        original.meta.lamport,
+        NodeId(1),
+        NodeId::ROOT,
+        vec![0, 1],
+    );
+    changed.meta.id = original.meta.id.clone();
+    conflicts.push(changed);
+
+    for conflict in conflicts {
+        assert_conflict(&mut storage, conflict);
+    }
+
+    assert_eq!(storage.load_since(0).unwrap(), vec![original]);
+}
+
+#[test]
+fn memory_storage_distinguishes_payload_null_empty_and_known_state() {
+    let replica = ReplicaId::new(b"replica");
+    let mut storage = MemoryStorage::default();
+
+    let cleared = Operation::payload(&replica, 1, 1, NodeId(1), None);
+    assert!(storage.apply(cleared.clone()).unwrap());
+    assert!(!storage.apply(cleared).unwrap());
+    assert_conflict(
+        &mut storage,
+        Operation::payload(&replica, 1, 1, NodeId(1), Some(Vec::new())),
+    );
+
+    let tombstone = Operation::tombstone(&replica, 2, 2, NodeId(1));
+    assert!(storage.apply(tombstone.clone()).unwrap());
+    assert!(!storage.apply(tombstone.clone()).unwrap());
+
+    let mut known_state = VersionVector::new();
+    known_state.observe(&replica, 1);
+    let mut changed = tombstone;
+    changed.meta.known_state = Some(known_state);
+    assert_conflict(&mut storage, changed);
+}
+
+#[test]
+fn rejected_equivocation_does_not_advance_the_local_clock() {
+    let remote = ReplicaId::new(b"remote");
+    let mut tree = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let original = Operation::insert(&remote, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 1]);
+    tree.apply_remote(original.clone()).unwrap();
+
+    let mut conflict = original;
+    conflict.meta.lamport = 100;
+    assert!(tree.apply_remote(conflict).is_err());
+
+    let (local, _) =
+        tree.local_insert(NodeId::ROOT, NodeId(2), LocalPlacement::Last, None).unwrap();
+    assert_eq!(local.meta.lamport, 2);
+}

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -145,6 +145,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioAppendIdempotentAndHeadLamportMonotonic,
     },
     {
+      name: 'append/appendMany: rejects operation id equivocation atomically',
+      run: scenarioRejectsOperationIdEquivocationAtomically,
+    },
+    {
       name: 'materialization events: structural batch',
       run: scenarioMaterializationEventStructuralBatch,
     },
@@ -674,6 +678,64 @@ async function scenarioAppendIdempotentAndHeadLamportMonotonic(
   const refs = await engine.opRefs.all();
   assertEqual(refs.length, 2, 'opRefs.all length after duplicate append');
   assertEqual(await engine.meta.headLamport(), 7, 'meta.headLamport after duplicate append');
+}
+
+async function scenarioRejectsOperationIdEquivocationAtomically(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('equivocation');
+  const root = nodeIdFromInt(0);
+  const node = nodeIdFromInt(1);
+  const other = nodeIdFromInt(2);
+  const original = makeInsertOp({
+    replica,
+    counter: 1,
+    lamport: 1,
+    parent: root,
+    node,
+    orderKey: orderKeyFromPosition(0),
+  });
+  const expectRejected = async (ops: Operation[], label: string): Promise<void> => {
+    let threw = false;
+    try {
+      await engine.ops.appendMany(ops);
+    } catch {
+      threw = true;
+    }
+    assert(threw, `${label} should reject operation id equivocation`);
+  };
+
+  await engine.ops.appendMany([original, original]);
+  assertEqual((await engine.opRefs.all()).length, 1, 'exact duplicate remains idempotent');
+
+  const validPrefix = makeInsertOp({
+    replica,
+    counter: 2,
+    lamport: 2,
+    parent: root,
+    node: other,
+    orderKey: orderKeyFromPosition(1),
+  });
+  const conflict = makeInsertOp({
+    replica,
+    counter: 1,
+    lamport: 3,
+    parent: root,
+    node,
+    orderKey: orderKeyFromPosition(0),
+  });
+  await expectRejected([validPrefix, conflict], 'conflict after valid prefix');
+  assertEqual((await engine.opRefs.all()).length, 1, 'failed batch must not commit a prefix');
+  assertEqual(await engine.tree.exists(other), false, 'failed batch must not materialize a prefix');
+
+  const cleared = makePayloadOp({ replica, counter: 3, lamport: 3, node, payload: null });
+  await engine.ops.append(cleared);
+  await expectRejected(
+    [makePayloadOp({ replica, counter: 3, lamport: 3, node, payload: new Uint8Array() })],
+    'null versus empty payload',
+  );
+  assertEqual((await engine.opRefs.all()).length, 2, 'conflicts must leave the op log unchanged');
 }
 
 async function scenarioMaterializationEventStructuralBatch(

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -1172,6 +1172,57 @@ fn op_kind_to_db(op: &Operation) -> Result<OpDbFields> {
     }
 }
 
+fn verify_persisted_ops(ctx: &PgCtx, c: &mut Client, ops: &[Operation]) -> Result<()> {
+    if ops.is_empty() {
+        return Ok(());
+    }
+
+    let op_refs: Vec<Vec<u8>> = ops
+        .iter()
+        .map(|op| {
+            derive_op_ref_v0(
+                &ctx.doc_id,
+                op.meta.id.replica.as_bytes(),
+                op.meta.id.counter,
+            )
+            .to_vec()
+        })
+        .collect();
+    let stmt = ctx.stmt(
+        c,
+        "SELECT \
+           o.lamport, o.replica, o.counter, o.kind, o.parent, o.node, o.new_parent, o.order_key, o.payload, o.known_state \
+         FROM unnest($2::bytea[]) WITH ORDINALITY AS requested(op_ref, ord) \
+         LEFT JOIN treecrdt_ops o \
+           ON o.doc_id = $1 AND o.op_ref = requested.op_ref \
+         ORDER BY requested.ord",
+    )?;
+    let rows = c.query(&stmt, &[&ctx.doc_id, &op_refs]).map_err(storage_debug)?;
+    if rows.len() != ops.len() {
+        return Err(Error::InconsistentState(
+            "operation verification returned an unexpected row count".into(),
+        ));
+    }
+
+    for (row, incoming) in rows.iter().zip(ops) {
+        let kind: Option<String> = row.get(3);
+        if kind.is_none() {
+            return Err(Error::InconsistentState(
+                "operation insert was ignored but no existing operation was found".into(),
+            ));
+        }
+        let persisted = row_to_op_at(row, 0)?;
+        if persisted != *incoming {
+            return Err(Error::InvalidOperation(format!(
+                "operation id {:?}:{} has conflicting contents",
+                incoming.meta.id.replica.as_bytes(),
+                incoming.meta.id.counter
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn insert_op_in_tx(ctx: &PgCtx, c: &mut Client, op: &Operation) -> Result<bool> {
     let replica = op.meta.id.replica.as_bytes();
     let counter = op.meta.id.counter;
@@ -1203,6 +1254,9 @@ fn insert_op_in_tx(ctx: &PgCtx, c: &mut Client, op: &Operation) -> Result<bool> 
             ],
         )
         .map_err(storage_debug)?;
+    if inserted == 0 {
+        verify_persisted_ops(ctx, c, std::slice::from_ref(op))?;
+    }
     Ok(inserted > 0)
 }
 
@@ -1289,6 +1343,9 @@ fn bulk_insert_ops_in_tx(ctx: &PgCtx, c: &mut Client, ops: &[Operation]) -> Resu
     let mut inserted = Vec::with_capacity(rows.len());
     for row in rows {
         inserted.push(row.get::<_, Vec<u8>>(0));
+    }
+    if inserted.len() != ops.len() {
+        verify_persisted_ops(ctx, c, ops)?;
     }
     Ok(inserted)
 }

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -52,6 +52,12 @@ impl MaterializationConformanceHarness for PgConformanceHarness {
         append_ops(&self.client, &self.doc_id, ops).unwrap();
     }
 
+    fn try_append_ops(&self, ops: &[Operation]) -> Result<(), String> {
+        append_ops(&self.client, &self.doc_id, ops)
+            .map(|_| ())
+            .map_err(|err| err.to_string())
+    }
+
     fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome {
         append_ops_with_materialization_outcome(&self.client, &self.doc_id, ops).unwrap()
     }
@@ -229,6 +235,14 @@ fn postgres_backend_append_batch_materializes_only_inserted_ops() {
         return;
     };
     materialization_conformance::append_batch_materializes_only_inserted_ops(&harness);
+}
+
+#[test]
+fn postgres_backend_rejects_operation_id_equivocation_atomically() {
+    let Some(harness) = setup_conformance_harness() else {
+        return;
+    };
+    materialization_conformance::operation_id_equivocation_is_rejected_atomically(&harness);
 }
 
 #[test]

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
@@ -135,6 +135,59 @@ fn read_operation_row(stmt: *mut sqlite3_stmt) -> treecrdt_core::Result<treecrdt
     })
 }
 
+fn load_operation_by_id(
+    db: *mut sqlite3,
+    replica: &[u8],
+    counter: u64,
+) -> treecrdt_core::Result<Option<treecrdt_core::Operation>> {
+    let sql = CString::new(
+        "SELECT replica,counter,lamport,kind,parent,node,new_parent,order_key,known_state,payload \
+         FROM ops WHERE replica = ?1 AND counter = ?2",
+    )
+    .expect("op by id sql");
+    let mut stmt: *mut sqlite3_stmt = null_mut();
+    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(sqlite_rc_error(rc, "sqlite_prepare_v2 op by id failed"));
+    }
+
+    let bind_rc = unsafe {
+        let replica_rc = sqlite_bind_blob(
+            stmt,
+            1,
+            replica.as_ptr() as *const c_void,
+            replica.len() as c_int,
+            None,
+        );
+        let counter_rc = sqlite_bind_int64(stmt, 2, counter as i64);
+        if replica_rc != SQLITE_OK as c_int {
+            replica_rc
+        } else {
+            counter_rc
+        }
+    };
+    if bind_rc != SQLITE_OK as c_int {
+        unsafe { sqlite_finalize(stmt) };
+        return Err(sqlite_rc_error(bind_rc, "bind op by id failed"));
+    }
+
+    let step_rc = unsafe { sqlite_step(stmt) };
+    let operation = if step_rc == SQLITE_ROW as c_int {
+        read_operation_row(stmt).map(Some)
+    } else if step_rc == SQLITE_DONE as c_int {
+        Ok(None)
+    } else {
+        unsafe { sqlite_finalize(stmt) };
+        return Err(sqlite_rc_error(step_rc, "op by id step failed"));
+    };
+
+    let finalize_rc = unsafe { sqlite_finalize(stmt) };
+    if finalize_rc != SQLITE_OK as c_int {
+        return Err(sqlite_rc_error(finalize_rc, "finalize op by id failed"));
+    }
+    operation
+}
+
 pub(super) struct SqliteOpStorage {
     db: *mut sqlite3,
     doc_id: Option<Vec<u8>>,
@@ -162,6 +215,7 @@ impl SqliteOpStorage {
 impl treecrdt_core::Storage for SqliteOpStorage {
     fn apply(&mut self, op: treecrdt_core::Operation) -> treecrdt_core::Result<bool> {
         op.validate()?;
+        let incoming = op.clone();
         let doc_id = self.ensure_doc_id()?;
 
         let (kind, parent, node, new_parent, order_key, known_state, payload) = match op.kind {
@@ -346,7 +400,29 @@ impl treecrdt_core::Storage for SqliteOpStorage {
         if finalize_rc != SQLITE_OK as c_int {
             return Err(sqlite_rc_error(finalize_rc, "finalize insert op failed"));
         }
-        Ok(inserted)
+        if inserted {
+            return Ok(true);
+        }
+
+        let existing = load_operation_by_id(
+            self.db,
+            incoming.meta.id.replica.as_bytes(),
+            incoming.meta.id.counter,
+        )?
+        .ok_or_else(|| {
+            treecrdt_core::Error::InconsistentState(
+                "operation insert was ignored but no existing operation was found".into(),
+            )
+        })?;
+        if existing == incoming {
+            Ok(false)
+        } else {
+            Err(treecrdt_core::Error::InvalidOperation(format!(
+                "operation id {:?}:{} has conflicting contents",
+                incoming.meta.id.replica.as_bytes(),
+                incoming.meta.id.counter
+            )))
+        }
     }
 
     fn load_since(&self, lamport: Lamport) -> treecrdt_core::Result<Vec<treecrdt_core::Operation>> {

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -292,18 +292,23 @@ fn read_materialized_node_state(conn: &Connection, node: NodeId) -> Materialized
     }
 }
 
-fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (MaterializationOutcome, i64) {
+fn try_append_ops_json(
+    conn: &Connection,
+    ops: &[JsonOp],
+) -> rusqlite::Result<(MaterializationOutcome, i64)> {
     let json = serde_json::to_string(ops).unwrap();
-    let affected_json: String = conn
-        .query_row(
-            "SELECT treecrdt_append_ops(?1)",
-            rusqlite::params![json],
-            |row| row.get(0),
-        )
-        .unwrap();
+    let affected_json: String = conn.query_row(
+        "SELECT treecrdt_append_ops(?1)",
+        rusqlite::params![json],
+        |row| row.get(0),
+    )?;
     let outcome: JsonMaterializationOutcome = serde_json::from_str(&affected_json).unwrap();
-    let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0)).unwrap();
-    (json_outcome_to_core(outcome), count)
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0))?;
+    Ok((json_outcome_to_core(outcome), count))
+}
+
+fn append_ops_json(conn: &Connection, ops: &[JsonOp]) -> (MaterializationOutcome, i64) {
+    try_append_ops_json(conn, ops).unwrap()
 }
 
 fn visible_children(conn: &Connection, parent: &[u8]) -> Vec<Vec<u8>> {
@@ -406,6 +411,12 @@ fn append_after_blocking_writer_commits(
 impl MaterializationConformanceHarness for SqliteConformanceHarness {
     fn append_ops(&self, ops: &[Operation]) {
         append_ops_json(&self.conn, &json_ops(ops));
+    }
+
+    fn try_append_ops(&self, ops: &[Operation]) -> Result<(), String> {
+        try_append_ops_json(&self.conn, &json_ops(ops))
+            .map(|_| ())
+            .map_err(|err| err.to_string())
     }
 
     fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome {
@@ -633,6 +644,12 @@ fn local_insert_returns_appended_insert_op() {
 fn remote_append_materializes_only_inserted_ops() {
     let harness = setup_conformance_harness();
     materialization_conformance::append_batch_materializes_only_inserted_ops(&harness);
+}
+
+#[test]
+fn remote_append_rejects_operation_id_equivocation_atomically() {
+    let harness = setup_conformance_harness();
+    materialization_conformance::operation_id_equivocation_is_rejected_atomically(&harness);
 }
 
 #[test]

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -113,8 +113,8 @@ function createRunner(db: any): SqliteRunner {
   return runner;
 }
 
-export function createSqliteNodeApi(db: any, opts: { maxBulkOps?: number } = {}): TreecrdtAdapter {
-  return createTreecrdtSqliteAdapter(createRunner(db), opts);
+export function createSqliteNodeApi(db: any): TreecrdtAdapter {
+  return createTreecrdtSqliteAdapter(createRunner(db));
 }
 
 /**
@@ -125,12 +125,13 @@ export function createSqliteNodeApi(db: any, opts: { maxBulkOps?: number } = {})
  */
 export function createTreecrdtClient(
   db: any,
-  opts: { docId?: string; maxBulkOps?: number } = {},
+  opts: {
+    docId?: string;
+  } = {},
 ): Promise<TreecrdtEngine & { runner: SqliteRunner; auth: TreecrdtSqliteAuthApi }> {
   const runner = createRunner(db);
   const materialized = createMaterializationDispatcher();
   const adapter = createTreecrdtSqliteAdapter(runner, {
-    maxBulkOps: opts.maxBulkOps,
     onMaterialized: materialized.emitEvent,
   });
   const docId = opts.docId ?? 'treecrdt';

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -14,6 +14,7 @@ pub struct MaterializedNodeState {
 
 pub trait MaterializationConformanceHarness {
     fn append_ops(&self, ops: &[Operation]);
+    fn try_append_ops(&self, ops: &[Operation]) -> Result<(), String>;
     fn append_ops_with_materialization_outcome(&self, ops: &[Operation]) -> MaterializationOutcome;
     fn visible_children(&self, parent: NodeId) -> Vec<NodeId>;
     fn payload(&self, node: NodeId) -> Option<Vec<u8>>;
@@ -112,6 +113,94 @@ pub fn append_batch_materializes_only_inserted_ops<H: MaterializationConformance
     assert_eq!(harness.op_count().saturating_sub(before), 2);
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![node]);
     assert_eq!(harness.head_seq(), 2);
+}
+
+pub fn operation_id_equivocation_is_rejected_atomically<H: MaterializationConformanceHarness>(
+    harness: &H,
+) {
+    let replica = ReplicaId::new(b"equivocation");
+    let original = Operation::insert(
+        &replica,
+        1,
+        1,
+        NodeId::ROOT,
+        node(1),
+        order_key_from_position(0),
+    );
+
+    harness.append_ops(&[original.clone(), original.clone()]);
+    assert_eq!(harness.op_count(), 1);
+
+    let mut conflicts = Vec::new();
+
+    let mut changed = original.clone();
+    changed.meta.lamport = 2;
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let treecrdt_core::OperationKind::Insert { parent, .. } = &mut changed.kind {
+        *parent = node(2);
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let treecrdt_core::OperationKind::Insert { node, .. } = &mut changed.kind {
+        *node = self::node(2);
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let treecrdt_core::OperationKind::Insert { order_key, .. } = &mut changed.kind {
+        *order_key = order_key_from_position(1);
+    }
+    conflicts.push(changed);
+
+    let mut changed = original.clone();
+    if let treecrdt_core::OperationKind::Insert { payload, .. } = &mut changed.kind {
+        *payload = Some(Vec::new());
+    }
+    conflicts.push(changed);
+
+    conflicts.push(Operation::move_node(
+        &replica,
+        1,
+        1,
+        node(1),
+        NodeId::ROOT,
+        order_key_from_position(0),
+    ));
+
+    for conflict in conflicts {
+        assert!(harness.try_append_ops(&[conflict]).is_err());
+        assert_eq!(harness.op_count(), 1);
+    }
+
+    let mut known_state = treecrdt_core::VersionVector::new();
+    known_state.observe(&replica, 1);
+    let mut tombstone = Operation::tombstone(&replica, 2, 2, node(1));
+    tombstone.meta.known_state = Some(known_state);
+    harness.append_ops(std::slice::from_ref(&tombstone));
+    let mut changed_known_state = treecrdt_core::VersionVector::new();
+    changed_known_state.observe(&replica, 2);
+    let mut changed_tombstone = tombstone.clone();
+    changed_tombstone.meta.known_state = Some(changed_known_state);
+    assert!(harness.try_append_ops(&[changed_tombstone]).is_err());
+    let mut missing_known_state = tombstone;
+    missing_known_state.meta.known_state = None;
+    assert!(harness.try_append_ops(&[missing_known_state]).is_err());
+
+    let valid_prefix = Operation::insert(
+        &replica,
+        3,
+        3,
+        NodeId::ROOT,
+        node(4),
+        order_key_from_position(1),
+    );
+    let mut conflict = original;
+    conflict.meta.lamport = 4;
+    assert!(harness.try_append_ops(&[valid_prefix, conflict]).is_err());
+    assert_eq!(harness.op_count(), 2, "failed batch committed a prefix");
 }
 
 pub fn representative_remote_batch_matches_shape<H: MaterializationConformanceHarness>(

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -251,24 +251,14 @@ async function treecrdtAppendOp(
   return decodeSqliteMaterializationOutcome(await sqliteGetJson<unknown>(runner, sql, params));
 }
 
-function mergeMaterializationOutcomes(outcomes: MaterializationOutcome[]): MaterializationOutcome {
-  const last = outcomes.length > 0 ? outcomes[outcomes.length - 1] : undefined;
-  return {
-    headSeq: last?.headSeq ?? 0,
-    changes: outcomes.flatMap((outcome) => outcome.changes),
-  };
-}
-
 async function treecrdtAppendOps(
   runner: SqliteRunner,
   ops: Operation[],
   serializeNodeId: SerializeNodeId,
   serializeReplica: SerializeReplica,
-  opts: { maxBulkOps?: number } = {},
 ): Promise<MaterializationOutcome> {
   if (ops.length === 0) return emptyMaterializationOutcome();
 
-  const maxBulkOps = opts.maxBulkOps ?? 5_000;
   const bulkSql = 'SELECT treecrdt_append_ops(?1)';
 
   if (
@@ -279,29 +269,9 @@ async function treecrdtAppendOps(
     throw new Error('treecrdt: delete operations require meta.knownState');
   }
 
-  // Try bulk entrypoint first, chunked to avoid huge JSON payloads.
-  let bulkFailedAt: number | null = null;
-  const outcomes: MaterializationOutcome[] = [];
-  for (let start = 0; start < ops.length; start += maxBulkOps) {
-    const chunk = ops.slice(start, start + maxBulkOps);
-    const payload = buildAppendOpsPayload(chunk, serializeNodeId, serializeReplica);
-    try {
-      const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
-      outcomes.push(decodeSqliteMaterializationOutcome(raw));
-    } catch {
-      bulkFailedAt = start;
-      break;
-    }
-  }
-  if (bulkFailedAt === null) return mergeMaterializationOutcomes(outcomes);
-
-  const remaining = ops.slice(bulkFailedAt);
-  for (const op of remaining) {
-    const payload = buildAppendOpsPayload([op], serializeNodeId, serializeReplica);
-    const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
-    outcomes.push(decodeSqliteMaterializationOutcome(raw));
-  }
-  return mergeMaterializationOutcomes(outcomes);
+  const payload = buildAppendOpsPayload(ops, serializeNodeId, serializeReplica);
+  const raw = await sqliteGetJson<unknown>(runner, bulkSql, [JSON.stringify(payload)]);
+  return decodeSqliteMaterializationOutcome(raw);
 }
 
 async function treecrdtOpsSince(
@@ -319,7 +289,9 @@ async function treecrdtOpsSince(
 
 export function createTreecrdtSqliteAdapter(
   runner: SqliteRunner,
-  opts: { maxBulkOps?: number; onMaterialized?: (event: MaterializationEvent) => void } = {},
+  opts: {
+    onMaterialized?: (event: MaterializationEvent) => void;
+  } = {},
 ): TreecrdtAdapter {
   const emitOutcome = (outcome: MaterializationOutcome) => {
     if (outcome.changes.length === 0) return;
@@ -344,7 +316,7 @@ export function createTreecrdtSqliteAdapter(
     appendOp: (op, serializeNodeId, serializeReplica) =>
       treecrdtAppendOp(runner, op, serializeNodeId, serializeReplica),
     appendOps: (ops, serializeNodeId, serializeReplica) =>
-      treecrdtAppendOps(runner, ops, serializeNodeId, serializeReplica, opts),
+      treecrdtAppendOps(runner, ops, serializeNodeId, serializeReplica),
     opsSince: (lamport, root) => treecrdtOpsSince(runner, { lamport, root }),
   };
 }

--- a/packages/treecrdt-wa-sqlite/src/adapter.ts
+++ b/packages/treecrdt-wa-sqlite/src/adapter.ts
@@ -13,7 +13,9 @@ function createRunner(db: Database): SqliteRunner {
 
 export function createWaSqliteApi(
   db: Database,
-  opts: { maxBulkOps?: number; onMaterialized?: (event: MaterializationEvent) => void } = {},
+  opts: {
+    onMaterialized?: (event: MaterializationEvent) => void;
+  } = {},
 ): TreecrdtAdapter {
   return createTreecrdtSqliteAdapter(createRunner(db), opts);
 }

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -21,7 +21,6 @@ import {
 import type {
   LocalWriteOptions,
   MaterializationEvent,
-  MaterializationOutcome,
   WriteOptions,
 } from '@treecrdt/interface/engine';
 import {
@@ -61,8 +60,6 @@ import type {
 } from './types.js';
 
 export const CLIENT_CLOSED_ERROR = 'TreecrdtClient was closed';
-// Keep long browser appendMany calls from monopolizing the worker queue.
-const APPEND_MANY_RPC_CHUNK_SIZE = 2500;
 
 function normalizeStorageOptions(opts: ClientOptions): NormalizedStorageOptions {
   const raw = opts.storage ?? { type: 'auto' };
@@ -844,19 +841,8 @@ function makeTreecrdtClientFromCall(opts: {
   const replicaMaxCounterImpl = async (replica: Operation['meta']['id']['replica']) =>
     Number(await call('replicaMaxCounter', [Array.from(encodeReplica(replica))]));
   const appendManyImpl = async (operations: Operation[], writeOpts?: WriteOptions) => {
-    if (operations.length <= APPEND_MANY_RPC_CHUNK_SIZE) {
-      const outcome = await call('appendMany', [operations]);
-      materialized.emitOutcome(outcome, writeOpts?.writeId);
-      return;
-    }
-
-    const outcomes: MaterializationOutcome[] = [];
-    for (let start = 0; start < operations.length; start += APPEND_MANY_RPC_CHUNK_SIZE) {
-      outcomes.push(
-        await call('appendMany', [operations.slice(start, start + APPEND_MANY_RPC_CHUNK_SIZE)]),
-      );
-    }
-    materialized.emitOutcome(mergeMaterializationOutcomes(outcomes), writeOpts?.writeId);
+    const outcome = await call('appendMany', [operations]);
+    materialized.emitOutcome(outcome, writeOpts?.writeId);
   };
   const localInsertImpl = async (
     replica: ReplicaId,
@@ -961,12 +947,4 @@ function encodeReplica(replica: ReplicaId): Uint8Array {
 
 function toRpcBytes(bytes: Uint8Array | number[]): Uint8Array {
   return bytes instanceof Uint8Array ? bytes : Uint8Array.from(bytes);
-}
-
-function mergeMaterializationOutcomes(outcomes: MaterializationOutcome[]): MaterializationOutcome {
-  const last = outcomes[outcomes.length - 1];
-  return {
-    headSeq: last?.headSeq ?? 0,
-    changes: outcomes.flatMap((outcome) => outcome.changes),
-  };
 }

--- a/packages/treecrdt-wa-sqlite/tests/node-client.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/node-client.test.ts
@@ -4,7 +4,9 @@ import {
   runTreecrdtEngineConformanceScenario,
   treecrdtEngineConformanceScenarios,
 } from '@treecrdt/engine-conformance';
+import type { Operation } from '@treecrdt/interface';
 import { createTreecrdtClient } from '../dist/index.node.js';
+import { buildDirectClient } from '../dist/client.js';
 
 const root = '0'.repeat(32);
 const replica = Uint8Array.from({ length: 32 }, (_, i) => (i === 31 ? 1 : 0));
@@ -41,6 +43,42 @@ test('createTreecrdtClient accepts cross-realm typed array payloads in Node', as
   try {
     await client.local.payload(replica, root, payload);
     expect(await client.tree.getPayload(root)).toEqual(Uint8Array.from([1, 2, 3]));
+  } finally {
+    await client.close();
+  }
+});
+
+test('appendMany sends one atomic backend call beyond the former RPC chunk boundary', async () => {
+  const original: Operation = {
+    meta: { id: { replica, counter: 1 }, lamport: 1 },
+    kind: {
+      type: 'insert',
+      parent: root,
+      node: nodeIdFromInt(1),
+      orderKey: Uint8Array.from([0, 1]),
+    },
+  };
+  const calls: Operation[][] = [];
+  const client = await buildDirectClient(
+    { storage: 'memory', docId: 'wa-sqlite-node-atomic-call' },
+    async () => ({
+      storage: 'memory',
+      filename: ':memory:',
+      db: { close: async () => {} } as any,
+      api: {
+        appendOps: async (ops: Operation[]) => {
+          calls.push(ops);
+          throw new Error('simulated storage rejection');
+        },
+      } as any,
+    }),
+  );
+
+  try {
+    const batch = Array.from({ length: 2_501 }, () => original);
+    await expect(client.ops.appendMany(batch)).rejects.toThrow();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toHaveLength(batch.length);
   } finally {
     await client.close();
   }

--- a/packages/treecrdt-wasm-js/src/index.ts
+++ b/packages/treecrdt-wasm-js/src/index.ts
@@ -96,22 +96,18 @@ export async function createWasmAdapter(opts: LoadOptions = {}): Promise<Treecrd
         if (!op.meta.knownState || op.meta.knownState.length === 0) {
           throw new Error('treecrdt: delete operations require meta.knownState');
         }
-        jsOp.known_state = Array.from(op.meta.knownState);
       }
       tree.appendOp(JSON.stringify(jsOp));
       return emptyMaterializationOutcome();
     },
     appendOps: async (ops, serializeNodeId, serializeReplica) => {
-      for (const op of ops) {
-        const jsOp = toJsOp(op, serializeNodeId, serializeReplica);
-        if (op.kind.type === 'delete') {
-          if (!op.meta.knownState || op.meta.knownState.length === 0) {
-            throw new Error('treecrdt: delete operations require meta.knownState');
-          }
-          jsOp.known_state = Array.from(op.meta.knownState);
+      const jsOps = ops.map((op) => {
+        if (op.kind.type === 'delete' && (!op.meta.knownState || op.meta.knownState.length === 0)) {
+          throw new Error('treecrdt: delete operations require meta.knownState');
         }
-        tree.appendOp(JSON.stringify(jsOp));
-      }
+        return toJsOp(op, serializeNodeId, serializeReplica);
+      });
+      tree.appendOps(JSON.stringify(jsOps));
       return emptyMaterializationOutcome();
     },
     opsSince: async (lamport: number) => {
@@ -155,6 +151,7 @@ function toJsOp(
     replica: toHex(serializeReplica(op.meta.id.replica)),
     counter: op.meta.id.counter,
     lamport: op.meta.lamport,
+    ...(op.meta.knownState ? { known_state: Array.from(op.meta.knownState) } : {}),
   };
 
   switch (op.kind.type) {
@@ -165,6 +162,7 @@ function toJsOp(
         parent: normalizeNodeId(op.kind.parent),
         node: normalizeNodeId(op.kind.node),
         order_key: toHex(op.kind.orderKey),
+        ...(op.kind.payload !== undefined ? { payload: toHex(op.kind.payload) } : {}),
       };
     case 'move':
       return {

--- a/packages/treecrdt-wasm/src/lib.rs
+++ b/packages/treecrdt-wasm/src/lib.rs
@@ -119,8 +119,13 @@ fn js_to_op(js: JsOp) -> Result<Operation, String> {
     let replica = ReplicaId::new(replica_bytes);
     let counter = js.counter;
     let lamport = js.lamport;
+    let known_state: Option<treecrdt_core::VersionVector> = js
+        .known_state
+        .as_deref()
+        .map(|bytes| serde_json::from_slice(bytes).map_err(|e| e.to_string()))
+        .transpose()?;
 
-    let op = match js.kind.as_str() {
+    let mut op = match js.kind.as_str() {
         "insert" => {
             let parent = js.parent.as_deref().map(hex_to_node).transpose()?.unwrap_or(NodeId::ROOT);
             let node = hex_to_node(&js.node)?;
@@ -148,13 +153,9 @@ fn js_to_op(js: JsOp) -> Result<Operation, String> {
             )
         }
         "delete" => {
-            let Some(bytes) = js.known_state else {
+            let Some(vv) = known_state.clone() else {
                 return Err("delete op missing known_state".into());
             };
-            if bytes.is_empty() {
-                return Err("delete known_state must not be empty".into());
-            }
-            let vv = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
             Operation::delete(&replica, counter, lamport, hex_to_node(&js.node)?, Some(vv))
         }
         "tombstone" => Operation::tombstone(&replica, counter, lamport, hex_to_node(&js.node)?),
@@ -167,12 +168,42 @@ fn js_to_op(js: JsOp) -> Result<Operation, String> {
         ),
         _ => return Err("unknown kind".into()),
     };
+    op.meta.known_state = known_state;
     Ok(op)
 }
 
 #[wasm_bindgen]
 pub struct WasmTree {
     inner: TreeCrdt<MemoryStorage, LamportClock>,
+}
+
+fn apply_remote_batch(
+    tree: &mut TreeCrdt<MemoryStorage, LamportClock>,
+    ops: Vec<Operation>,
+) -> treecrdt_core::Result<()> {
+    let mut by_id: std::collections::HashMap<_, _> = tree
+        .operations_since(0)?
+        .into_iter()
+        .map(|op| (op.meta.id.clone(), op))
+        .collect();
+    for op in &ops {
+        op.validate()?;
+        if let Some(existing) = by_id.get(&op.meta.id) {
+            if existing != op {
+                return Err(treecrdt_core::Error::InvalidOperation(format!(
+                    "operation id {:?}:{} has conflicting contents",
+                    op.meta.id.replica.as_bytes(),
+                    op.meta.id.counter
+                )));
+            }
+        } else {
+            by_id.insert(op.meta.id.clone(), op.clone());
+        }
+    }
+    for op in ops {
+        tree.apply_remote(op)?;
+    }
+    Ok(())
 }
 
 #[wasm_bindgen]
@@ -193,6 +224,18 @@ impl WasmTree {
             serde_json::from_str(&op_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let op = js_to_op(js_op).map_err(|e| JsValue::from_str(&e))?;
         self.inner.apply_remote(op).map_err(|e| JsValue::from_str(&format!("{:?}", e)))
+    }
+
+    #[wasm_bindgen(js_name = appendOps)]
+    pub fn append_ops(&mut self, ops_json: String) -> Result<(), JsValue> {
+        let js_ops: Vec<JsOp> =
+            serde_json::from_str(&ops_json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let ops = js_ops
+            .into_iter()
+            .map(js_to_op)
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| JsValue::from_str(&e))?;
+        apply_remote_batch(&mut self.inner, ops).map_err(|e| JsValue::from_str(&format!("{:?}", e)))
     }
 
     #[wasm_bindgen(js_name = appendOpWithDelta)]
@@ -353,5 +396,31 @@ impl WasmTree {
         }
 
         to_value(&rows).map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_batch_rolls_back_before_equivocation() {
+        let replica = ReplicaId::new(b"remote");
+        let mut tree = TreeCrdt::new(
+            ReplicaId::new(b"local"),
+            MemoryStorage::default(),
+            LamportClock::default(),
+        )
+        .unwrap();
+        let original = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 1]);
+        tree.apply_remote(original.clone()).unwrap();
+
+        let prefix = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0, 2]);
+        let mut conflict = original;
+        conflict.meta.lamport = 3;
+        assert!(apply_remote_batch(&mut tree, vec![prefix, conflict]).is_err());
+
+        assert!(!tree.is_known(NodeId(2)).unwrap());
+        assert_eq!(tree.operations_since(0).unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
## Why

Different operations with the same (replica, counter) could be accepted by different peers. Because sync derives opRef from that ID, peers could report matching opRef sets while remaining permanently divergent.

## What changes

- Keep exact duplicates idempotent.
- Atomically reject reuse of an operation ID with any different operation content.
- Return conflicts before mutating TreeCRDT clock, version, or counter state.
- Compare complete stored operations across Memory, SQLite, PostgreSQL, and WASM.
- Make batch ingestion atomic so a later conflict cannot commit an earlier prefix.

This prevents silent divergence once both conflicting bodies reach a storage boundary. Detecting a withheld alternate body would require a future content-bound protocol.

## Stack

Merge order: #177 → #226 → #180 → #178 → #184 → #185.