### PR TITLE
fix: harden sibling order-key allocation

### DIFF
--- a/.changeset/harden-order-key-allocation.md
+++ b/.changeset/harden-order-key-allocation.md
@@ -1,0 +1,8 @@
+---
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+---
+
+Generate deterministic sibling order keys with seed entropy so concurrent local inserts no longer collapse into a tiny set of positions. Structural keys use one extensible encoding and are always strictly inside their requested bounds.
+
+Exact `After(node)` placement now fails when a following sibling has the same order key, because that position cannot be represented without rekeying. Moves to Trash retain their empty sentinel key.

--- a/packages/treecrdt-core/src/order_key.rs
+++ b/packages/treecrdt-core/src/order_key.rs
@@ -1,8 +1,13 @@
+//! Deterministic allocation of sibling ordering keys.
+//!
+//! Keys are non-empty sequences of big-endian `u16` digits. The final digit is non-zero, which
+//! keeps the valid key space dense under the bytewise ordering used by storage backends.
+
 use crate::error::{Error, Result};
 
-const ORDER_KEY_DOMAIN: &[u8] = b"treecrdt/order_key/v0";
+const ORDER_KEY_DOMAIN: &[u8] = b"treecrdt/order_key/v1";
 const DIGIT_BYTES: usize = 2;
-const DEFAULT_BOUNDARY: u16 = 10;
+const ENTROPY_DIGITS: usize = 4;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 
@@ -27,11 +32,7 @@ pub(crate) fn validate_order_key(key: &[u8]) -> Result<()> {
 }
 
 fn decode_digits(bytes: &[u8]) -> Result<Vec<u16>> {
-    if !bytes.len().is_multiple_of(DIGIT_BYTES) {
-        return Err(Error::InvalidOperation(
-            "order_key must have even length (u16 big-endian digits)".into(),
-        ));
-    }
+    validate_order_key(bytes)?;
     Ok(bytes
         .chunks_exact(DIGIT_BYTES)
         .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
@@ -40,101 +41,120 @@ fn decode_digits(bytes: &[u8]) -> Result<Vec<u16>> {
 
 fn encode_digits(digits: &[u16]) -> Vec<u8> {
     let mut out = Vec::with_capacity(digits.len() * DIGIT_BYTES);
-    for d in digits {
-        out.extend_from_slice(&d.to_be_bytes());
+    for digit in digits {
+        out.extend_from_slice(&digit.to_be_bytes());
     }
     out
 }
 
+fn hash_bytes(mut hash: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
 fn sample_u64(seed: &[u8], depth: usize) -> u64 {
-    let mut h = FNV_OFFSET_BASIS;
-    for b in ORDER_KEY_DOMAIN {
-        h ^= *b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    for b in &(seed.len() as u32).to_be_bytes() {
-        h ^= *b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    for b in seed {
-        h ^= *b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    for b in &(depth as u32).to_be_bytes() {
-        h ^= *b as u64;
-        h = h.wrapping_mul(FNV_PRIME);
-    }
-    h
+    let mut hash = hash_bytes(FNV_OFFSET_BASIS, ORDER_KEY_DOMAIN);
+    hash = hash_bytes(hash, &(seed.len() as u64).to_be_bytes());
+    hash = hash_bytes(hash, seed);
+    hash = hash_bytes(hash, &(depth as u64).to_be_bytes());
+
+    hash ^= hash >> 33;
+    hash = hash.wrapping_mul(0xff51afd7ed558ccd);
+    hash ^= hash >> 33;
+    hash = hash.wrapping_mul(0xc4ceb9fe1a85ec53);
+    hash ^ (hash >> 33)
 }
 
-fn choose_side(seed: &[u8], depth: usize) -> bool {
-    // true = choose near left, false = choose near right
-    (sample_u64(seed, depth) & 1) == 0
-}
-
-fn choose_in_range(seed: &[u8], depth: usize, lo: u16, hi: u16) -> u16 {
-    debug_assert!(lo <= hi);
-    if lo == hi {
-        return lo;
+fn append_entropy(digits: &mut Vec<u16>, seed: &[u8], depth: usize) {
+    let sample = sample_u64(seed, depth);
+    for index in 0..ENTROPY_DIGITS {
+        let shift = (ENTROPY_DIGITS - index - 1) * u16::BITS as usize;
+        let raw = ((sample >> shift) & u64::from(u16::MAX)) as u16;
+        digits.push(if index + 1 == ENTROPY_DIGITS {
+            (u32::from(raw) % u32::from(u16::MAX) + 1) as u16
+        } else {
+            raw
+        });
     }
-    let span = (hi - lo) as u32 + 1;
-    let n = (sample_u64(seed, depth) % (span as u64)) as u16;
-    lo + n
 }
 
-/// Allocate a stable ordering key strictly between `left` and `right` (lexicographic order).
+fn allocate_after(left: &[u16], seed: &[u8], depth: usize) -> Vec<u16> {
+    let mut out = left.to_vec();
+    append_entropy(&mut out, seed, depth + left.len());
+    out
+}
+
+fn allocate_before(right: &[u16], seed: &[u8], depth: usize) -> Vec<u16> {
+    let offset = right
+        .iter()
+        .position(|digit| *digit != 0)
+        .expect("validated key has a non-zero final digit");
+    let mut out = right[..offset].to_vec();
+    out.push(right[offset] / 2);
+    append_entropy(&mut out, seed, depth + offset + 1);
+    out
+}
+
+fn allocate_between_digits(left: &[u16], right: &[u16], seed: &[u8]) -> Vec<u16> {
+    let common = left.iter().zip(right).take_while(|(a, b)| a == b).count();
+
+    if common == left.len() {
+        let mut out = left.to_vec();
+        out.extend(allocate_before(&right[common..], seed, common));
+        return out;
+    }
+
+    let left_digit = left[common];
+    let right_digit = right[common];
+    let mut out = left[..common].to_vec();
+    if u32::from(right_digit) > u32::from(left_digit) + 1 {
+        out.push(((u32::from(left_digit) + u32::from(right_digit)) / 2) as u16);
+        append_entropy(&mut out, seed, common + 1);
+    } else {
+        out.push(left_digit);
+        out.extend(allocate_after(&left[common + 1..], seed, common + 1));
+    }
+    out
+}
+
+/// Allocate a deterministic key strictly between `left` and `right` in bytewise order.
 ///
-/// Keys are encoded as a variable-length sequence of big-endian `u16` digits, compared
-/// lexicographically. The generator is LSEQ-inspired: it prefers allocating within a bounded
-/// interval near one side to reduce expected key growth in repeated "insert between the same
-/// neighbors" workloads.
+/// `None` opens that side of the key space. Every provided bound must be a canonical structural
+/// key: non-empty, even-length, and ending in a non-zero `u16` digit.
 pub fn allocate_between(left: Option<&[u8]>, right: Option<&[u8]>, seed: &[u8]) -> Result<Vec<u8>> {
-    let left_digits = decode_digits(left.unwrap_or_default())?;
-    let right_digits = decode_digits(right.unwrap_or_default())?;
+    let left_digits = left.map(decode_digits).transpose()?;
+    let right_digits = right.map(decode_digits).transpose()?;
 
-    let mut out: Vec<u16> = Vec::new();
-    let mut depth: usize = 0;
-
-    loop {
-        let ld = left_digits.get(depth).copied().unwrap_or(0);
-        let rd = right_digits.get(depth).copied().unwrap_or(u16::MAX);
-        if rd < ld {
+    if let (Some(left), Some(right)) = (left, right) {
+        if left >= right {
             return Err(Error::InvalidOperation(
-                "cannot allocate order_key: right < left".into(),
+                "cannot allocate order_key: bounds must be in strictly increasing order".into(),
             ));
         }
-
-        if u32::from(rd) > u32::from(ld) + 1 {
-            let gap = rd - ld - 1;
-            let boundary = DEFAULT_BOUNDARY.min(gap);
-            let choose_left = choose_side(seed, depth);
-
-            let (lo, hi) = if gap > boundary {
-                if choose_left {
-                    (ld + 1, ld + boundary)
-                } else {
-                    (rd - boundary, rd - 1)
-                }
-            } else {
-                (ld + 1, rd - 1)
-            };
-
-            out.push(choose_in_range(seed, depth, lo, hi));
-            break;
-        }
-
-        // Once a concrete left digit is immediately below the upper digit, its remaining suffix
-        // can be extended without comparing it against the right key's suffix.
-        if rd > ld && depth < left_digits.len() {
-            out.extend_from_slice(&left_digits[depth..]);
-            out.push(choose_in_range(seed, left_digits.len(), 1, u16::MAX));
-            break;
-        }
-
-        // No room at this level; extend the prefix and continue deeper.
-        out.push(ld);
-        depth += 1;
     }
 
-    Ok(encode_digits(&out))
+    let digits = match (left_digits.as_deref(), right_digits.as_deref()) {
+        (None, None) => {
+            let mut out = Vec::with_capacity(ENTROPY_DIGITS);
+            append_entropy(&mut out, seed, 0);
+            out
+        }
+        (Some(left), None) => allocate_after(left, seed, 0),
+        (None, Some(right)) => allocate_before(right, seed, 0),
+        (Some(left), Some(right)) => allocate_between_digits(left, right, seed),
+    };
+
+    let encoded = encode_digits(&digits);
+    validate_order_key(&encoded)?;
+    if left.is_some_and(|bound| encoded.as_slice() <= bound)
+        || right.is_some_and(|bound| encoded.as_slice() >= bound)
+    {
+        return Err(Error::InvalidOperation(
+            "cannot allocate order_key strictly between bounds".into(),
+        ));
+    }
+    Ok(encoded)
 }

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -976,16 +976,33 @@ where
             let idx = children.iter().position(|c| *c == after).ok_or_else(|| {
                 Error::InvalidOperation("after node is not a child of parent".into())
             })?;
-            let left = self.nodes.order_key(after)?;
+            let left = self.nodes.order_key(after)?.ok_or_else(|| {
+                Error::InvalidOperation("after node is missing its structural order_key".into())
+            })?;
             let right = if idx + 1 < children.len() {
-                self.nodes.order_key(children[idx + 1])?
+                let next = self.nodes.order_key(children[idx + 1])?.ok_or_else(|| {
+                    Error::InvalidOperation(
+                        "next sibling is missing its structural order_key".into(),
+                    )
+                })?;
+                if next == left {
+                    return Err(Error::InvalidOperation(
+                        "cannot place directly after node: the next sibling has the same order_key"
+                            .into(),
+                    ));
+                }
+                Some(next)
             } else {
                 None
             };
-            (left, right)
+            (Some(left), right)
         } else {
             let right = if let Some(first) = children.first().copied() {
-                self.nodes.order_key(first)?
+                Some(self.nodes.order_key(first)?.ok_or_else(|| {
+                    Error::InvalidOperation(
+                        "first sibling is missing its structural order_key".into(),
+                    )
+                })?)
             } else {
                 None
             };

--- a/packages/treecrdt-core/tests/order_keys.rs
+++ b/packages/treecrdt-core/tests/order_keys.rs
@@ -1,0 +1,136 @@
+use std::collections::HashSet;
+
+use treecrdt_core::{
+    order_key::allocate_between, LamportClock, LocalPlacement, MemoryStorage, NodeId, Operation,
+    OperationKind, ReplicaId, TreeCrdt,
+};
+
+fn assert_canonical(key: &[u8]) {
+    assert!(!key.is_empty());
+    assert!(key.len().is_multiple_of(2));
+    assert_ne!(&key[key.len() - 2..], &[0, 0]);
+}
+
+#[test]
+fn generated_keys_have_high_seed_diversity() {
+    let mut initial_keys = HashSet::new();
+    let mut tight_interval_keys = HashSet::new();
+    for counter in 0..65_536_u64 {
+        let mut seed = b"replica-a".to_vec();
+        seed.extend_from_slice(&counter.to_be_bytes());
+
+        let initial = allocate_between(None, None, &seed).unwrap();
+        assert_canonical(&initial);
+        assert!(initial_keys.insert(initial));
+
+        let tight = allocate_between(Some(&[0, 1]), Some(&[0, 2]), &seed).unwrap();
+        assert_canonical(&tight);
+        assert!(tight_interval_keys.insert(tight));
+    }
+}
+
+#[test]
+fn allocator_requires_canonical_increasing_bounds() {
+    for (left, right, expected) in [
+        (Some([].as_slice()), None, "non-empty"),
+        (Some([1].as_slice()), None, "complete"),
+        (Some([0, 0].as_slice()), None, "non-zero"),
+        (
+            Some([0, 1].as_slice()),
+            Some([0, 1].as_slice()),
+            "strictly increasing",
+        ),
+        (
+            Some([0, 2].as_slice()),
+            Some([0, 1].as_slice()),
+            "strictly increasing",
+        ),
+    ] {
+        let error = allocate_between(left, right, b"seed").unwrap_err();
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error: {error}"
+        );
+    }
+}
+
+#[test]
+fn max_digit_is_allocatable() {
+    let max = [0xff, 0xff];
+    let after = allocate_between(Some(&max), None, b"seed").unwrap();
+    let before = allocate_between(Some(&[0xff, 0xfe]), Some(&max), b"seed").unwrap();
+
+    assert!(after.as_slice() > max.as_slice());
+    assert!(before.as_slice() > [0xff, 0xfe].as_slice());
+    assert!(before.as_slice() < max.as_slice());
+    assert_canonical(&after);
+    assert_canonical(&before);
+}
+
+#[test]
+fn repeated_exact_after_insertions_remain_strictly_ordered() {
+    let mut tree = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let anchor = NodeId(1);
+    let (anchor_op, _) =
+        tree.local_insert(NodeId::ROOT, anchor, LocalPlacement::First, None).unwrap();
+    let OperationKind::Insert {
+        order_key: anchor_key,
+        ..
+    } = anchor_op.kind
+    else {
+        unreachable!();
+    };
+
+    let mut keys = HashSet::from([anchor_key.clone()]);
+    for id in 2..=258 {
+        let node = NodeId(id);
+        let (op, _) = tree
+            .local_insert(NodeId::ROOT, node, LocalPlacement::After(anchor), None)
+            .unwrap();
+        let OperationKind::Insert { order_key, .. } = op.kind else {
+            unreachable!();
+        };
+        assert_canonical(&order_key);
+        assert!(order_key > anchor_key);
+        assert!(keys.insert(order_key));
+        assert_eq!(tree.children(NodeId::ROOT).unwrap()[..2], [anchor, node]);
+    }
+}
+
+#[test]
+fn equal_keys_use_node_tiebreak_and_exact_after_fails_closed() {
+    let mut tree = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let remote = ReplicaId::new(b"remote");
+    let first = NodeId(10);
+    let second = NodeId(20);
+    let key = vec![0x12, 0x34];
+
+    tree.apply_remote(Operation::insert(
+        &remote,
+        1,
+        1,
+        NodeId::ROOT,
+        second,
+        key.clone(),
+    ))
+    .unwrap();
+    tree.apply_remote(Operation::insert(&remote, 2, 2, NodeId::ROOT, first, key))
+        .unwrap();
+
+    assert_eq!(tree.children(NodeId::ROOT).unwrap(), &[first, second]);
+    let error = tree
+        .local_insert(NodeId::ROOT, NodeId(30), LocalPlacement::After(first), None)
+        .unwrap_err();
+    assert!(error.to_string().contains("same order_key"));
+    assert_eq!(tree.children(NodeId::ROOT).unwrap(), &[first, second]);
+}

--- a/packages/treecrdt-core/tests/property_tests.rs
+++ b/packages/treecrdt-core/tests/property_tests.rs
@@ -1,7 +1,55 @@
 use proptest::prelude::*;
-use treecrdt_core::{Lamport, LamportClock, MemoryStorage, NodeId, Operation, ReplicaId, TreeCrdt};
+use treecrdt_core::{
+    order_key::allocate_between, Lamport, LamportClock, MemoryStorage, NodeId, Operation,
+    ReplicaId, TreeCrdt,
+};
 
 proptest! {
+    #[test]
+    fn order_key_output_is_strictly_inside_valid_digit_bounds(
+        left in 1u16..=u16::MAX,
+        right in 1u16..=u16::MAX,
+        seed in prop::collection::vec(any::<u8>(), 0..64),
+    ) {
+        prop_assume!(left < right);
+        let left = left.to_be_bytes();
+        let right = right.to_be_bytes();
+        let key = allocate_between(Some(&left), Some(&right), &seed).unwrap();
+        prop_assert!(key.as_slice() > left.as_slice());
+        prop_assert!(key.as_slice() < right.as_slice());
+    }
+
+    #[test]
+    fn order_key_allocation_never_panics_and_is_deterministic(
+        left in prop::option::of(prop::collection::vec(any::<u8>(), 0..32)),
+        right in prop::option::of(prop::collection::vec(any::<u8>(), 0..32)),
+        seed in prop::collection::vec(any::<u8>(), 0..64),
+    ) {
+        let first = allocate_between(left.as_deref(), right.as_deref(), &seed);
+        let second = allocate_between(left.as_deref(), right.as_deref(), &seed);
+
+        match (first, second) {
+            (Ok(first), Ok(second)) => {
+                prop_assert_eq!(&first, &second);
+                prop_assert!(!first.is_empty());
+                prop_assert!(first.len().is_multiple_of(2));
+                let terminator = u16::from_be_bytes([
+                    first[first.len() - 2],
+                    first[first.len() - 1],
+                ]);
+                prop_assert_ne!(terminator, 0);
+                if let Some(left) = left.as_deref() {
+                    prop_assert!(first.as_slice() > left);
+                }
+                if let Some(right) = right.as_deref() {
+                    prop_assert!(first.as_slice() < right);
+                }
+            }
+            (Err(first), Err(second)) => prop_assert_eq!(first.to_string(), second.to_string()),
+            _ => prop_assert!(false, "same inputs returned different result variants"),
+        }
+    }
+
     #[test]
     fn permutations_converge_property(ops in {
         // Generate up to 5 operations with lamports 1..=5 over a small node set.

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -1000,7 +1000,12 @@ fn local_insert_after_is_deterministic_for_single_gap() {
             .unwrap();
     }
 
-    // after(A) between 1 and 3 => 2 (deterministic)
+    // after(A) uses the deterministic local-operation seed within the open interval (1, 3).
+    let seed = {
+        let mut seed = replica.clone();
+        seed.extend_from_slice(&3u64.to_be_bytes());
+        seed
+    };
     let json: String = conn
         .query_row(
             "SELECT treecrdt_local_insert(?1, ?2, ?3, 'after', ?4, NULL)",
@@ -1012,10 +1017,8 @@ fn local_insert_after_is_deterministic_for_single_gap() {
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "insert");
-    assert_eq!(
-        op.order_key.as_ref().unwrap(),
-        &(2u16).to_be_bytes().to_vec()
-    );
+    let expected = allocate_between(Some(&key_a), Some(&key_b), &seed).unwrap();
+    assert_eq!(op.order_key.as_ref().unwrap(), &expected);
 }
 
 #[test]
@@ -1036,6 +1039,11 @@ fn local_insert_last_is_deterministic_for_single_gap() {
         )
         .unwrap();
 
+    let seed = {
+        let mut seed = replica.clone();
+        seed.extend_from_slice(&2u64.to_be_bytes());
+        seed
+    };
     let json: String = conn
         .query_row(
             "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL)",
@@ -1047,10 +1055,8 @@ fn local_insert_last_is_deterministic_for_single_gap() {
     assert_eq!(ops.len(), 1);
     let op = &ops[0];
     assert_eq!(op.kind, "insert");
-    assert_eq!(
-        op.order_key.as_ref().unwrap(),
-        &(0xfffeu16).to_be_bytes().to_vec()
-    );
+    let expected = allocate_between(Some(&key_a), None, &seed).unwrap();
+    assert_eq!(op.order_key.as_ref().unwrap(), &expected);
 
     let parent_arr = <[u8; 16]>::try_from(parent.as_slice()).unwrap();
     let node_rows: Vec<Vec<u8>> = {


### PR DESCRIPTION
## Problem

Sibling positions use lexicographically ordered byte keys. The previous allocator conflated an open bound with an empty key, overflowed at `ffff`, and drew placement choices from too little seed entropy. Repeated or concurrent inserts could collapse onto a small set of positions or fail at valid boundaries.

#218 now defines and enforces the one canonical key format. This PR only allocates within that format.

## What changes

- Allocate deterministic keys with a seed-derived 64-bit suffix.
- Treat missing bounds as open ends, not persisted empty keys.
- Support valid `ffff` bounds without overflow.
- Verify the result is strictly between the requested bounds.
- Preserve deterministic `(orderKey, nodeId)` ordering when canonical sibling keys are equal.
- Fail closed for exact `After(anchor)` placement when the next sibling has the same key, because that slot cannot be represented without rekeying.

## Clean-slate choice

The allocator has no malformed-key fallback, old-format decoder, migration, or tree-wide rekey path. #218 rejects non-canonical operations at ingestion and replay, so this code accepts one bound format only.

Trash keeps its dedicated empty sentinel; ordinary keys never use it.

## Fast paths

- Allocation reads only the two neighboring in-memory keys.
- There is no database round trip, scan, repair replay, or migration.
- Open-ended prepend/append and ordinary between-neighbor cases allocate directly.
- Equal keys continue to converge through the existing node-ID tie-break.

## Size

Relative to #218: **6 files, +330/-87**.

The allocator itself is 160 lines, down from 246 in the previous PR revision. Splitting validation into #218 reduced #186 from 598 to 417 changed lines (30% less churn).

## Verification

- `cargo test --workspace`
- full core and SQLite extension-feature tests
- strict workspace Clippy
- arbitrary-byte determinism/canonical/bounds properties
- 65,536 distinct operation seeds at open and adjacent-digit intervals
- Rust formatting and diff checks

## Stack

Stacked on #218, which is stacked on #185.