### PR TITLE
fix(sqlite): commit local proofs with their operations

### DIFF
--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -55,7 +55,15 @@ struct JsonLocalOpTransactionError {
 enum LocalOpMode {
     Immediate,
     Prepare,
-    Commit(String),
+    Commit {
+        precondition: String,
+        proof: LocalOpProof,
+    },
+}
+
+struct LocalOpProof {
+    sig: Vec<u8>,
+    proof_ref: Vec<u8>,
 }
 
 enum LocalOpDispatchResult {
@@ -109,20 +117,37 @@ fn parse_local_op_mode(
     args: &[*mut sqlite3_value],
     base_argc: usize,
 ) -> Result<LocalOpMode, ()> {
-    if argc as usize == base_argc {
-        return Ok(LocalOpMode::Immediate);
+    match argc as usize {
+        n if n == base_argc => return Ok(LocalOpMode::Immediate),
+        n if n == base_argc + 1 => {
+            return (read_text(args[base_argc]) == "prepare")
+                .then_some(LocalOpMode::Prepare)
+                .ok_or(());
+        }
+        n if n == base_argc + 3 => {}
+        _ => return Err(()),
     }
-    if argc as usize != base_argc + 1 {
+
+    let precondition = read_text(args[base_argc]);
+    if !precondition.starts_with("v1:") {
         return Err(());
     }
-    let phase = read_text(args[base_argc]);
-    if phase == "prepare" {
-        Ok(LocalOpMode::Prepare)
-    } else if phase.starts_with("v1:") {
-        Ok(LocalOpMode::Commit(phase))
-    } else {
-        Err(())
+    let sig = read_required_blob(args[base_argc + 1])?;
+    if sig.len() != 64 {
+        return Err(());
     }
+    let proof_ref = read_required_blob(args[base_argc + 2])?;
+    if proof_ref.len() != 16 {
+        return Err(());
+    }
+    Ok(LocalOpMode::Commit {
+        precondition,
+        proof: LocalOpProof { sig, proof_ref },
+    })
+}
+
+fn valid_local_op_argc(argc: c_int, base_argc: usize) -> bool {
+    matches!(argc as usize, n if n == base_argc || n == base_argc + 1 || n == base_argc + 3)
 }
 
 fn sqlite_busy_or_locked(rc: c_int) -> bool {
@@ -283,6 +308,72 @@ fn local_precondition(
     hasher.update(&(op_bytes.len() as u64).to_be_bytes());
     hasher.update(&op_bytes);
     Ok(Some(format!("v1:{}", hasher.finalize().to_hex())))
+}
+
+fn persist_local_op_proof(
+    db: *mut sqlite3,
+    doc_id: &[u8],
+    op: &Operation,
+    proof: &LocalOpProof,
+) -> Result<(), c_int> {
+    let sql = CString::new(
+        "INSERT OR REPLACE INTO treecrdt_sync_op_auth \
+         (doc_id, op_ref, sig, proof_ref, created_at_ms) \
+         VALUES (?1, ?2, ?3, ?4, CAST(strftime('%s','now') AS INTEGER) * 1000)",
+    )
+    .expect("local op proof sql");
+    let mut stmt: *mut sqlite3_stmt = null_mut();
+    let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, &mut stmt, null_mut());
+    if rc != SQLITE_OK as c_int {
+        return Err(rc);
+    }
+
+    let op_ref = derive_op_ref_v0(doc_id, op.meta.id.replica.as_bytes(), op.meta.id.counter);
+    let mut bind_err = false;
+    unsafe {
+        bind_err |= sqlite_bind_text(
+            stmt,
+            1,
+            doc_id.as_ptr() as *const c_char,
+            doc_id.len() as c_int,
+            None,
+        ) != SQLITE_OK as c_int;
+        bind_err |= sqlite_bind_blob(
+            stmt,
+            2,
+            op_ref.as_ptr() as *const c_void,
+            op_ref.len() as c_int,
+            None,
+        ) != SQLITE_OK as c_int;
+        bind_err |= sqlite_bind_blob(
+            stmt,
+            3,
+            proof.sig.as_ptr() as *const c_void,
+            proof.sig.len() as c_int,
+            None,
+        ) != SQLITE_OK as c_int;
+        bind_err |= sqlite_bind_blob(
+            stmt,
+            4,
+            proof.proof_ref.as_ptr() as *const c_void,
+            proof.proof_ref.len() as c_int,
+            None,
+        ) != SQLITE_OK as c_int;
+    }
+    if bind_err {
+        unsafe { sqlite_finalize(stmt) };
+        return Err(SQLITE_ERROR as c_int);
+    }
+
+    let step_rc = unsafe { sqlite_step(stmt) };
+    let finalize_rc = unsafe { sqlite_finalize(stmt) };
+    if step_rc != SQLITE_DONE as c_int {
+        return Err(step_rc);
+    }
+    if finalize_rc != SQLITE_OK as c_int {
+        return Err(finalize_rc);
+    }
+    Ok(())
 }
 
 fn begin_local_core_op(
@@ -493,7 +584,10 @@ where
             };
             finish_local_core_op(session, op, plan).map(LocalOpDispatchResult::Committed)
         }
-        LocalOpMode::Commit(expected_precondition) => {
+        LocalOpMode::Commit {
+            precondition: expected_precondition,
+            proof,
+        } => {
             let mut session = match begin_optimistic_local_core_op(db, &replica, savepoint_name) {
                 Ok(v) => v,
                 Err(OptimisticBeginError::Conflict) => return Ok(LocalOpDispatchResult::Conflict),
@@ -525,6 +619,9 @@ where
                 Ok(v) => v,
                 Err(err) => return Err(session.rollback(sqlite_err_from_core(err))),
             };
+            if let Err(rc) = persist_local_op_proof(session.db, &session.doc_id, &op, &proof) {
+                return Err(session.rollback(rc));
+            }
             finish_local_core_op(session, op, plan).map(LocalOpDispatchResult::Committed)
         }
     }
@@ -556,10 +653,10 @@ pub(super) unsafe extern "C" fn treecrdt_local_insert(
         return;
     }
 
-    if argc != 6 && argc != 7 {
+    if !valid_local_op_argc(argc, 6) {
         sqlite_result_error(
             ctx,
-            b"treecrdt_local_insert expects 6 args plus optional prepare/precondition\0".as_ptr()
+            b"treecrdt_local_insert expects 6 args, 7 for prepare, or 9 for commit\0".as_ptr()
                 as *const c_char,
         );
         return;
@@ -571,7 +668,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_insert(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_insert: invalid prepare/precondition argument\0".as_ptr()
+                b"treecrdt_local_insert: invalid prepare or commit arguments\0".as_ptr()
                     as *const c_char,
             );
             return;
@@ -655,10 +752,10 @@ pub(super) unsafe extern "C" fn treecrdt_local_move(
         return;
     }
 
-    if argc != 5 && argc != 6 {
+    if !valid_local_op_argc(argc, 5) {
         sqlite_result_error(
             ctx,
-            b"treecrdt_local_move expects 5 args plus optional prepare/precondition\0".as_ptr()
+            b"treecrdt_local_move expects 5 args, 6 for prepare, or 8 for commit\0".as_ptr()
                 as *const c_char,
         );
         return;
@@ -670,7 +767,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_move(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_move: invalid prepare/precondition argument\0".as_ptr()
+                b"treecrdt_local_move: invalid prepare or commit arguments\0".as_ptr()
                     as *const c_char,
             );
             return;
@@ -752,10 +849,10 @@ pub(super) unsafe extern "C" fn treecrdt_local_delete(
         return;
     }
 
-    if argc != 2 && argc != 3 {
+    if !valid_local_op_argc(argc, 2) {
         sqlite_result_error(
             ctx,
-            b"treecrdt_local_delete expects 2 args plus optional prepare/precondition\0".as_ptr()
+            b"treecrdt_local_delete expects 2 args, 3 for prepare, or 5 for commit\0".as_ptr()
                 as *const c_char,
         );
         return;
@@ -767,7 +864,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_delete(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_delete: invalid prepare/precondition argument\0".as_ptr()
+                b"treecrdt_local_delete: invalid prepare or commit arguments\0".as_ptr()
                     as *const c_char,
             );
             return;
@@ -818,10 +915,10 @@ pub(super) unsafe extern "C" fn treecrdt_local_payload(
         return;
     }
 
-    if argc != 3 && argc != 4 {
+    if !valid_local_op_argc(argc, 3) {
         sqlite_result_error(
             ctx,
-            b"treecrdt_local_payload expects 3 args plus optional prepare/precondition\0".as_ptr()
+            b"treecrdt_local_payload expects 3 args, 4 for prepare, or 6 for commit\0".as_ptr()
                 as *const c_char,
         );
         return;
@@ -833,7 +930,7 @@ pub(super) unsafe extern "C" fn treecrdt_local_payload(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_payload: invalid prepare/precondition argument\0".as_ptr()
+                b"treecrdt_local_payload: invalid prepare or commit arguments\0".as_ptr()
                     as *const c_char,
             );
             return;

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/schema.rs
@@ -307,6 +307,16 @@ CREATE TABLE IF NOT EXISTS tree_payload (
   last_counter INTEGER NOT NULL
 );
 "#;
+    const OP_AUTH: &str = r#"
+CREATE TABLE IF NOT EXISTS treecrdt_sync_op_auth (
+  doc_id TEXT NOT NULL,
+  op_ref BLOB NOT NULL,
+  sig BLOB NOT NULL CHECK(length(sig) = 64),
+  proof_ref BLOB NOT NULL CHECK(length(proof_ref) = 16),
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (doc_id, op_ref)
+);
+"#;
 
     let rc_meta = {
         let sql = CString::new(META).expect("meta schema");
@@ -352,6 +362,13 @@ CREATE TABLE IF NOT EXISTS tree_payload (
         return Err(rc_tree_payload);
     }
 
+    let rc_op_auth = {
+        let sql = CString::new(OP_AUTH).expect("op auth schema");
+        sqlite_exec(db, sql.as_ptr(), None, null_mut(), null_mut())
+    };
+    if rc_op_auth != SQLITE_OK as c_int {
+        return Err(rc_op_auth);
+    }
     const INDEXES: &str = r#"
 CREATE INDEX IF NOT EXISTS idx_ops_lamport ON ops(lamport, replica, counter);
 CREATE INDEX IF NOT EXISTS idx_ops_op_ref ON ops(op_ref);

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -616,7 +616,7 @@ fn optimistic_local_prepare_is_read_only_and_stale_commit_is_a_conflict() {
 
     let contended_json: String = conn_a
         .query_row(
-            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4)",
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(64), zeroblob(16))",
             rusqlite::params![
                 replica.clone(),
                 root.clone(),
@@ -632,7 +632,7 @@ fn optimistic_local_prepare_is_read_only_and_stale_commit_is_a_conflict() {
     // Once B commits, the same token is stale and still returns a clean conflict.
     let stale_json: String = conn_a
         .query_row(
-            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4)",
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(64), zeroblob(16))",
             rusqlite::params![
                 replica.clone(),
                 root.clone(),
@@ -667,7 +667,7 @@ fn optimistic_local_prepare_is_read_only_and_stale_commit_is_a_conflict() {
     assert_eq!(retried.op.lamport, 2);
     let committed_json: String = conn_a
         .query_row(
-            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4)",
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(64), zeroblob(16))",
             rusqlite::params![
                 replica,
                 root.clone(),
@@ -685,6 +685,236 @@ fn optimistic_local_prepare_is_read_only_and_stale_commit_is_a_conflict() {
         visible_children(&conn_a, &root),
         vec![unrelated_node, proposed_node]
     );
+}
+
+#[test]
+fn op_auth_schema_is_shared_across_initialization_orders() {
+    fn columns(conn: &Connection) -> Vec<(String, String, i64, i64)> {
+        let mut stmt = conn.prepare("PRAGMA table_info('treecrdt_sync_op_auth')").unwrap();
+        stmt.query_map([], |row| {
+            Ok((row.get(1)?, row.get(2)?, row.get(3)?, row.get(5)?))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap()
+    }
+
+    let fresh = setup_conn();
+    assert_eq!(
+        columns(&fresh),
+        vec![
+            ("doc_id".into(), "TEXT".into(), 1, 1),
+            ("op_ref".into(), "BLOB".into(), 1, 2),
+            ("sig".into(), "BLOB".into(), 1, 0),
+            ("proof_ref".into(), "BLOB".into(), 1, 0),
+            ("created_at_ms".into(), "INTEGER".into(), 1, 0),
+        ]
+    );
+
+    let proof_store_first = Connection::open_in_memory().unwrap();
+    proof_store_first
+        .execute_batch(
+            r#"
+CREATE TABLE treecrdt_sync_op_auth (
+  doc_id TEXT NOT NULL,
+  op_ref BLOB NOT NULL,
+  sig BLOB NOT NULL CHECK(length(sig) = 64),
+  proof_ref BLOB NOT NULL CHECK(length(proof_ref) = 16),
+  created_at_ms INTEGER NOT NULL,
+  PRIMARY KEY (doc_id, op_ref)
+);
+INSERT INTO treecrdt_sync_op_auth
+  (doc_id, op_ref, sig, proof_ref, created_at_ms)
+VALUES ('proof-store-first', X'01', zeroblob(64), zeroblob(16), 7);
+"#,
+        )
+        .unwrap();
+    load_extension(&proof_store_first);
+
+    assert_eq!(columns(&proof_store_first), columns(&fresh));
+    assert_eq!(
+        proof_store_first
+            .query_row(
+                "SELECT created_at_ms FROM treecrdt_sync_op_auth WHERE doc_id = 'proof-store-first'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .unwrap(),
+        7
+    );
+
+    for conn in [&fresh, &proof_store_first] {
+        assert!(conn
+            .execute(
+                "INSERT INTO treecrdt_sync_op_auth \
+                 (doc_id, op_ref, sig, proof_ref, created_at_ms) \
+                 VALUES ('short-sig', X'02', zeroblob(63), zeroblob(16), 8)",
+                [],
+            )
+            .is_err());
+        assert!(conn
+            .execute(
+                "INSERT INTO treecrdt_sync_op_auth \
+                 (doc_id, op_ref, sig, proof_ref, created_at_ms) \
+                 VALUES ('short-proof-ref', X'03', zeroblob(64), zeroblob(15), 9)",
+                [],
+            )
+            .is_err());
+    }
+}
+
+#[test]
+fn optimistic_local_proof_is_atomic_with_operation_commit() {
+    let doc_id = "träd/🌲/文档";
+    let conn = setup_conn_with_doc_id(doc_id);
+    let replica = b"proof-replica".to_vec();
+    let root = node_bytes(0);
+    let node = node_bytes(50);
+    let sig = vec![7u8; 64];
+    let proof_ref = vec![8u8; 16];
+
+    let prepared_json: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, 'prepare')",
+            rusqlite::params![replica.clone(), root.clone(), node.clone()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let prepared: JsonPreparedLocalOpResult = serde_json::from_str(&prepared_json).unwrap();
+    for sql in [
+        "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4)",
+        "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(63), zeroblob(16))",
+        "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(64), NULL)",
+        "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, zeroblob(64), zeroblob(15))",
+    ] {
+        let invalid: rusqlite::Result<String> = conn.query_row(
+            sql,
+            rusqlite::params![
+                replica.clone(),
+                root.clone(),
+                node.clone(),
+                prepared.precondition.clone()
+            ],
+            |row| row.get(0),
+        );
+        assert!(invalid.is_err());
+    }
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
+    let before_ms: i64 = conn
+        .query_row(
+            "SELECT CAST(strftime('%s','now') AS INTEGER) * 1000",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let _: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, ?5, ?6)",
+            rusqlite::params![
+                replica.clone(),
+                root.clone(),
+                node.clone(),
+                prepared.precondition,
+                sig.clone(),
+                proof_ref.clone()
+            ],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let after_ms: i64 = conn
+        .query_row(
+            "SELECT CAST(strftime('%s','now') AS INTEGER) * 1000",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let stored: (String, String, Vec<u8>, Vec<u8>, i64) = conn
+        .query_row(
+            "SELECT typeof(doc_id), doc_id, sig, proof_ref, created_at_ms \
+             FROM treecrdt_sync_op_auth",
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(stored.0, "text");
+    assert_eq!(stored.1, doc_id);
+    assert_eq!(stored.2, sig.clone());
+    assert_eq!(stored.3, proof_ref);
+    assert!((before_ms..=after_ms).contains(&stored.4));
+    assert_eq!(
+        conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM treecrdt_sync_op_auth AS auth \
+             JOIN ops ON ops.op_ref = auth.op_ref WHERE auth.doc_id = ?1)",
+            [doc_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap(),
+        1
+    );
+
+    let rejected_node = node_bytes(51);
+    let rejected_json: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, 'prepare')",
+            rusqlite::params![replica.clone(), root.clone(), rejected_node.clone()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let rejected: JsonPreparedLocalOpResult = serde_json::from_str(&rejected_json).unwrap();
+    conn.execute_batch(
+        "CREATE TRIGGER reject_local_proof BEFORE INSERT ON treecrdt_sync_op_auth \
+         BEGIN SELECT RAISE(ABORT, 'proof failure'); END;",
+    )
+    .unwrap();
+    let failed: rusqlite::Result<String> = conn.query_row(
+        "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL, ?4, ?5, ?6)",
+        rusqlite::params![
+            replica,
+            root,
+            rejected_node.clone(),
+            rejected.precondition,
+            sig,
+            proof_ref
+        ],
+        |row| row.get(0),
+    );
+    assert!(failed.is_err());
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        1
+    );
+    assert!(!visible_children(&conn, &node_bytes(0)).contains(&rejected_node));
+    assert_eq!(read_tree_meta(&conn).3, 1);
+    assert!(conn.is_autocommit());
+
+    conn.execute_batch("DROP TRIGGER reject_local_proof").unwrap();
+    let recovery_node = node_bytes(52);
+    let _: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL)",
+            rusqlite::params![
+                b"recovery-replica".to_vec(),
+                node_bytes(0),
+                recovery_node.clone()
+            ],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(visible_children(&conn, &node_bytes(0)).contains(&recovery_node));
 }
 
 #[test]
@@ -1382,26 +1612,36 @@ fn local_payload_does_not_prepare_an_unused_delete_statement() {
 }
 
 fn setup_conn() -> Connection {
-    setup_conn_at(None)
+    setup_conn_with_doc_id("treecrdt-sqlite-ext-test")
 }
 
 fn setup_conn_at(path: Option<&Path>) -> Connection {
-    let ext_path = find_extension().expect("extension dylib path");
+    setup_conn_at_with_doc_id(path, "treecrdt-sqlite-ext-test")
+}
+
+fn setup_conn_with_doc_id(doc_id: &str) -> Connection {
+    setup_conn_at_with_doc_id(None, doc_id)
+}
+
+fn setup_conn_at_with_doc_id(path: Option<&Path>, doc_id: &str) -> Connection {
     let conn = match path {
         Some(path) => Connection::open(path).unwrap(),
         None => Connection::open_in_memory().unwrap(),
     };
+    load_extension(&conn);
+    conn.query_row("SELECT treecrdt_set_doc_id(?1)", [doc_id], |row| {
+        row.get::<_, i64>(0)
+    })
+    .unwrap();
+    conn
+}
+
+fn load_extension(conn: &Connection) {
+    let ext_path = find_extension().expect("extension dylib path");
     unsafe {
         conn.load_extension_enable().unwrap();
         conn.load_extension(ext_path, Some("sqlite3_treecrdt_init")).unwrap();
     }
-    conn.query_row(
-        "SELECT treecrdt_set_doc_id('treecrdt-sqlite-ext-test')",
-        [],
-        |row| row.get::<_, i64>(0),
-    )
-    .unwrap();
-    conn
 }
 
 fn node_bytes(id: u128) -> Vec<u8> {


### PR DESCRIPTION
## Problem

If a local operation commits and its authorization proof is stored afterward, a crash between those writes leaves an operation that cannot be safely forwarded or audited.

## What changes

Every optimistic SQLite commit requires a 64-byte signature and 16-byte proof reference. The native extension writes that complete proof into `treecrdt_sync_op_auth` inside the same savepoint as the operation, materialized tree changes, and materialization metadata.

Both schema initialization orders enforce `NOT NULL`, `length(sig) = 64`, and `length(proof_ref) = 16`. The operation reference comes from the operation actually committed and the database clock supplies the timestamp.

## Clean-slate choice

There is no proofless commit arity, optional reference, unconstrained old schema, migration, or durable mirror. Authenticated optimistic commits are proof-bearing by contract. Unauthenticated writes use #193's separate immediate path.

## Fast paths

- The immediate unauthenticated UDF performs no sidecar write.
- The proof store reads the native row directly.
- The authenticated commit adds one co-transactional row, with no second transaction or lookup.

## Failure behavior

Any bind, constraint, insert, trigger, finalization, materialization, or savepoint-release failure rolls back operation, proof, tree state, and metadata together.

## Verification

- SQLite extension test suite
- malformed/missing/wrong-width proof rejection
- both schema initialization orders
- op-ref derivation, database timestamps, and atomic rollback

## Stack

Stacked on #193 and consumes #187's exact-proof shape.
