### PR TITLE
fix(auth): fail closed on unsafe scoped op-log projection

### DIFF
--- a/.changeset/fail-closed-oplog-projection.md
+++ b/.changeset/fail-closed-oplog-projection.md
@@ -2,4 +2,4 @@
 '@treecrdt/auth': patch
 ---
 
-Require document-wide `read_structure` for reference COSE/CWT operation-log filters, and document-wide `read_payload` before projecting payload updates, clears, or payload-bearing inserts. This supersedes the current-materialized-membership filtering proposed in #183, which could reveal excluded destinations and private history after a node re-entered readable state.
+Require document-wide `read_structure` for reference COSE/CWT operation-log filters and document-wide `read_payload` for batches containing payload state. Unsafe scoped projections fail closed.

--- a/.changeset/fail-closed-oplog-projection.md
+++ b/.changeset/fail-closed-oplog-projection.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/auth': patch
+---
+
+Require document-wide `read_structure` for reference COSE/CWT operation-log filters, and document-wide `read_payload` before projecting payload updates, clears, or payload-bearing inserts. This supersedes the current-materialized-membership filtering proposed in #183, which could reveal excluded destinations and private history after a node re-entered readable state.

--- a/docs/sync/v0/auth.md
+++ b/docs/sync/v0/auth.md
@@ -246,17 +246,27 @@ presence tag, a relay cannot strip delete state to bypass this policy. Applicati
 
 ## Subtree reads and operation writes
 
-### Stateful subtree scopes remain available for reads
+### Reference operation-log reads require document-wide grants
 
-Read/filter authorization can evaluate the requested node against the receiver's current materialized ancestry. The
-reference evaluator uses a tri-state result:
+The reference COSE+CWT implementation authorizes `Filter.all` and `Filter.children(parent)` only with a document-wide
+`read_structure` grant: ROOT with no `max_depth` or `exclude`. The filter can still reduce synchronization work, but it
+does not reduce the authorization scope.
 
-- `allow`: the requested node is within scope
-- `deny`: the requested node is outside scope
-- `unknown`: the receiver lacks enough ancestry to decide
+Sync v0 filters reconcile historical operations, while a subtree evaluator sees only current materialized ancestry. If a
+node moves into an excluded subtree and later re-enters readable state, a current-state check would expose the historical
+move's excluded destination and payload updates authored during the private interval. The same ambiguity applies to
+boundary moves, defensive restoration, and superseded payload operations. Per-operation allow/deny flags cannot safely
+repair the projection: omitting a selected dependency changes the reconciled op set and can leave stale state.
 
-An `unknown` read decision fails closed. `filterOutgoingOps` also applies these scopes when projecting operations for an
-authorized filter.
+Until the protocol carries authenticated historical ancestry or redacted snapshot/removal records, the reference auth
+layer therefore rejects the entire operation-log projection for non-document-wide read scopes. It does not consult the
+stateful scope evaluator for this decision. Applications can still provide a custom `SyncAuth` implementation when their
+backend exposes a different, authenticated projection that is safe for scoped reads.
+
+Payload operations (including clears) and inserts with an inline payload additionally require a document-wide
+`read_payload` grant. Sync v0 cannot redact their payload state while preserving the selected operation, so a
+structure-only projection fails as a whole when it encounters one. Structure-only batches retain the direct fast path,
+as do batches whose peer has both document-wide read grants.
 
 ### Operation writes require a document-wide grant
 
@@ -270,7 +280,7 @@ permanent op-set divergence. Insert/move destination checks and defensive delete
 
 Until an operation carries an authenticated causal ancestry witness that every peer can verify, only a ROOT scope with no
 `max_depth` or `exclude` is state-independent enough to authorize writes. Non-document-wide write grants return `deny`
-immediately; they are not placed in `pending_context`. Existing subtree read/filter behavior is unchanged.
+immediately; they are not placed in `pending_context`.
 
 `pending_context` remains a protocol mechanism for custom auth schemes that have a stable, verifiable way to resolve
 missing context. It is not used to make mutable receiver ancestry authoritative for reference operation writes.

--- a/examples/playground/tests/playground.spec.ts
+++ b/examples/playground/tests/playground.spec.ts
@@ -242,36 +242,12 @@ async function waitForLocalAuthTokens(page: import("@playwright/test").Page) {
   await page.getByRole("button", { name: "Auth", exact: true }).click();
 }
 
-async function readReplicaPubkeyHex(page: import("@playwright/test").Page): Promise<string> {
-  const title = await page.getByTestId("self-pubkey").getAttribute("title");
-  const match = title?.match(/[0-9a-f]{64}/i);
-  if (!match) throw new Error(`expected replica pubkey in title: ${title ?? ""}`);
-  return match[0]!;
-}
-
 async function enableRevealIdentity(page: import("@playwright/test").Page) {
   await ensureAuthAdvancedOpen(page);
   const identityToggle = page.getByRole("button", { name: "Private", exact: true });
   await identityToggle.click();
   await expect(page.getByRole("button", { name: "Revealing", exact: true })).toBeVisible({ timeout: 30_000 });
   await page.getByRole("button", { name: "Auth", exact: true }).click();
-}
-
-async function readDeviceWrapKeyB64(page: import("@playwright/test").Page): Promise<string> {
-  const marker = page.getByText("Sharing & Auth", { exact: true });
-  const authWasOpen = (await marker.count()) > 0;
-  await ensureAuthAdvancedOpen(page);
-
-  const title = page.getByText("Device wrap key", { exact: true });
-
-  const card = title.locator("..").locator("..");
-  const mono = card.locator("div.font-mono").first();
-  await expect(mono).toHaveAttribute("title", /[A-Za-z0-9_-]{43}/, { timeout: 30_000 });
-  const wrapKey = await mono.getAttribute("title");
-
-  if (!authWasOpen) await page.getByRole("button", { name: "Auth", exact: true }).click();
-  if (!wrapKey) throw new Error("expected device wrap key");
-  return wrapKey;
 }
 
 function treeRowByNodeId(page: import("@playwright/test").Page, nodeId: string) {
@@ -794,170 +770,53 @@ test("defensive delete restores parent when unseen child arrives", async ({ brow
   }
 });
 
-test("grant by public key reveals a private subtree on resync", async ({ browser }) => {
-  test.setTimeout(240_000);
+test("scoped invite sync fails closed without revealing private data", async ({ browser }) => {
+  test.setTimeout(180_000);
 
-  const doc = uniqueDocId("pw-playground-grant");
-  const profile = `pw-grant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const doc = uniqueDocId("pw-playground-scoped-fail-closed");
+  const profile = `pw-scoped-fail-closed-${Date.now()}-${Math.random().toString(16).slice(2)}`;
   const context = await browser.newContext();
-  const pageA = await context.newPage();
-  const pageB = await context.newPage();
+  const owner = await context.newPage();
+  const guest = await context.newPage();
 
   try {
     await Promise.all([
-      waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`),
-      waitForReady(pageB, `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profile)}&join=1`),
+      waitForReady(owner, `/?doc=${encodeURIComponent(doc)}`),
+      waitForReady(
+        guest,
+        `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profile)}&join=1`
+      ),
     ]);
+    await expectAuthEnabledByDefault(owner);
 
-    await expectAuthEnabledByDefault(pageA);
+    await owner.getByPlaceholder("Stored as payload bytes").fill("public");
+    await treeRowByNodeId(owner, ROOT_ID).getByRole("button", { name: "Add child" }).click();
+    await expect(treeRowByLabel(owner, "public")).toBeVisible({ timeout: 30_000 });
 
-    // Create a public node and a private root on A.
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("public");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    await expect(treeRowByLabel(pageA, "public")).toBeVisible({ timeout: 30_000 });
+    await owner.getByPlaceholder("Stored as payload bytes").fill("private");
+    await treeRowByNodeId(owner, ROOT_ID).getByRole("button", { name: "Add child" }).click();
+    const privateRow = treeRowByLabel(owner, "private");
+    await expect(privateRow).toBeVisible({ timeout: 30_000 });
+    const privateNodeId = await privateRow.getAttribute("data-node-id");
+    if (!privateNodeId) throw new Error("expected private node id");
 
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("secret-placeholder");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const placeholderRowA = treeRowByLabel(pageA, "secret-placeholder");
-    await expect(placeholderRowA).toBeVisible({ timeout: 30_000 });
+    const privacyToggle = privateRow.getByRole("button", { name: "Toggle node privacy" });
+    await privacyToggle.click();
+    await expect(privacyToggle).toHaveAttribute("aria-pressed", "true");
 
-    const secretNodeId = await placeholderRowA.getAttribute("data-node-id");
-    if (!secretNodeId) throw new Error("expected secret node id");
-    const secretRowA = treeRowByNodeId(pageA, secretNodeId);
-    const privacyToggleA = secretRowA.getByRole("button", { name: "Toggle node privacy" });
-    await privacyToggleA.click();
-    await expect(privacyToggleA).toHaveAttribute("aria-pressed", "true");
+    const inviteLink = await shareSubtreeInvite(owner, ROOT_ID);
+    await joinViaInviteLink(guest, inviteLink);
 
-    // Invite B with private roots excluded (default behavior).
-    const inviteLink = await shareSubtreeInvite(pageA, ROOT_ID);
-    await joinViaInviteLink(pageB, inviteLink);
+    const ownerSync = owner.getByRole("button", { name: "Sync", exact: true });
+    await expect(ownerSync).toBeEnabled({ timeout: 30_000 });
+    await ownerSync.click();
+    await expect(owner.getByTestId("sync-error")).toContainText(
+      "capability does not allow operation-log projection",
+      { timeout: 30_000 }
+    );
 
-    // Wait for peer discovery and sync public ops.
-    await Promise.all([
-      expect(pageA.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-      expect(pageB.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-    ]);
-
-    const publicRowB = treeRowByLabel(pageB, "public");
-    const syncErrorA = pageA.getByTestId("sync-error");
-    const syncErrorB = pageB.getByTestId("sync-error");
-
-    await pageA.getByRole("button", { name: "Sync", exact: true }).click();
-    await Promise.race([
-      publicRowB.waitFor({ state: "visible", timeout: 30_000 }),
-      (async () => {
-        await syncErrorA.waitFor({ state: "visible", timeout: 30_000 });
-        throw new Error(`sync error (A): ${await syncErrorA.textContent()}`);
-      })(),
-      (async () => {
-        await syncErrorB.waitFor({ state: "visible", timeout: 30_000 });
-        throw new Error(`sync error (B): ${await syncErrorB.textContent()}`);
-      })(),
-    ]);
-
-    await expect(treeRowByNodeId(pageB, secretNodeId)).toHaveCount(0, { timeout: 30_000 });
-    await pageB.getByRole("button", { name: "Sync", exact: true }).click();
-
-    // Grant access to B's public key for the secret subtree.
-    const recipientPkHex = await readReplicaPubkeyHex(pageB);
-    await secretRowA.getByRole("button", { name: "Members and capabilities" }).click();
-    const peerRow = pageA
-      .getByText(recipientPkHex, { exact: true })
-      .first()
-      .locator("xpath=ancestor::div[.//button[normalize-space()='Share…']][1]");
-    await expect(peerRow).toBeVisible({ timeout: 30_000 });
-    const peerShareButton = peerRow.getByRole("button", { name: "Share…", exact: true }).first();
-    const peerGrantButton = peerShareButton.locator("xpath=preceding-sibling::button[1]");
-    await expect(peerGrantButton).toBeVisible({ timeout: 30_000 });
-    await expect(peerGrantButton).toBeEnabled({ timeout: 30_000 });
-    await peerGrantButton.evaluate((el) => (el as HTMLButtonElement).click());
-    await expect(peerRow.getByText("active")).toBeVisible({ timeout: 30_000 });
-
-    // Sync from B so it advertises the new token and pulls the newly authorized ops.
-    const secretRowB = treeRowByNodeId(pageB, secretNodeId);
-    let revealed = false;
-    for (let attempt = 0; attempt < 4; attempt++) {
-      await clickSyncWithRetryOnTransientAuthError(pageA, "A", { attempts: 3 });
-      await clickSyncWithRetryOnTransientAuthError(pageB, "B", { attempts: 3 });
-      if (await secretRowB.count()) {
-        await expect(secretRowB).toBeVisible({ timeout: 5_000 });
-        revealed = true;
-        break;
-      }
-      await pageB.waitForTimeout(250);
-    }
-    if (!revealed) await expect(secretRowB).toBeVisible({ timeout: 30_000 });
-  } finally {
-    await context.close();
-  }
-});
-
-test("both tabs can subscribe to a private subtree and receive child additions", async ({ browser }) => {
-  test.setTimeout(300_000);
-
-  const doc = uniqueDocId("pw-playground-private-live-subscribe");
-  const profileB = `pw-private-live-b-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const context = await browser.newContext();
-  const pageA = await context.newPage();
-  const pageB = await context.newPage();
-
-  try {
-    await Promise.all([
-      waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`),
-      waitForReady(pageB, `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profileB)}&join=1`),
-    ]);
-    await expectAuthEnabledByDefault(pageA);
-    await waitForLocalAuthTokens(pageA);
-
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("secret-live-root");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const secretRootRowA = treeRowByLabel(pageA, "secret-live-root");
-    await expect(secretRootRowA).toBeVisible({ timeout: 30_000 });
-    const secretNodeId = await secretRootRowA.getAttribute("data-node-id");
-    if (!secretNodeId) throw new Error("expected secret node id");
-
-    const privacyToggleA = treeRowByNodeId(pageA, secretNodeId).getByRole("button", { name: "Toggle node privacy" });
-    await privacyToggleA.click();
-    await expect(privacyToggleA).toHaveAttribute("aria-pressed", "true");
-
-    const inviteToB = await shareSubtreeInvite(pageA, secretNodeId);
-    await joinViaInviteLink(pageB, inviteToB);
-
-    await Promise.all([
-      expect(pageA.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-      expect(pageB.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-    ]);
-
-    const secretRootByIdA = treeRowByNodeId(pageA, secretNodeId);
-    const secretRootByIdB = treeRowByNodeId(pageB, secretNodeId);
-    for (let attempt = 0; attempt < 6; attempt++) {
-      await clickSyncWithRetryOnTransientAuthError(pageB, "B");
-      await clickSyncWithRetryOnTransientAuthError(pageA, "A");
-      if (await secretRootByIdB.count()) break;
-      await pageB.waitForTimeout(250);
-    }
-    await expect(secretRootByIdB).toBeVisible({ timeout: 30_000 });
-
-    await Promise.all([expandIfCollapsed(secretRootByIdA), expandIfCollapsed(secretRootByIdB)]);
-
-    const liveA = secretRootByIdA.getByRole("button", { name: "Live sync children" });
-    const liveB = secretRootByIdB.getByRole("button", { name: "Live sync children" });
-    await liveA.click();
-    await liveB.click();
-    await expect(liveA).toHaveAttribute("aria-pressed", "true");
-    await expect(liveB).toHaveAttribute("aria-pressed", "true");
-
-    await expect(pageA.getByTestId("sync-error")).toBeHidden({ timeout: 30_000 });
-    await expect(pageB.getByTestId("sync-error")).toBeHidden({ timeout: 30_000 });
-
-    const fromA = `live-from-A-${Date.now()}`;
-    await pageA.getByPlaceholder("Stored as payload bytes").fill(fromA);
-    await secretRootByIdA.getByRole("button", { name: "Add child" }).click();
-    await expect(treeRowByLabel(pageA, fromA)).toBeVisible({ timeout: 30_000 });
-    await expect(treeRowByLabel(pageB, fromA)).toBeVisible({ timeout: 60_000 });
-
-    await expect(pageA.getByTestId("sync-error")).toBeHidden();
-    await expect(pageB.getByTestId("sync-error")).toBeHidden();
+    await expect(treeRowByLabel(guest, "public")).toHaveCount(0);
+    await expect(treeRowByNodeId(guest, privateNodeId)).toHaveCount(0);
   } finally {
     await context.close();
   }
@@ -1075,99 +934,6 @@ test("identity key blobs can be exported and imported", async ({ browser }) => {
   }
 });
 
-test("isolated peer tab uses separate storage namespace and requires invite", async ({ browser }) => {
-  test.setTimeout(240_000);
-
-  const doc = uniqueDocId("pw-playground-isolated");
-  const profile = `pw-iso-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const context = await browser.newContext();
-  const pageA = await context.newPage();
-  const pageB = await context.newPage();
-
-  try {
-    await Promise.all([
-      waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`),
-      waitForReady(pageB, `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profile)}&join=1`),
-    ]);
-
-    await expectAuthEnabledByDefault(pageA);
-
-    const wrapKeyA = await readDeviceWrapKeyB64(pageA);
-    const wrapKeyB = await readDeviceWrapKeyB64(pageB);
-    expect(wrapKeyB).not.toBe(wrapKeyA);
-
-    // Create a public node and a private root on A.
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("public");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    await expect(treeRowByLabel(pageA, "public")).toBeVisible({ timeout: 30_000 });
-
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("secret-placeholder");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const placeholderRowA = treeRowByLabel(pageA, "secret-placeholder");
-    await expect(placeholderRowA).toBeVisible({ timeout: 30_000 });
-
-    const secretNodeId = await placeholderRowA.getAttribute("data-node-id");
-    if (!secretNodeId) throw new Error("expected secret node id");
-    const secretRowA = treeRowByNodeId(pageA, secretNodeId);
-    const privacyToggleA = secretRowA.getByRole("button", { name: "Toggle node privacy" });
-    await privacyToggleA.click();
-    await expect(privacyToggleA).toHaveAttribute("aria-pressed", "true");
-
-    // Generate invite link on A.
-    const inviteLink = await shareSubtreeInvite(pageA, ROOT_ID);
-    await joinViaInviteLink(pageB, inviteLink);
-
-    // Wait for peer discovery (Sync button enabled).
-    await Promise.all([
-      expect(pageA.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-      expect(pageB.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-    ]);
-
-    // Push ops from A to B.
-    const publicRowBLabel = treeRowByLabel(pageB, "public");
-    const syncErrorA = pageA.getByTestId("sync-error");
-    const syncErrorB = pageB.getByTestId("sync-error");
-
-    const waitForPublicOrError = async () => {
-      await Promise.race([
-        publicRowBLabel.waitFor({ state: "visible", timeout: 30_000 }),
-        (async () => {
-          await syncErrorA.waitFor({ state: "visible", timeout: 30_000 });
-          throw new Error(`sync error (A): ${await syncErrorA.textContent()}`);
-        })(),
-        (async () => {
-          await syncErrorB.waitFor({ state: "visible", timeout: 30_000 });
-          throw new Error(`sync error (B): ${await syncErrorB.textContent()}`);
-        })(),
-      ]);
-    };
-
-    let pushed = false;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      await pageA.getByRole("button", { name: "Sync", exact: true }).click();
-      try {
-        await waitForPublicOrError();
-        pushed = true;
-        break;
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        const initializing = msg.includes("initializing keys/tokens");
-        if (msg.startsWith("sync error") && !initializing) throw err;
-        if (attempt < 2) {
-          await pageA.waitForTimeout(250);
-          continue;
-        }
-        throw err;
-      }
-    }
-    if (!pushed) throw new Error("failed to sync public node");
-
-    await expect(treeRowByNodeId(pageB, secretNodeId)).toHaveCount(0, { timeout: 30_000 });
-  } finally {
-    await context.close();
-  }
-});
-
 test("new device can sync historical authors learned by the inviter", async ({ browser }) => {
   test.setTimeout(240_000);
 
@@ -1227,210 +993,6 @@ test("new device can sync historical authors learned by the inviter", async ({ b
     }
 
     await expect(treeRowByLabel(pageC, historicalLabel)).toBeVisible({ timeout: 30_000 });
-  } finally {
-    await context.close();
-  }
-});
-
-test("open device auto-syncs so the scoped root label is visible", async ({ browser }) => {
-  test.setTimeout(240_000);
-
-  const doc = uniqueDocId("pw-playground-open-device");
-  const context = await browser.newContext();
-  const pageA = await context.newPage();
-
-  try {
-    await waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`);
-    await expectAuthEnabledByDefault(pageA);
-    await waitForLocalAuthTokens(pageA);
-
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("AASD");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const rowA = treeRowByLabel(pageA, "AASD");
-    await expect(rowA).toBeVisible({ timeout: 30_000 });
-
-    const nodeId = await rowA.getAttribute("data-node-id");
-    if (!nodeId) throw new Error("expected node id");
-
-    await treeRowByNodeId(pageA, nodeId).getByRole("button", { name: "Share subtree (invite)" }).click();
-    const textarea = pageA.getByPlaceholder("Invite link will appear here…");
-    await expect(textarea).toHaveValue(/invite=/, { timeout: 30_000 });
-
-    const [pageB] = await Promise.all([
-      pageA.waitForEvent("popup"),
-      pageA.getByRole("button", { name: "Open device", exact: true }).click(),
-    ]);
-
-    await pageB.bringToFront();
-    await expect(pageB.getByText("Ready (memory)")).toBeVisible({ timeout: 60_000 });
-
-    const rowB = treeRowByNodeId(pageB, nodeId);
-    await expect(rowB.getByRole("button", { name: "AASD" })).toBeVisible({ timeout: 60_000 });
-  } finally {
-    await context.close();
-  }
-});
-
-test("open device sees latest scoped-root label after rename", async ({ browser }) => {
-  test.setTimeout(240_000);
-
-  const doc = uniqueDocId("pw-playground-open-device-rename");
-  const context = await browser.newContext();
-  const pageA = await context.newPage();
-
-  try {
-    await waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`);
-    await expectAuthEnabledByDefault(pageA);
-    await waitForLocalAuthTokens(pageA);
-
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("OLD-LABEL");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const scopedRowA = treeRowByLabel(pageA, "OLD-LABEL");
-    await expect(scopedRowA).toBeVisible({ timeout: 30_000 });
-
-    const scopedNodeId = await scopedRowA.getAttribute("data-node-id");
-    if (!scopedNodeId) throw new Error("expected scoped node id");
-    const scopedByIdA = treeRowByNodeId(pageA, scopedNodeId);
-
-    const privacyToggleA = scopedByIdA.getByRole("button", { name: "Toggle node privacy" });
-    await privacyToggleA.click();
-    await expect(privacyToggleA).toHaveAttribute("aria-pressed", "true");
-
-    // Rename and immediately share via Open device. Share controls should wait until local write settles.
-    await scopedByIdA.getByRole("button", { name: "OLD-LABEL", exact: true }).click();
-    await scopedByIdA.getByRole("textbox").fill("NEW-LABEL");
-    await scopedByIdA.getByRole("button", { name: "Save", exact: true }).click();
-
-    await scopedByIdA.getByRole("button", { name: "Share subtree (invite)" }).click();
-    const textarea = pageA.getByPlaceholder("Invite link will appear here…");
-    await expect(textarea).toHaveValue(/invite=/, { timeout: 30_000 });
-
-    const [pageB] = await Promise.all([
-      pageA.waitForEvent("popup"),
-      pageA.getByRole("button", { name: "Open device", exact: true }).click(),
-    ]);
-
-    await pageB.bringToFront();
-    await expect(pageB.getByText("Ready (memory)")).toBeVisible({ timeout: 60_000 });
-
-    const scopedByIdB = treeRowByNodeId(pageB, scopedNodeId);
-    await expect(scopedByIdB.getByRole("button", { name: "NEW-LABEL", exact: true })).toBeVisible({
-      timeout: 60_000,
-    });
-  } finally {
-    await context.close();
-  }
-});
-
-test("delegated invite can be reshared (A → B → C) and scoped writes propagate", async ({ browser }) => {
-  test.setTimeout(300_000);
-
-  const doc = uniqueDocId("pw-playground-delegated");
-  const profileB = `pw-deleg-b-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  const profileC = `pw-deleg-c-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-
-  const context = await browser.newContext();
-  const pageA = await context.newPage();
-  const pageB = await context.newPage();
-  const pageC = await context.newPage();
-
-  try {
-    await Promise.all([
-      waitForReady(pageA, `/?doc=${encodeURIComponent(doc)}`),
-      waitForReady(pageB, `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profileB)}&join=1`),
-      waitForReady(pageC, `/?doc=${encodeURIComponent(doc)}&profile=${encodeURIComponent(profileC)}&join=1`),
-    ]);
-
-    await expectAuthEnabledByDefault(pageA);
-    await waitForLocalAuthTokens(pageA);
-
-    // Create public + private subtree root on A.
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("public");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    await expect(treeRowByLabel(pageA, "public")).toBeVisible({ timeout: 30_000 });
-
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("secret-root");
-    await treeRowByNodeId(pageA, ROOT_ID).getByRole("button", { name: "Add child" }).click();
-    const secretRootRowA = treeRowByLabel(pageA, "secret-root");
-    await expect(secretRootRowA).toBeVisible({ timeout: 30_000 });
-
-    const secretNodeId = await secretRootRowA.getAttribute("data-node-id");
-    if (!secretNodeId) throw new Error("expected secret node id");
-
-    const privacyToggleA = treeRowByNodeId(pageA, secretNodeId).getByRole("button", { name: "Toggle node privacy" });
-    await privacyToggleA.click();
-    await expect(privacyToggleA).toHaveAttribute("aria-pressed", "true");
-
-    // A shares the secret subtree to B (invite includes grant so B can reshare).
-    const inviteToB = await shareSubtreeInvite(pageA, secretNodeId);
-
-    await joinViaInviteLink(pageB, inviteToB);
-
-    await Promise.all([
-      expect(pageA.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-      expect(pageB.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-    ]);
-
-    // B should be able to pull the scoped root payload by syncing its own `children(scopeRoot)` filter.
-    await clickSync(pageB, "B");
-    await expect(treeRowByLabel(pageB, "secret-root")).toBeVisible({ timeout: 30_000 });
-
-    const secretRootRowB = treeRowByNodeId(pageB, secretNodeId);
-    await expect(secretRootRowB.getByText("scoped access", { exact: true })).toBeVisible({ timeout: 30_000 });
-    await expect(secretRootRowB.getByText("private root", { exact: true })).toBeVisible({ timeout: 30_000 });
-
-    const secretRootRowC = treeRowByNodeId(pageC, secretNodeId);
-    // B reshared invite to C (delegated). Re-issue once if C can't verify/import on first attempt.
-    let inviteToC = await shareSubtreeInvite(pageB, secretNodeId);
-    let cRevealed = false;
-    for (let inviteAttempt = 0; inviteAttempt < 2 && !cRevealed; inviteAttempt++) {
-      if (inviteAttempt > 0) inviteToC = await shareSubtreeInvite(pageB, secretNodeId);
-      try {
-        await joinViaInviteLink(pageC, inviteToC);
-        await Promise.all([
-          expect(pageA.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-          expect(pageC.getByRole("button", { name: "Sync", exact: true })).toBeEnabled({ timeout: 30_000 }),
-        ]);
-
-        for (let syncAttempt = 0; syncAttempt < 18; syncAttempt++) {
-          await clickSyncWithRetryOnTransientAuthError(pageA, "A");
-          await clickSyncWithRetryOnTransientAuthError(pageB, "B");
-          await clickSyncWithRetryOnTransientAuthError(pageC, "C");
-          if (await secretRootRowC.count()) {
-            cRevealed = true;
-            break;
-          }
-          await pageC.waitForTimeout(300);
-        }
-      } catch {
-        // Fall through and retry with a fresh delegated invite.
-      }
-    }
-    expect(cRevealed).toBe(true);
-    await expect(secretRootRowC).toBeVisible({ timeout: 30_000 });
-    await expect(secretRootRowC.getByText("scoped access", { exact: true })).toBeVisible({ timeout: 30_000 });
-    await expect(secretRootRowC.getByText("private root", { exact: true })).toBeVisible({ timeout: 30_000 });
-
-    // A writes under the secret subtree; B and C should receive it.
-    const secretRowAById = treeRowByNodeId(pageA, secretNodeId);
-    await expandIfCollapsed(secretRowAById);
-    await pageA.getByPlaceholder("Stored as payload bytes").fill("from-A");
-    await secretRowAById.getByRole("button", { name: "Add child" }).click();
-    await expect(treeRowByLabel(pageA, "from-A")).toBeVisible({ timeout: 30_000 });
-
-    const fromARowB = treeRowByLabel(pageB, "from-A");
-    const fromARowC = treeRowByLabel(pageC, "from-A");
-    for (let attempt = 0; attempt < 12; attempt++) {
-      await clickSyncWithRetryOnTransientAuthError(pageA, "A");
-      if ((await fromARowB.isVisible()) && (await fromARowC.isVisible())) break;
-      await clickSyncWithRetryOnTransientAuthError(pageB, "B");
-      await clickSyncWithRetryOnTransientAuthError(pageC, "C");
-      if ((await fromARowB.isVisible()) && (await fromARowC.isVisible())) break;
-      await pageA.waitForTimeout(250);
-    }
-    await expect(fromARowB).toBeVisible({ timeout: 30_000 });
-    await expect(fromARowC).toBeVisible({ timeout: 30_000 });
-
   } finally {
     await context.close();
   }

--- a/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
+++ b/packages/treecrdt-auth/src/internal/cose-cwt-auth.ts
@@ -49,12 +49,9 @@ import { signTreecrdtOp, verifyTreecrdtOp } from './op-sig.js';
 import { getField } from './claims.js';
 import {
   capAllowsNode,
-  capsAllowsNodeAccess,
   capsAllowsOp,
   isDocWideScope,
   parseScope,
-  triOr,
-  type ScopeTri,
   type TreecrdtScopeEvaluator,
 } from './scope.js';
 
@@ -456,6 +453,47 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
     throw new Error('capability does not allow op');
   };
 
+  const grantsAllowDocWideRead = async (
+    grants: readonly CapabilityGrant[],
+    docId: string,
+    requiredActions: readonly string[],
+  ): Promise<boolean> => {
+    for (const grant of grants) {
+      for (const cap of grant.caps) {
+        const res = getField(cap, 'res');
+        if (!res || typeof res !== 'object') continue;
+        if (getField(res, 'doc_id') !== docId) continue;
+        if (!isDocWideScope(parseScope(res))) continue;
+
+        const tri = await capAllowsNode({
+          cap,
+          docId,
+          node: nodeIdToBytes16(ROOT_NODE_ID_HEX),
+          requiredActions,
+        });
+        if (tri === 'allow') return true;
+      }
+    }
+    return false;
+  };
+
+  const containsPayloadState = (op: Operation): boolean => {
+    switch (op.kind.type) {
+      case 'insert':
+        return op.kind.payload !== undefined;
+      case 'payload':
+        return true;
+      case 'move':
+      case 'delete':
+      case 'tombstone':
+        return false;
+      default: {
+        const _exhaustive: never = op.kind;
+        throw new Error(`unknown op kind: ${String((_exhaustive as any)?.type)}`);
+      }
+    }
+  };
+
   return {
     helloCapabilities: async (ctx) => helloCaps(ctx.docId),
     onHello: async (hello: Hello, ctx) => {
@@ -475,59 +513,14 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
       const grants = await parsePeerCapabilityGrants(tokenCaps, ctx.docId);
       if (grants.length === 0) throw new Error(`no trusted "${AUTH_CAPABILITY_NAME}" token`);
 
-      const requiredActions = ['read_structure'];
-      const node =
-        'all' in filter
-          ? nodeIdToBytes16(ROOT_NODE_ID_HEX)
-          : 'children' in filter
-            ? filter.children.parent
-            : (() => {
-                throw new Error('unsupported filter');
-              })();
+      if (!('all' in filter) && !('children' in filter)) throw new Error('unsupported filter');
 
-      // `filter(all)` is only safe for doc-wide scopes. If a token has any scope restrictions
-      // (e.g. `max_depth`/`exclude` or a non-root `root`), allow it to use `children(parent)` instead.
-      if ('all' in filter) {
-        for (const grant of grants) {
-          for (const cap of grant.caps) {
-            const res = getField(cap, 'res');
-            if (!res || typeof res !== 'object') continue;
-            if (getField(res, 'doc_id') !== ctx.docId) continue;
-
-            const scope = parseScope(res);
-            if (!isDocWideScope(scope)) continue;
-
-            const tri = await capAllowsNode({
-              cap,
-              docId: ctx.docId,
-              node,
-              requiredActions,
-              scopeEvaluator: opts.scopeEvaluator,
-            });
-            if (tri === 'allow') return;
-          }
-        }
-        throw new Error('capability does not allow filter');
-      }
-
-      let best: ScopeTri = 'deny';
-      for (const grant of grants) {
-        best = triOr(
-          best,
-          await capsAllowsNodeAccess({
-            caps: grant.caps,
-            docId: ctx.docId,
-            node,
-            requiredActions,
-            scopeEvaluator: opts.scopeEvaluator,
-          }),
-        );
-        if (best === 'allow') return;
-      }
-
-      if (best === 'unknown') {
-        throw new Error('missing subtree context to authorize filter');
-      }
+      // The current wire format reconciles historical operations. Current materialized ancestry
+      // cannot prove where an operation's node lived when that operation was authored: a node may
+      // leave an excluded subtree and later re-enter readable state. Until filtered reads carry an
+      // authenticated historical ancestry witness or use redacted snapshot records, every
+      // operation-log filter requires state-independent, document-wide structure access.
+      if (await grantsAllowDocWideRead(grants, ctx.docId, ['read_structure'])) return;
       throw new Error('capability does not allow filter');
     },
     filterOutgoingOps: async (ops, ctx) => {
@@ -537,70 +530,21 @@ export function createTreecrdtCoseCwtAuth(opts: TreecrdtCoseCwtAuthOptions): Syn
       const grants = await parsePeerCapabilityGrants(tokenCaps, ctx.docId);
       if (grants.length === 0) return ops.map(() => false);
 
-      // Fast path: if the peer has any doc-wide read_structure capability, we don't need to filter.
-      const requiredStructure = ['read_structure'];
-      for (const grant of grants) {
-        for (const cap of grant.caps) {
-          const res = getField(cap, 'res');
-          if (!res || typeof res !== 'object') continue;
-          if (getField(res, 'doc_id') !== ctx.docId) continue;
-
-          const scope = parseScope(res);
-          if (!isDocWideScope(scope)) continue;
-
-          const tri = await capAllowsNode({
-            cap,
-            docId: ctx.docId,
-            node: nodeIdToBytes16(ROOT_NODE_ID_HEX),
-            requiredActions: requiredStructure,
-            scopeEvaluator: opts.scopeEvaluator,
-          });
-          if (tri === 'allow') return ops.map(() => true);
-        }
+      if (!(await grantsAllowDocWideRead(grants, ctx.docId, ['read_structure']))) {
+        throw new Error('capability does not allow operation-log projection');
       }
 
-      const allowNode = async (
-        node: Uint8Array,
-        requiredActions: readonly string[],
-      ): Promise<boolean> => {
-        let best: ScopeTri = 'deny';
-        for (const grant of grants) {
-          best = triOr(
-            best,
-            await capsAllowsNodeAccess({
-              caps: grant.caps,
-              docId: ctx.docId,
-              node,
-              requiredActions,
-              scopeEvaluator: opts.scopeEvaluator,
-            }),
-          );
-          if (best === 'allow') return true;
-        }
-        // Fail closed: if scope membership is unknown, do not reveal the op.
-        return false;
-      };
-
-      const out: boolean[] = [];
-      for (const op of ops) {
-        // For `children(parent)` we still need to hide ops for nodes outside scope
-        // (e.g. excluded private roots) so peers cannot discover them by syncing the parent's children.
-        switch (op.kind.type) {
-          case 'insert':
-          case 'payload':
-          case 'move':
-          case 'delete':
-          case 'tombstone':
-            out.push(await allowNode(nodeIdToBytes16(op.kind.node), requiredStructure));
-            break;
-          default: {
-            const _exhaustive: never = op.kind;
-            throw new Error(`unknown op kind: ${String((_exhaustive as any)?.type)}`);
-          }
-        }
+      // Payload updates (including clears) and payload-bearing inserts cannot be omitted without
+      // changing the selected op set and cannot be redacted in Sync v0. Reject the entire
+      // projection unless payload state is also readable document-wide.
+      if (
+        ops.some(containsPayloadState) &&
+        !(await grantsAllowDocWideRead(grants, ctx.docId, ['read_payload']))
+      ) {
+        throw new Error('operation-log projection requires read_payload for payload state');
       }
 
-      return out;
+      return ops.map(() => true);
     },
     signOps: async (ops, ctx) => {
       await ensureLocalTokensRecorded(ctx.docId);

--- a/packages/treecrdt-auth/tests/auth.test.ts
+++ b/packages/treecrdt-auth/tests/auth.test.ts
@@ -818,7 +818,7 @@ test('auth: replayed author capability tokens do not widen peer filter scope', a
       filter: { all: {} },
       capabilities: scopedPeerCaps,
     }),
-  ).resolves.toEqual([true, false]);
+  ).rejects.toThrow(/does not allow operation-log projection/i);
 });
 
 test('auth: cached stale local tokens cannot authorize new local writes after an access downgrade', async () => {
@@ -1456,8 +1456,8 @@ test('auth: syncOnce accepts doc-wide read_structure capability for filter(all)'
   }
 });
 
-test('auth: syncOnce accepts filter(children) when capability scope matches the parent', async () => {
-  const docId = 'doc-auth-filter-allow-children';
+test('auth: reference COSE/CWT rejects scoped filter(children)', async () => {
+  const docId = 'doc-auth-filter-reject-scoped-children';
   const root = '0'.repeat(32);
 
   const a = new MemoryBackend(docId);
@@ -1482,7 +1482,9 @@ test('auth: syncOnce accepts filter(children) when capability scope matches the 
     rootNodeId: parent,
   });
 
+  let scopeEvaluations = 0;
   const scopeEvaluator = ({ node, scope }: { node: Uint8Array; scope: { root: Uint8Array } }) => {
+    scopeEvaluations += 1;
     const nodeHex = bytesToHex(node);
     const rootHex = bytesToHex(scope.root);
     return nodeHex === rootHex ? 'allow' : 'deny';
@@ -1517,11 +1519,14 @@ test('auth: syncOnce accepts filter(children) when capability scope matches the 
   });
 
   try {
-    await pa.syncOnce(
-      ta,
-      { children: { parent: nodeIdToBytes16(parent) } },
-      { maxCodewords: 1_000, codewordsPerMessage: 64 },
-    );
+    await expect(
+      pa.syncOnce(
+        ta,
+        { children: { parent: nodeIdToBytes16(parent) } },
+        { maxCodewords: 1_000, codewordsPerMessage: 64 },
+      ),
+    ).rejects.toThrow(/UNAUTHORIZED.*capability does not allow filter/i);
+    expect(scopeEvaluations).toBe(0);
   } finally {
     detach();
   }
@@ -1603,7 +1608,7 @@ test('auth: syncOnce rejects filter(children) when capability scope does not mat
   void bPk;
 });
 
-test('auth: filterOutgoingOps hides move/delete/tombstone for excluded subtrees', async () => {
+test('auth: scoped projections cannot reveal excluded destinations or private history after re-entry', async () => {
   const docId = 'doc-auth-filter-outgoing-exclude';
   const root = '0'.repeat(32);
 
@@ -1618,62 +1623,25 @@ test('auth: filterOutgoingOps hides move/delete/tombstone for excluded subtrees'
 
   const publicNode = nodeIdFromInt(1);
   const privateRoot = nodeIdFromInt(2);
-  const privateChild = nodeIdFromInt(3);
-  const privateSibling = nodeIdFromInt(4);
-
-  const parentByNodeHex = new Map<string, string | null>([
-    [root, null],
-    [publicNode, root],
-    [privateRoot, root],
-    // Current tree state (after the move below): child is under sibling, both under privateRoot.
-    [privateSibling, privateRoot],
-    [privateChild, privateSibling],
-  ]);
+  let scopeEvaluations = 0;
 
   const scopeEvaluator = ({
     node,
-    scope,
   }: {
     node: Uint8Array;
     scope: { root: Uint8Array; maxDepth?: number; exclude?: Uint8Array[] };
   }) => {
-    const rootHex = bytesToHex(scope.root);
-    const excludeHex = new Set((scope.exclude ?? []).map((b) => bytesToHex(b)));
-    const maxDepth = scope.maxDepth;
-
-    let curHex = bytesToHex(node);
-    let distance = 0;
-
-    for (let hops = 0; hops < 10_000; hops += 1) {
-      if (excludeHex.has(curHex)) return 'deny' as const;
-      if (curHex === rootHex) {
-        if (maxDepth !== undefined && distance > maxDepth) return 'deny' as const;
-        return 'allow' as const;
-      }
-
-      // Reserved ids terminate the chain (unless they are the scope root, handled above).
-      if (curHex === root || curHex === 'f'.repeat(32)) return 'deny' as const;
-
-      // If we already traversed `maxDepth` edges without reaching `root`, the node cannot be within scope.
-      if (maxDepth !== undefined && distance >= maxDepth) return 'deny' as const;
-
-      const parentHex = parentByNodeHex.get(curHex);
-      if (parentHex === undefined) return 'unknown' as const;
-      if (parentHex === null) return 'deny' as const;
-
-      curHex = parentHex;
-      distance += 1;
-    }
-
-    // Defensive: cycles or extreme depth.
-    return 'unknown' as const;
+    scopeEvaluations += 1;
+    // The materialized tree only knows the node's current, post-re-entry location. The old
+    // implementation therefore allowed every historical op below, including the private period.
+    return bytesToHex(node) === publicNode ? ('allow' as const) : ('deny' as const);
   };
 
   const tokenReceiver = issueTreecrdtCapabilityTokenV1({
     issuerPrivateKey: issuerSk,
     subjectPublicKey: receiverPk,
     docId,
-    actions: ['read_structure'],
+    actions: ['read_structure', 'read_payload'],
     rootNodeId: root,
     excludeNodeIds: [privateRoot],
   });
@@ -1697,72 +1665,181 @@ test('auth: filterOutgoingOps hides move/delete/tombstone for excluded subtrees'
   const receiverCaps = await authReceiver.helloCapabilities?.({ docId });
   expect(receiverCaps).toBeTruthy();
 
-  const ops: Operation[] = [
-    makeOp(senderPk, 1, 1, {
-      type: 'insert',
-      parent: root,
-      node: publicNode,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makeOp(senderPk, 2, 2, {
-      type: 'insert',
-      parent: root,
-      node: privateRoot,
-      orderKey: orderKeyFromPosition(1),
-    }),
-    makeOp(senderPk, 3, 3, {
-      type: 'insert',
-      parent: privateRoot,
-      node: privateSibling,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makeOp(senderPk, 4, 4, {
-      type: 'insert',
-      parent: privateRoot,
-      node: privateChild,
-      orderKey: orderKeyFromPosition(1),
-    }),
-    makeOp(senderPk, 5, 5, {
-      type: 'move',
-      node: privateChild,
-      newParent: privateSibling,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makeOp(senderPk, 6, 6, {
-      type: 'payload',
-      node: privateChild,
-      payload: new Uint8Array([1, 2, 3]),
-    }),
-    makeOp(senderPk, 7, 7, { type: 'delete', node: privateChild }),
-    makeOp(senderPk, 8, 8, { type: 'tombstone', node: privateChild }),
-    makeOp(senderPk, 9, 9, {
-      type: 'move',
-      node: publicNode,
-      newParent: root,
-      orderKey: orderKeyFromPosition(0),
-    }),
-    makeOp(senderPk, 10, 10, { type: 'delete', node: publicNode }),
-  ];
-
-  const allowed = await authSender.filterOutgoingOps?.(ops, {
+  const movedIntoPrivate = makeOp(senderPk, 1, 1, {
+    type: 'move',
+    node: publicNode,
+    newParent: privateRoot,
+    orderKey: orderKeyFromPosition(0),
+  });
+  const privatePayload = makeOp(senderPk, 2, 2, {
+    type: 'payload',
+    node: publicNode,
+    payload: new TextEncoder().encode('private history'),
+  });
+  const movedBack = makeOp(senderPk, 3, 3, {
+    type: 'move',
+    node: publicNode,
+    newParent: root,
+    orderKey: orderKeyFromPosition(0),
+  });
+  const publicPayload = makeOp(senderPk, 4, 4, {
+    type: 'payload',
+    node: publicNode,
+    payload: new TextEncoder().encode('current public value'),
+  });
+  const ctx = {
     docId,
-    purpose: 'reconcile',
-    filter: { all: {} },
+    purpose: 'reconcile' as const,
+    filter: { children: { parent: nodeIdToBytes16(root) } },
     capabilities: receiverCaps ?? [],
+  };
+
+  await expect(
+    authSender.authorizeFilter?.(ctx.filter, {
+      docId,
+      purpose: 'hello',
+      capabilities: ctx.capabilities,
+    }),
+  ).rejects.toThrow(/capability does not allow filter/i);
+  await expect(authSender.filterOutgoingOps?.([movedIntoPrivate], ctx)).rejects.toThrow(
+    /does not allow operation-log projection/i,
+  );
+  await expect(
+    authSender.filterOutgoingOps?.([privatePayload, movedBack, publicPayload], ctx),
+  ).rejects.toThrow(/does not allow operation-log projection/i);
+  expect(scopeEvaluations).toBe(0);
+});
+
+test('auth: document-wide projection requires read_payload for every payload-state op', async () => {
+  const docId = 'doc-auth-filter-payload-actions';
+  const root = '0'.repeat(32);
+  const scopedRoot = nodeIdFromInt(9);
+
+  const issuerSk = ed25519Utils.randomSecretKey();
+  const issuerPk = await getPublicKey(issuerSk);
+  const peerSk = ed25519Utils.randomSecretKey();
+  const peerPk = await getPublicKey(peerSk);
+
+  const structureToken = issueTreecrdtCapabilityTokenV1({
+    issuerPrivateKey: issuerSk,
+    subjectPublicKey: peerPk,
+    docId,
+    actions: ['read_structure'],
+    rootNodeId: root,
+  });
+  const scopedPayloadToken = issueTreecrdtCapabilityTokenV1({
+    issuerPrivateKey: issuerSk,
+    subjectPublicKey: peerPk,
+    docId,
+    actions: ['read_payload'],
+    rootNodeId: scopedRoot,
+  });
+  const payloadToken = issueTreecrdtCapabilityTokenV1({
+    issuerPrivateKey: issuerSk,
+    subjectPublicKey: peerPk,
+    docId,
+    actions: ['read_payload'],
+    rootNodeId: root,
   });
 
-  expect(allowed).toBeTruthy();
-  expect(allowed?.length).toBe(ops.length);
+  const capabilitiesFor = async (localCapabilityTokens: Uint8Array[]) => {
+    const auth = createTreecrdtCoseCwtAuth({
+      issuerPublicKeys: [issuerPk],
+      localPrivateKey: peerSk,
+      localPublicKey: peerPk,
+      localCapabilityTokens,
+      requireProofRef: true,
+    });
+    return (await auth.helloCapabilities?.({ docId })) ?? [];
+  };
 
-  // Allowed: ops for the public subtree.
-  expect(allowed?.[0]).toBe(true); // insert(public)
-  expect(allowed?.[8]).toBe(true); // move(public)
-  expect(allowed?.[9]).toBe(true); // delete(public)
+  const structureCaps = await capabilitiesFor([structureToken]);
+  const scopedPayloadCaps = await capabilitiesFor([structureToken, scopedPayloadToken]);
+  const fullCaps = await capabilitiesFor([structureToken, payloadToken]);
+  const authSender = createTreecrdtCoseCwtAuth({
+    issuerPublicKeys: [issuerPk],
+    localPrivateKey: peerSk,
+    localPublicKey: peerPk,
+    requireProofRef: true,
+    scopeEvaluator: () => {
+      throw new Error('document-wide fast path must not consult materialized ancestry');
+    },
+  });
 
-  // Denied: everything under the excluded private root (including move/delete/tombstone).
-  for (const i of [1, 2, 3, 4, 5, 6, 7]) {
-    expect(allowed?.[i]).toBe(false);
+  for (const filter of [
+    { all: {} } as const,
+    { children: { parent: nodeIdToBytes16(scopedRoot) } } as const,
+  ]) {
+    await expect(
+      authSender.authorizeFilter?.(filter, {
+        docId,
+        purpose: 'hello',
+        capabilities: structureCaps,
+      }),
+    ).resolves.toBeUndefined();
   }
+
+  const structuralOps: Operation[] = [
+    makeOp(peerPk, 1, 1, {
+      type: 'insert',
+      parent: root,
+      node: nodeIdFromInt(1),
+      orderKey: orderKeyFromPosition(0),
+    }),
+    makeOp(peerPk, 2, 2, {
+      type: 'move',
+      node: nodeIdFromInt(1),
+      newParent: scopedRoot,
+      orderKey: orderKeyFromPosition(0),
+    }),
+    makeOp(peerPk, 3, 3, { type: 'delete', node: nodeIdFromInt(1) }),
+    makeOp(peerPk, 4, 4, { type: 'tombstone', node: nodeIdFromInt(1) }),
+  ];
+  const payloadOps: Operation[] = [
+    makeOp(peerPk, 5, 5, {
+      type: 'insert',
+      parent: root,
+      node: nodeIdFromInt(2),
+      orderKey: orderKeyFromPosition(0),
+      payload: new Uint8Array(),
+    }),
+    makeOp(peerPk, 6, 6, {
+      type: 'payload',
+      node: nodeIdFromInt(1),
+      payload: new Uint8Array([1]),
+    }),
+    makeOp(peerPk, 7, 7, { type: 'payload', node: nodeIdFromInt(1), payload: null }),
+  ];
+  const context = {
+    docId,
+    purpose: 'reconcile' as const,
+    filter: { all: {} } as const,
+  };
+
+  await expect(
+    authSender.filterOutgoingOps?.(structuralOps, {
+      ...context,
+      capabilities: structureCaps,
+    }),
+  ).resolves.toEqual(structuralOps.map(() => true));
+
+  for (const op of payloadOps) {
+    await expect(
+      authSender.filterOutgoingOps?.([op], { ...context, capabilities: structureCaps }),
+    ).rejects.toThrow(/requires read_payload for payload state/i);
+  }
+  await expect(
+    authSender.filterOutgoingOps?.(payloadOps, {
+      ...context,
+      capabilities: scopedPayloadCaps,
+    }),
+  ).rejects.toThrow(/requires read_payload for payload state/i);
+  await expect(
+    authSender.filterOutgoingOps?.([...structuralOps, ...payloadOps], {
+      ...context,
+      capabilities: fullCaps,
+    }),
+  ).resolves.toEqual([...structuralOps, ...payloadOps].map(() => true));
 });
 
 test('auth: delegated capability token can be verified via issuer-signed proof', async () => {

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1622,7 +1622,8 @@ async function scenarioSyncAuthScopedTokenRejectsAllFilter(
   await a.local.insert(aPk, root, nodeIdFromInt(1), { type: 'last' }, null);
   await b.local.insert(bPk, root, nodeIdFromInt(2), { type: 'last' }, null);
 
-  // Scoped tokens must not be allowed to use `filter(all)`; they should use `children(parent)` instead.
+  // The reference COSE/CWT policy cannot safely project historical operations from current
+  // ancestry, so a scoped grant must not authorize any operation-log filter.
   const tokenA = issueTreecrdtCapabilityTokenV1({
     issuerPrivateKey: issuerSk,
     subjectPublicKey: aPk,


### PR DESCRIPTION
## Problem

Sync filters reconcile historical operations, but the subtree evaluator only sees current materialized ancestry. A node can enter a private subtree and later re-enter readable state; filtering from current membership can then reveal its private destination or payload history.

Simply omitting a required operation is also unsafe because it changes the selected causal op set and can leave the receiver stale.

## What changes

- The reference COSE/CWT auth implementation requires document-wide `read_structure` for both `Filter.all` and `Filter.children`.
- Payload updates, payload clears, and payload-bearing inserts additionally require document-wide `read_payload`.
- Unsafe projections reject as a whole instead of trying to redact individual historical operations.
- Filters may still reduce reconciliation work; they no longer reduce the authorization scope.
- Custom `SyncAuth` implementations remain free to provide a different authenticated projection format.
- Obsolete current-membership projection tests are replaced with fail-closed coverage.

## Fast paths

- Structure-only batches need only `read_structure`.
- Peers with document-wide grants keep the direct allow path.
- Backend `children` filtering and the existing reconciliation optimizations remain available.

## Tests

- private destinations and history remain hidden after a node re-enters readable state
- structure-only projections work without payload authority
- payload updates, clears, and inline payload inserts require `read_payload`
- playground scoped projections fail closed

## Stack

Stacked on #189.
