### PR TITLE
fix(postgres): commit authorized local writes optimistically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         env:
           TREECRDT_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/treecrdt
         run: |
+          cargo test -p treecrdt-postgres --all-targets
           pnpm -C packages/treecrdt-postgres-napi test
           pnpm -C packages/sync-protocol/material/postgres test
           pnpm -C packages/sync-protocol/server/postgres-node test

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -113,41 +113,59 @@ pub struct NativeLocalOpResult {
     pub outcome: NativeMaterializationOutcome,
 }
 
-#[napi]
-pub struct NativePreparedLocalOpTx {
-    tx: Option<treecrdt_postgres::PreparedLocalOpTx>,
+#[napi(object)]
+pub struct NativeLocalOpAuthProof {
+    pub sig: Buffer,
+    pub proof_ref: Option<Buffer>,
 }
 
 #[napi]
-impl NativePreparedLocalOpTx {
+pub struct NativePreparedLocalOp {
+    url: String,
+    proposal: Option<treecrdt_postgres::PreparedLocalOpProposal>,
+}
+
+#[napi]
+impl NativePreparedLocalOp {
     #[napi]
     pub fn op(&self) -> napi::Result<NativeOp> {
-        let tx = self
-            .tx
+        let proposal = self
+            .proposal
             .as_ref()
-            .ok_or_else(|| map_err("prepared local op transaction is already closed"))?;
-        core_to_native_op(tx.op().clone()).map_err(map_core_err)
+            .ok_or_else(|| map_err("prepared local operation is already closed"))?;
+        core_to_native_op(proposal.op().clone()).map_err(map_core_err)
     }
 
     #[napi]
-    pub fn commit(&mut self) -> napi::Result<NativeLocalOpResult> {
-        let tx = self
-            .tx
+    pub fn recovery_outcome(&self) -> napi::Result<NativeMaterializationOutcome> {
+        let proposal = self
+            .proposal
+            .as_ref()
+            .ok_or_else(|| map_err("prepared local operation is already closed"))?;
+        Ok(outcome_to_native(proposal.recovery_outcome().clone()))
+    }
+
+    #[napi]
+    pub fn commit(
+        &mut self,
+        proof: NativeLocalOpAuthProof,
+    ) -> napi::Result<Option<NativeLocalOpResult>> {
+        let proposal = self
+            .proposal
             .take()
-            .ok_or_else(|| map_err("prepared local op transaction is already closed"))?;
-        let result = tx.commit().map_err(map_core_err)?;
-        Ok(NativeLocalOpResult {
-            op: core_to_native_op(result.op).map_err(map_core_err)?,
-            outcome: outcome_to_native(result.outcome),
-        })
-    }
-
-    #[napi]
-    pub fn rollback(&mut self) -> napi::Result<()> {
-        if let Some(tx) = self.tx.take() {
-            tx.rollback().map_err(map_core_err)?;
-        }
-        Ok(())
+            .ok_or_else(|| map_err("prepared local operation is already closed"))?;
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+        let result = treecrdt_postgres::try_commit_prepared_local(
+            &client,
+            proposal,
+            treecrdt_postgres::LocalOpAuthProof {
+                sig: proof.sig.to_vec(),
+                proof_ref: proof.proof_ref.map(|value| value.to_vec()),
+            },
+        )
+        .map_err(map_core_err)?;
+        result.map(local_result_to_native).transpose().map_err(map_core_err)
     }
 }
 
@@ -239,6 +257,25 @@ fn outcome_to_native(outcome: MaterializationOutcome) -> NativeMaterializationOu
         head_seq: BigInt::from(outcome.head_seq),
         changes,
     }
+}
+
+fn local_result_to_native(
+    result: treecrdt_postgres::LocalOpResult,
+) -> CoreResult<NativeLocalOpResult> {
+    Ok(NativeLocalOpResult {
+        op: core_to_native_op(result.op)?,
+        outcome: outcome_to_native(result.outcome),
+    })
+}
+
+fn prepared_local_to_native(
+    url: &str,
+    proposal: Option<treecrdt_postgres::PreparedLocalOpProposal>,
+) -> Option<NativePreparedLocalOp> {
+    proposal.map(|proposal| NativePreparedLocalOp {
+        url: url.to_string(),
+        proposal: Some(proposal),
+    })
 }
 
 fn bigint_to_u64(name: &str, v: BigInt) -> CoreResult<u64> {
@@ -422,7 +459,7 @@ impl PgFactory {
         // Test-only convenience: wipe all docs.
         client
             .batch_execute(
-                "TRUNCATE treecrdt_oprefs_children, treecrdt_payload, treecrdt_nodes, treecrdt_ops, treecrdt_meta",
+                "TRUNCATE treecrdt_sync_op_auth, treecrdt_oprefs_children, treecrdt_payload, treecrdt_nodes, treecrdt_ops, treecrdt_meta",
             )
             .map_err(map_err)?;
         Ok(())
@@ -684,8 +721,24 @@ impl PgBackend {
         after: Option<Buffer>,
         payload: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
-        let mut tx = self.prepare_local_insert(replica, parent, node, placement, after, payload)?;
-        tx.commit()
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+        let replica = ReplicaId(replica.to_vec());
+        let parent = bytes16_to_node(&parent).map_err(map_core_err)?;
+        let node = bytes16_to_node(&node).map_err(map_core_err)?;
+        let after = after.map(|bytes| bytes16_to_node(&bytes).map_err(map_core_err)).transpose()?;
+        let result = treecrdt_postgres::local_insert(
+            &client,
+            &self.doc_id,
+            &replica,
+            parent,
+            node,
+            &placement,
+            after,
+            payload.map(|value| value.to_vec()),
+        )
+        .map_err(map_core_err)?;
+        local_result_to_native(result).map_err(map_core_err)
     }
 
     #[napi]
@@ -697,7 +750,7 @@ impl PgBackend {
         placement: String,
         after: Option<Buffer>,
         payload: Option<Buffer>,
-    ) -> napi::Result<NativePreparedLocalOpTx> {
+    ) -> napi::Result<Option<NativePreparedLocalOp>> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -709,7 +762,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let tx = treecrdt_postgres::prepare_local_insert_tx(
+        let result = treecrdt_postgres::try_prepare_local_insert(
             &client,
             &self.doc_id,
             &replica,
@@ -720,7 +773,7 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
+        Ok(prepared_local_to_native(&self.url, result))
     }
 
     #[napi]
@@ -732,8 +785,23 @@ impl PgBackend {
         placement: String,
         after: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
-        let mut tx = self.prepare_local_move(replica, node, new_parent, placement, after)?;
-        tx.commit()
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+        let replica = ReplicaId(replica.to_vec());
+        let node = bytes16_to_node(&node).map_err(map_core_err)?;
+        let new_parent = bytes16_to_node(&new_parent).map_err(map_core_err)?;
+        let after = after.map(|bytes| bytes16_to_node(&bytes).map_err(map_core_err)).transpose()?;
+        let result = treecrdt_postgres::local_move(
+            &client,
+            &self.doc_id,
+            &replica,
+            node,
+            new_parent,
+            &placement,
+            after,
+        )
+        .map_err(map_core_err)?;
+        local_result_to_native(result).map_err(map_core_err)
     }
 
     #[napi]
@@ -744,7 +812,7 @@ impl PgBackend {
         new_parent: Buffer,
         placement: String,
         after: Option<Buffer>,
-    ) -> napi::Result<NativePreparedLocalOpTx> {
+    ) -> napi::Result<Option<NativePreparedLocalOp>> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
@@ -756,7 +824,7 @@ impl PgBackend {
             Some(b) => Some(bytes16_to_node(&b).map_err(map_core_err)?),
         };
 
-        let tx = treecrdt_postgres::prepare_local_move_tx(
+        let result = treecrdt_postgres::try_prepare_local_move(
             &client,
             &self.doc_id,
             &replica,
@@ -766,13 +834,18 @@ impl PgBackend {
             after_id,
         )
         .map_err(map_core_err)?;
-        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
+        Ok(prepared_local_to_native(&self.url, result))
     }
 
     #[napi]
     pub fn local_delete(&self, replica: Buffer, node: Buffer) -> napi::Result<NativeLocalOpResult> {
-        let mut tx = self.prepare_local_delete(replica, node)?;
-        tx.commit()
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+        let replica = ReplicaId(replica.to_vec());
+        let node = bytes16_to_node(&node).map_err(map_core_err)?;
+        let result = treecrdt_postgres::local_delete(&client, &self.doc_id, &replica, node)
+            .map_err(map_core_err)?;
+        local_result_to_native(result).map_err(map_core_err)
     }
 
     #[napi]
@@ -780,15 +853,16 @@ impl PgBackend {
         &self,
         replica: Buffer,
         node: Buffer,
-    ) -> napi::Result<NativePreparedLocalOpTx> {
+    ) -> napi::Result<Option<NativePreparedLocalOp>> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let tx = treecrdt_postgres::prepare_local_delete_tx(&client, &self.doc_id, &replica, node)
-            .map_err(map_core_err)?;
-        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
+        let result =
+            treecrdt_postgres::try_prepare_local_delete(&client, &self.doc_id, &replica, node)
+                .map_err(map_core_err)?;
+        Ok(prepared_local_to_native(&self.url, result))
     }
 
     #[napi]
@@ -798,8 +872,19 @@ impl PgBackend {
         node: Buffer,
         payload: Option<Buffer>,
     ) -> napi::Result<NativeLocalOpResult> {
-        let mut tx = self.prepare_local_payload(replica, node, payload)?;
-        tx.commit()
+        let client = connect(&self.url)?;
+        let client = std::rc::Rc::new(std::cell::RefCell::new(client));
+        let replica = ReplicaId(replica.to_vec());
+        let node = bytes16_to_node(&node).map_err(map_core_err)?;
+        let result = treecrdt_postgres::local_payload(
+            &client,
+            &self.doc_id,
+            &replica,
+            node,
+            payload.map(|value| value.to_vec()),
+        )
+        .map_err(map_core_err)?;
+        local_result_to_native(result).map_err(map_core_err)
     }
 
     #[napi]
@@ -808,13 +893,13 @@ impl PgBackend {
         replica: Buffer,
         node: Buffer,
         payload: Option<Buffer>,
-    ) -> napi::Result<NativePreparedLocalOpTx> {
+    ) -> napi::Result<Option<NativePreparedLocalOp>> {
         let client = connect(&self.url)?;
         let client = std::rc::Rc::new(std::cell::RefCell::new(client));
 
         let replica = ReplicaId(replica.to_vec());
         let node = bytes16_to_node(&node).map_err(map_core_err)?;
-        let tx = treecrdt_postgres::prepare_local_payload_tx(
+        let result = treecrdt_postgres::try_prepare_local_payload(
             &client,
             &self.doc_id,
             &replica,
@@ -822,6 +907,6 @@ impl PgBackend {
             payload.map(|p| p.to_vec()),
         )
         .map_err(map_core_err)?;
-        Ok(NativePreparedLocalOpTx { tx: Some(tx) })
+        Ok(prepared_local_to_native(&self.url, result))
     }
 }

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -116,7 +116,7 @@ pub struct NativeLocalOpResult {
 #[napi(object)]
 pub struct NativeLocalOpAuthProof {
     pub sig: Buffer,
-    pub proof_ref: Option<Buffer>,
+    pub proof_ref: Buffer,
 }
 
 #[napi]
@@ -161,7 +161,7 @@ impl NativePreparedLocalOp {
             proposal,
             treecrdt_postgres::LocalOpAuthProof {
                 sig: proof.sig.to_vec(),
-                proof_ref: proof.proof_ref.map(|value| value.to_vec()),
+                proof_ref: proof.proof_ref.to_vec(),
             },
         )
         .map_err(map_core_err)?;

--- a/packages/treecrdt-postgres-napi/src/client.ts
+++ b/packages/treecrdt-postgres-napi/src/client.ts
@@ -16,8 +16,9 @@ import {
   loadNative,
   type NativeLocalOpResult,
   type NativeMaterializationOutcome,
-  type NativePreparedLocalOpTx,
+  type NativePreparedLocalOp,
 } from './native.js';
+import { commitOptimisticAuthorizedLocalWrite } from './optimistic-local.js';
 
 function ensureNonEmptyString(name: string, value: string): void {
   if (typeof value !== 'string' || value.length === 0) {
@@ -68,27 +69,38 @@ export async function createTreecrdtPostgresClient(
     emitNativeOutcome(result.outcome, writeId);
     return nativeToOperation(result.op);
   };
-  const finishPreparedLocalOp = async (
-    tx: NativePreparedLocalOpTx,
-    writeOpts?: LocalWriteOptions,
-  ): Promise<Operation> => {
-    if (writeOpts?.authSession) {
-      const op = nativeToOperation(tx.op());
-      try {
-        await writeOpts.authSession.authorizeLocalOps([op]);
-      } catch (err) {
-        try {
-          tx.rollback();
-        } catch {
-          // Preserve the auth failure. The native transaction also rolls back on drop.
-        }
-        throw err;
-      }
-    }
-    return finishLocalOp(tx.commit(), writeOpts?.writeId);
-  };
   const ensureMaterializedImpl = () => {
     emitNativeOutcome(backend.ensureMaterialized());
+  };
+
+  const finishOptimisticLocalOp = async (
+    immediate: () => NativeLocalOpResult,
+    prepare: () => NativePreparedLocalOp | null,
+    writeOpts?: LocalWriteOptions,
+  ): Promise<Operation> => {
+    const authSession = writeOpts?.authSession;
+    if (!authSession) return finishLocalOp(immediate(), writeOpts?.writeId);
+
+    return commitOptimisticAuthorizedLocalWrite({
+      authSession,
+      prepare: () => {
+        const nativeProposal = prepare();
+        if (!nativeProposal) return null;
+        emitNativeOutcome(nativeProposal.recoveryOutcome());
+        const operation = nativeToOperation(nativeProposal.op());
+        return {
+          operation,
+          commit: (proof) => {
+            // The co-located treecrdt_sync_op_auth row is the authoritative crash-safe proof.
+            // Auth stores in another database are only mirrors; this transaction cannot include
+            // them.
+            const result = nativeProposal.commit(proof);
+            return result ? { operation: nativeToOperation(result.op), value: result } : null;
+          },
+        };
+      },
+      onCommitted: (result) => emitNativeOutcome(result.outcome, writeOpts?.writeId),
+    });
   };
 
   const encodeReplica = (replica: Operation['meta']['id']['replica']): Uint8Array =>
@@ -172,15 +184,17 @@ export async function createTreecrdtPostgresClient(
     writeOpts?: LocalWriteOptions,
   ) => {
     const { type, after } = placementToArgs(placement);
-    const tx = backend.prepareLocalInsert(
-      encodeReplica(replica),
-      nodeIdToBytes16(parent),
-      nodeIdToBytes16(node),
-      type,
-      after,
-      payload,
+    const replicaBytes = Uint8Array.from(encodeReplica(replica));
+    const parentBytes = nodeIdToBytes16(parent);
+    const nodeBytes = nodeIdToBytes16(node);
+    const afterBytes = after ? Uint8Array.from(after) : null;
+    const payloadBytes = payload === null ? null : Uint8Array.from(payload);
+    const args = [replicaBytes, parentBytes, nodeBytes, type, afterBytes, payloadBytes] as const;
+    return finishOptimisticLocalOp(
+      () => backend.localInsert(...args),
+      () => backend.prepareLocalInsert(...args),
+      writeOpts,
     );
-    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   const localMoveImpl = async (
@@ -191,14 +205,18 @@ export async function createTreecrdtPostgresClient(
     writeOpts?: LocalWriteOptions,
   ) => {
     const { type, after } = placementToArgs(placement);
-    const tx = backend.prepareLocalMove(
-      encodeReplica(replica),
+    const args = [
+      Uint8Array.from(encodeReplica(replica)),
       nodeIdToBytes16(node),
       nodeIdToBytes16(newParent),
       type,
-      after,
+      after ? Uint8Array.from(after) : null,
+    ] as const;
+    return finishOptimisticLocalOp(
+      () => backend.localMove(...args),
+      () => backend.prepareLocalMove(...args),
+      writeOpts,
     );
-    return finishPreparedLocalOp(tx, writeOpts);
   };
 
   const localDeleteImpl = async (
@@ -206,8 +224,12 @@ export async function createTreecrdtPostgresClient(
     node: string,
     writeOpts?: LocalWriteOptions,
   ) => {
-    const tx = backend.prepareLocalDelete(encodeReplica(replica), nodeIdToBytes16(node));
-    return finishPreparedLocalOp(tx, writeOpts);
+    const args = [Uint8Array.from(encodeReplica(replica)), nodeIdToBytes16(node)] as const;
+    return finishOptimisticLocalOp(
+      () => backend.localDelete(...args),
+      () => backend.prepareLocalDelete(...args),
+      writeOpts,
+    );
   };
 
   const localPayloadImpl = async (
@@ -216,8 +238,16 @@ export async function createTreecrdtPostgresClient(
     payload: Uint8Array | null,
     writeOpts?: LocalWriteOptions,
   ) => {
-    const tx = backend.prepareLocalPayload(encodeReplica(replica), nodeIdToBytes16(node), payload);
-    return finishPreparedLocalOp(tx, writeOpts);
+    const args = [
+      Uint8Array.from(encodeReplica(replica)),
+      nodeIdToBytes16(node),
+      payload === null ? null : Uint8Array.from(payload),
+    ] as const;
+    return finishOptimisticLocalOp(
+      () => backend.localPayload(...args),
+      () => backend.prepareLocalPayload(...args),
+      writeOpts,
+    );
   };
 
   const local = createTreecrdtEngineLocal({

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -47,10 +47,17 @@ export type NativeLocalOpResult = {
   outcome: NativeMaterializationOutcome;
 };
 
-export type NativePreparedLocalOpTx = {
+export type NativeLocalOpAuthProof = {
+  sig: Uint8Array;
+  proofRef?: Uint8Array | null;
+};
+
+/** Owned proposal; the native layer retains no connection, transaction, or row lock. */
+export type NativePreparedLocalOp = {
   op(): NativeOp;
-  commit(): NativeLocalOpResult;
-  rollback(): void;
+  recoveryOutcome(): NativeMaterializationOutcome;
+  /** `null` is the only retryable optimistic-conflict signal. */
+  commit(proof: NativeLocalOpAuthProof): NativeLocalOpResult | null;
 };
 
 export type NativeBackend = {
@@ -95,7 +102,7 @@ export type NativeBackend = {
     placement: string,
     after: Uint8Array | null,
     payload: Uint8Array | null,
-  ): NativePreparedLocalOpTx;
+  ): NativePreparedLocalOp | null;
   localMove(
     replica: Uint8Array,
     node: Uint8Array,
@@ -109,9 +116,9 @@ export type NativeBackend = {
     newParent: Uint8Array,
     placement: string,
     after: Uint8Array | null,
-  ): NativePreparedLocalOpTx;
+  ): NativePreparedLocalOp | null;
   localDelete(replica: Uint8Array, node: Uint8Array): NativeLocalOpResult;
-  prepareLocalDelete(replica: Uint8Array, node: Uint8Array): NativePreparedLocalOpTx;
+  prepareLocalDelete(replica: Uint8Array, node: Uint8Array): NativePreparedLocalOp | null;
   localPayload(
     replica: Uint8Array,
     node: Uint8Array,
@@ -121,7 +128,7 @@ export type NativeBackend = {
     replica: Uint8Array,
     node: Uint8Array,
     payload: Uint8Array | null,
-  ): NativePreparedLocalOpTx;
+  ): NativePreparedLocalOp | null;
 };
 
 export type NativeFactory = {

--- a/packages/treecrdt-postgres-napi/src/native.ts
+++ b/packages/treecrdt-postgres-napi/src/native.ts
@@ -49,7 +49,7 @@ export type NativeLocalOpResult = {
 
 export type NativeLocalOpAuthProof = {
   sig: Uint8Array;
-  proofRef?: Uint8Array | null;
+  proofRef: Uint8Array;
 };
 
 /** Owned proposal; the native layer retains no connection, transaction, or row lock. */

--- a/packages/treecrdt-postgres-napi/src/optimistic-local.ts
+++ b/packages/treecrdt-postgres-napi/src/optimistic-local.ts
@@ -68,13 +68,14 @@ export async function commitOptimisticAuthorizedLocalWrite<T>(
     if (
       !(sig instanceof Uint8Array) ||
       sig.length !== 64 ||
-      (proofRef !== undefined && (!(proofRef instanceof Uint8Array) || proofRef.length !== 16))
+      !(proofRef instanceof Uint8Array) ||
+      proofRef.length !== 16
     ) {
       throw new Error('authorizeLocalOps returned an invalid operation proof');
     }
     const proofSnapshot = {
       sig: Uint8Array.from(sig),
-      ...(proofRef !== undefined ? { proofRef: Uint8Array.from(proofRef) } : {}),
+      proofRef: Uint8Array.from(proofRef),
     };
     const committed = proposal.commit(proofSnapshot);
     if (!committed) {

--- a/packages/treecrdt-postgres-napi/src/optimistic-local.ts
+++ b/packages/treecrdt-postgres-napi/src/optimistic-local.ts
@@ -1,0 +1,92 @@
+import { isDeepStrictEqual } from 'node:util';
+
+import type { Operation } from '@treecrdt/interface';
+import { type LocalWriteAuthProof, type LocalWriteAuthSession } from '@treecrdt/interface/engine';
+
+const POSTGRES_LOCAL_AUTH_MAX_ATTEMPTS = 4;
+
+type OptimisticLocalProposal<T> = {
+  operation: Operation;
+  /** `null` is the only retryable conflict signal; thrown failures are terminal. */
+  commit: (proof: LocalWriteAuthProof) => { operation: Operation; value: T } | null;
+};
+
+type OptimisticLocalWriteOptions<T> = {
+  authSession: LocalWriteAuthSession;
+  prepare: () => OptimisticLocalProposal<T> | null;
+  onCommitted: (value: T) => void;
+  maxAttempts?: number;
+};
+
+function assertExactAuthOperation(expected: Operation, actual: readonly Operation[]): void {
+  let unchanged = false;
+  try {
+    unchanged = actual.length === 1 && isDeepStrictEqual(actual[0], expected);
+  } catch {
+    // Treat hostile proxies and other comparison failures as mutation.
+  }
+  if (!unchanged) {
+    throw new Error('treecrdt: local authorization mutated the proposed operation');
+  }
+}
+
+/**
+ * Authorize and optimistically commit one exact PostgreSQL-backed local operation.
+ *
+ * Only explicit `null` prepare/commit results are retried. Policy, verifier, database, codec, proof,
+ * and listener failures remain terminal, so callers cannot accidentally remint after a real error.
+ */
+export async function commitOptimisticAuthorizedLocalWrite<T>(
+  options: OptimisticLocalWriteOptions<T>,
+): Promise<Operation> {
+  const maxAttempts = options.maxAttempts ?? POSTGRES_LOCAL_AUTH_MAX_ATTEMPTS;
+  const waitForConflict = (attempt: number) =>
+    attempt < maxAttempts
+      ? new Promise<void>((resolve) => setTimeout(resolve, attempt - 1))
+      : Promise.resolve();
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const proposal = options.prepare();
+    if (!proposal) {
+      await waitForConflict(attempt);
+      continue;
+    }
+
+    // Keep the Rust-backed proposal private. Auth hooks receive an isolated clone while another
+    // clone remains untouched for exact structural and typed-array byte comparisons.
+    const expectedOperation = structuredClone(proposal.operation);
+    const authOperations = [structuredClone(expectedOperation)];
+    const proofs = await options.authSession.authorizeLocalOps(authOperations);
+    assertExactAuthOperation(expectedOperation, authOperations);
+    if (!Array.isArray(proofs) || proofs.length !== 1) {
+      throw new Error('authorizeLocalOps must return exactly one proof for one operation');
+    }
+    const proof = proofs[0];
+    if (!proof) {
+      throw new Error('authorizeLocalOps returned an invalid operation proof');
+    }
+    const { sig, proofRef } = proof;
+    if (
+      !(sig instanceof Uint8Array) ||
+      sig.length !== 64 ||
+      (proofRef !== undefined && (!(proofRef instanceof Uint8Array) || proofRef.length !== 16))
+    ) {
+      throw new Error('authorizeLocalOps returned an invalid operation proof');
+    }
+    const proofSnapshot = {
+      sig: Uint8Array.from(sig),
+      ...(proofRef !== undefined ? { proofRef: Uint8Array.from(proofRef) } : {}),
+    };
+    const committed = proposal.commit(proofSnapshot);
+    if (!committed) {
+      await waitForConflict(attempt);
+      continue;
+    }
+
+    options.onCommitted(committed.value);
+    return committed.operation;
+  }
+
+  throw new Error(
+    `treecrdt: local authorization could not commit after ${maxAttempts} attempts because PostgreSQL state kept changing`,
+  );
+}

--- a/packages/treecrdt-postgres-napi/tests/optimistic-local.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/optimistic-local.test.ts
@@ -1,0 +1,175 @@
+import { expect, test, vi } from 'vitest';
+
+import type { Operation } from '@treecrdt/interface';
+
+import { commitOptimisticAuthorizedLocalWrite } from '../dist/optimistic-local.js';
+
+const root = '0'.repeat(32);
+const replica = Uint8Array.from({ length: 32 }, (_, index) => (index === 31 ? 1 : 0));
+
+function node(value: number): string {
+  return value.toString(16).padStart(32, '0');
+}
+
+function insert(counter: number, target: string): Operation {
+  return {
+    meta: { id: { replica, counter }, lamport: counter },
+    kind: {
+      type: 'insert',
+      parent: root,
+      node: target,
+      orderKey: Uint8Array.of(counter),
+    },
+  };
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function proofPersistingCommit(operation: Operation) {
+  const proofRows: Uint8Array[] = [];
+  const commit = vi.fn((proof: { sig: Uint8Array }) => {
+    proofRows.push(proof.sig);
+    return { operation, value: operation };
+  });
+  return { commit, proofRows };
+}
+
+test('authorization holds no lock and a conflict gets a fresh op, auth, and atomic proof', async () => {
+  let revision = 0;
+  const firstTarget = node(1);
+  const secondTarget = node(2);
+  const firstAuthorizationStarted = deferred();
+  const releaseFirstAuthorization = deferred();
+  const emitted: string[] = [];
+  const atomicallyPersisted: string[] = [];
+  const firstAuthorizedCounters: number[] = [];
+
+  const prepare = (target: string) => {
+    const proposalRevision = revision;
+    const operation = insert(proposalRevision + 1, target);
+    return {
+      operation,
+      commit: (proof: { sig: Uint8Array }) => {
+        if (revision !== proposalRevision) return null;
+        revision += 1;
+        atomicallyPersisted.push(`${target}-${proof.sig[0]}`);
+        return { operation, value: { operation } };
+      },
+    };
+  };
+  const proofFor = (ops: readonly Operation[]) => [
+    { sig: new Uint8Array(64).fill(ops[0]!.meta.id.counter) },
+  ];
+  const firstAuth = {
+    authorizeLocalOps: vi.fn(async (ops: readonly Operation[]) => {
+      firstAuthorizedCounters.push(ops[0]!.meta.id.counter);
+      if (firstAuthorizedCounters.length === 1) {
+        firstAuthorizationStarted.resolve();
+        await releaseFirstAuthorization.promise;
+      }
+      return proofFor(ops);
+    }),
+  };
+  const secondAuth = {
+    authorizeLocalOps: vi.fn(async (ops: readonly Operation[]) => proofFor(ops)),
+  };
+  const run = (target: string, authSession: typeof firstAuth | typeof secondAuth) =>
+    commitOptimisticAuthorizedLocalWrite({
+      authSession,
+      prepare: () => prepare(target),
+      onCommitted: (value) => emitted.push(value.operation.kind.node),
+    });
+
+  const first = run(firstTarget, firstAuth);
+  await firstAuthorizationStarted.promise;
+
+  // This is the deadlock regression: a second synchronous native write completes while the first
+  // authorization promise is intentionally unresolved.
+  await expect(run(secondTarget, secondAuth)).resolves.toMatchObject({
+    kind: { node: secondTarget },
+  });
+  releaseFirstAuthorization.resolve();
+  await expect(first).resolves.toMatchObject({ kind: { node: firstTarget } });
+
+  expect(firstAuthorizedCounters).toEqual([1, 2]);
+  expect(atomicallyPersisted).toEqual([`${secondTarget}-1`, `${firstTarget}-2`]);
+  expect(emitted).toEqual([secondTarget, firstTarget]);
+  expect(revision).toBe(2);
+});
+
+test('invalid proof fails before native commit', async () => {
+  const target = node(3);
+  const operation = insert(1, target);
+  const commit = vi.fn(() => ({ operation, value: operation }));
+
+  await expect(
+    commitOptimisticAuthorizedLocalWrite({
+      authSession: {
+        authorizeLocalOps: async () => [
+          { sig: Uint8Array.of(1), proofRef: Uint8Array.of(1) },
+        ],
+      },
+      prepare: () => ({
+        operation,
+        commit,
+      }),
+      onCommitted: () => {},
+    }),
+  ).rejects.toThrow(/invalid operation proof/);
+  expect(commit).not.toHaveBeenCalled();
+});
+
+test('proof buffers are snapshotted before native commit', async () => {
+  const operation = insert(1, node(31));
+  const sig = new Uint8Array(64).fill(7);
+  const proofRef = new Uint8Array(16).fill(8);
+  const commit = vi.fn((proof: { sig: Uint8Array; proofRef?: Uint8Array }) => {
+    expect(proof.sig).not.toBe(sig);
+    expect(proof.proofRef).not.toBe(proofRef);
+    proof.sig[0] = 9;
+    proof.proofRef![0] = 10;
+    return { operation, value: operation };
+  });
+
+  await expect(
+    commitOptimisticAuthorizedLocalWrite({
+      authSession: {
+        authorizeLocalOps: async () => [{ sig, proofRef }],
+      },
+      prepare: () => ({ operation, commit }),
+      onCommitted: () => {},
+    }),
+  ).resolves.toEqual(operation);
+
+  expect(sig[0]).toBe(7);
+  expect(proofRef[0]).toBe(8);
+});
+
+test('authorization metadata mutation cannot reach native commit or proof storage', async () => {
+  const target = node(4);
+  const operation = insert(1, target);
+  const { commit, proofRows } = proofPersistingCommit(operation);
+
+  await expect(
+    commitOptimisticAuthorizedLocalWrite({
+      authSession: {
+        authorizeLocalOps: async (ops) => {
+          ops[0]!.meta.id.counter += 1;
+          return [{ sig: new Uint8Array(64) }];
+        },
+      },
+      prepare: () => ({ operation, commit }),
+      onCommitted: () => {},
+    }),
+  ).rejects.toThrow(/mutated the proposed operation/);
+
+  expect(operation.meta.id.counter).toBe(1);
+  expect(commit).not.toHaveBeenCalled();
+  expect(proofRows).toEqual([]);
+});

--- a/packages/treecrdt-postgres-napi/tests/optimistic-local.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/optimistic-local.test.ts
@@ -33,7 +33,7 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 
 function proofPersistingCommit(operation: Operation) {
   const proofRows: Uint8Array[] = [];
-  const commit = vi.fn((proof: { sig: Uint8Array }) => {
+  const commit = vi.fn((proof: { sig: Uint8Array; proofRef: Uint8Array }) => {
     proofRows.push(proof.sig);
     return { operation, value: operation };
   });
@@ -55,7 +55,7 @@ test('authorization holds no lock and a conflict gets a fresh op, auth, and atom
     const operation = insert(proposalRevision + 1, target);
     return {
       operation,
-      commit: (proof: { sig: Uint8Array }) => {
+      commit: (proof: { sig: Uint8Array; proofRef: Uint8Array }) => {
         if (revision !== proposalRevision) return null;
         revision += 1;
         atomicallyPersisted.push(`${target}-${proof.sig[0]}`);
@@ -64,7 +64,10 @@ test('authorization holds no lock and a conflict gets a fresh op, auth, and atom
     };
   };
   const proofFor = (ops: readonly Operation[]) => [
-    { sig: new Uint8Array(64).fill(ops[0]!.meta.id.counter) },
+    {
+      sig: new Uint8Array(64).fill(ops[0]!.meta.id.counter),
+      proofRef: new Uint8Array(16),
+    },
   ];
   const firstAuth = {
     authorizeLocalOps: vi.fn(async (ops: readonly Operation[]) => {
@@ -111,9 +114,7 @@ test('invalid proof fails before native commit', async () => {
   await expect(
     commitOptimisticAuthorizedLocalWrite({
       authSession: {
-        authorizeLocalOps: async () => [
-          { sig: Uint8Array.of(1), proofRef: Uint8Array.of(1) },
-        ],
+        authorizeLocalOps: async () => [{ sig: Uint8Array.of(1), proofRef: Uint8Array.of(1) }],
       },
       prepare: () => ({
         operation,
@@ -129,11 +130,11 @@ test('proof buffers are snapshotted before native commit', async () => {
   const operation = insert(1, node(31));
   const sig = new Uint8Array(64).fill(7);
   const proofRef = new Uint8Array(16).fill(8);
-  const commit = vi.fn((proof: { sig: Uint8Array; proofRef?: Uint8Array }) => {
+  const commit = vi.fn((proof: { sig: Uint8Array; proofRef: Uint8Array }) => {
     expect(proof.sig).not.toBe(sig);
     expect(proof.proofRef).not.toBe(proofRef);
     proof.sig[0] = 9;
-    proof.proofRef![0] = 10;
+    proof.proofRef[0] = 10;
     return { operation, value: operation };
   });
 
@@ -161,7 +162,7 @@ test('authorization metadata mutation cannot reach native commit or proof storag
       authSession: {
         authorizeLocalOps: async (ops) => {
           ops[0]!.meta.id.counter += 1;
-          return [{ sig: new Uint8Array(64) }];
+          return [{ sig: new Uint8Array(64), proofRef: new Uint8Array(16) }];
         },
       },
       prepare: () => ({ operation, commit }),

--- a/packages/treecrdt-postgres-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-rs/src/lib.rs
@@ -12,8 +12,9 @@ mod schema;
 mod store;
 
 pub use local_ops::{
-    local_delete, local_insert, local_move, local_payload, prepare_local_delete_tx,
-    prepare_local_insert_tx, prepare_local_move_tx, prepare_local_payload_tx, PreparedLocalOpTx,
+    local_delete, local_insert, local_move, local_payload, try_commit_prepared_local,
+    try_prepare_local_delete, try_prepare_local_insert, try_prepare_local_move,
+    try_prepare_local_payload, LocalOpAuthProof, LocalOpResult, PreparedLocalOpProposal,
 };
 pub use reads::{
     get_ops_by_op_refs, list_op_refs_all, list_op_refs_children,

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -43,7 +43,7 @@ impl std::ops::Deref for LocalOpResult {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LocalOpAuthProof {
     pub sig: Vec<u8>,
-    pub proof_ref: Option<Vec<u8>>,
+    pub proof_ref: Vec<u8>,
 }
 
 #[derive(Clone, Debug)]
@@ -278,6 +278,9 @@ where
 {
     begin_tx(client)?;
     let result = (|| {
+        // A local write may be the first operation for a document. Create its revision row inside
+        // this same transaction before materialization takes the row lock.
+        ensure_doc_meta(client, doc_id)?;
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let prepared = build(&mut session.crdt)?;
         let (op, plan) = session.crdt.commit_prepared_local(prepared)?;
@@ -294,7 +297,7 @@ fn validate_local_auth_proof(proof: &LocalOpAuthProof) -> Result<()> {
             "local operation auth signature must be 64 bytes".into(),
         ));
     }
-    if proof.proof_ref.as_ref().is_some_and(|value| value.len() != 16) {
+    if proof.proof_ref.len() != 16 {
         return Err(Error::InvalidOperation(
             "local operation auth proof reference must be 16 bytes".into(),
         ));

--- a/packages/treecrdt-postgres-rs/src/local_ops.rs
+++ b/packages/treecrdt-postgres-rs/src/local_ops.rs
@@ -5,13 +5,15 @@ use postgres::Client;
 
 use treecrdt_core::{
     Error, LamportClock, LocalFinalizePlan, LocalPlacement, MaterializationCursor,
-    MaterializationOutcome, NodeId, Operation, PreparedLocalOp, ReplicaId, Result, TreeCrdt,
+    MaterializationOutcome, MaterializationState, NodeId, Operation,
+    PreparedLocalOp as CorePreparedLocalOp, ReplicaId, Result, TreeCrdt,
 };
 
+use crate::opref::derive_op_ref_v0;
 use crate::store::{
-    ensure_materialized_in_tx, load_tree_meta_for_update, set_tree_meta_replay_frontier,
-    update_tree_meta_head, PgCtx, PgNodeStore, PgOpStorage, PgParentOpIndex, PgPayloadStore,
-    TreeMeta,
+    ensure_doc_meta, ensure_materialized_in_tx, load_tree_meta_for_update,
+    set_tree_meta_replay_frontier, try_load_tree_meta_for_update, update_tree_meta_head, PgCtx,
+    PgNodeStore, PgOpStorage, PgParentOpIndex, PgPayloadStore, TreeMeta,
 };
 
 type LocalCrdt = TreeCrdt<PgOpStorage, LamportClock, PgNodeStore, PgPayloadStore>;
@@ -37,6 +39,80 @@ impl std::ops::Deref for LocalOpResult {
     }
 }
 
+/// Standard operation proof persisted atomically with an authenticated local operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LocalOpAuthProof {
+    pub sig: Vec<u8>,
+    pub proof_ref: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug)]
+enum LocalOpRequest {
+    Insert {
+        parent: NodeId,
+        node: NodeId,
+        placement: LocalPlacement,
+        payload: Option<Vec<u8>>,
+    },
+    Move {
+        node: NodeId,
+        new_parent: NodeId,
+        placement: LocalPlacement,
+    },
+    Delete {
+        node: NodeId,
+    },
+    Payload {
+        node: NodeId,
+        payload: Option<Vec<u8>>,
+    },
+}
+
+impl LocalOpRequest {
+    fn prepare(&self, crdt: &mut LocalCrdt) -> Result<CorePreparedLocalOp> {
+        match self {
+            Self::Insert {
+                parent,
+                node,
+                placement,
+                payload,
+            } => crdt.prepare_local_insert(*parent, *node, *placement, payload.clone()),
+            Self::Move {
+                node,
+                new_parent,
+                placement,
+            } => crdt.prepare_local_move(*node, *new_parent, *placement),
+            Self::Delete { node } => crdt.prepare_local_delete(*node),
+            Self::Payload { node, payload } => crdt.prepare_local_payload(*node, payload.clone()),
+        }
+    }
+}
+
+/// An exact local-operation proposal detached from its preparation transaction.
+///
+/// The proposal owns only values. It holds no PostgreSQL connection, row lock, or transaction, so
+/// callers may safely await authorization. Commit re-prepares the request under the same locked
+/// revision and accepts only the exact authorized operation.
+#[derive(Clone, Debug)]
+pub struct PreparedLocalOpProposal {
+    doc_id: String,
+    replica: ReplicaId,
+    request: LocalOpRequest,
+    op: Operation,
+    revision: MaterializationState,
+    recovery_outcome: MaterializationOutcome,
+}
+
+impl PreparedLocalOpProposal {
+    pub fn op(&self) -> &Operation {
+        &self.op
+    }
+
+    pub fn recovery_outcome(&self) -> &MaterializationOutcome {
+        &self.recovery_outcome
+    }
+}
+
 fn begin_tx(client: &Rc<RefCell<Client>>) -> Result<()> {
     let mut c = client.borrow_mut();
     c.batch_execute("BEGIN").map_err(|e| Error::Storage(e.to_string()))
@@ -52,17 +128,60 @@ fn rollback_tx(client: &Rc<RefCell<Client>>) -> Result<()> {
     c.batch_execute("ROLLBACK").map_err(|e| Error::Storage(e.to_string()))
 }
 
-fn begin_local_core_op(
+fn finish_tx<T>(client: &Rc<RefCell<Client>>, result: Result<T>) -> Result<T> {
+    match result {
+        Ok(value) => {
+            if let Err(error) = commit_tx(client) {
+                let _ = rollback_tx(client);
+                return Err(error);
+            }
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = rollback_tx(client);
+            Err(error)
+        }
+    }
+}
+
+fn finish_optimistic_tx<T>(
+    client: &Rc<RefCell<Client>>,
+    result: Result<Option<T>>,
+) -> Result<Option<T>> {
+    match result {
+        Ok(Some(value)) => finish_tx(client, Ok(value)).map(Some),
+        Ok(None) => {
+            rollback_tx(client)?;
+            Ok(None)
+        }
+        Err(error) => {
+            let _ = rollback_tx(client);
+            Err(error)
+        }
+    }
+}
+
+fn ensure_doc_meta_if_missing(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<()> {
+    let exists = {
+        let mut c = client.borrow_mut();
+        c.query_opt("SELECT 1 FROM treecrdt_meta WHERE doc_id = $1", &[&doc_id])
+            .map_err(|error| Error::Storage(error.to_string()))?
+            .is_some()
+    };
+    if exists {
+        Ok(())
+    } else {
+        ensure_doc_meta(client, doc_id)
+    }
+}
+
+fn local_op_session(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
+    meta: TreeMeta,
 ) -> Result<LocalOpSession> {
-    // Local ops take the opposite route from append_ops_in_tx: start from a clean materialized
-    // snapshot, then let TreeCrdt mint/store/apply the local op directly against Postgres stores.
-    ensure_materialized_in_tx(client, doc_id)?;
-    let meta = load_tree_meta_for_update(client, doc_id)?;
     let ctx = PgCtx::new(client.clone(), doc_id)?;
-
     let storage = PgOpStorage::new(ctx.clone());
     let nodes = PgNodeStore::new(ctx.clone());
     let payloads = PgPayloadStore::new(ctx.clone());
@@ -80,6 +199,17 @@ fn begin_local_core_op(
         nodes,
         crdt,
     })
+}
+
+fn begin_local_core_op(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+) -> Result<LocalOpSession> {
+    // Immediate local writes retain their original single-transaction behavior.
+    ensure_materialized_in_tx(client, doc_id)?;
+    let meta = load_tree_meta_for_update(client, doc_id)?;
+    local_op_session(client, doc_id, replica, meta)
 }
 
 fn finish_local_core_op(
@@ -137,79 +267,132 @@ fn finish_local_core_op(
     Ok(outcome)
 }
 
-pub struct PreparedLocalOpTx {
-    session: Option<LocalOpSession>,
-    prepared: Option<PreparedLocalOp>,
-}
-
-impl PreparedLocalOpTx {
-    pub fn op(&self) -> &Operation {
-        &self.prepared.as_ref().expect("prepared local op already closed").op
-    }
-
-    pub fn commit(mut self) -> Result<LocalOpResult> {
-        let mut session = self.session.take().expect("prepared local op already closed");
-        let prepared = self.prepared.take().expect("prepared local op already closed");
-        let res = (|| {
-            let (op, plan) = session.crdt.commit_prepared_local(prepared)?;
-            let outcome = finish_local_core_op(&mut session, &op, plan)?;
-            Ok(LocalOpResult { op, outcome })
-        })();
-
-        match res {
-            Ok(v) => {
-                if let Err(e) = commit_tx(&session.ctx.client) {
-                    let _ = rollback_tx(&session.ctx.client);
-                    return Err(e);
-                }
-                Ok(v)
-            }
-            Err(e) => {
-                let _ = rollback_tx(&session.ctx.client);
-                Err(e)
-            }
-        }
-    }
-
-    pub fn rollback(mut self) -> Result<()> {
-        let Some(session) = self.session.take() else {
-            return Ok(());
-        };
-        self.prepared.take();
-        rollback_tx(&session.ctx.client)
-    }
-}
-
-impl Drop for PreparedLocalOpTx {
-    fn drop(&mut self) {
-        if let Some(session) = self.session.take() {
-            let _ = rollback_tx(&session.ctx.client);
-        }
-    }
-}
-
-fn prepare_local_core_op<F>(
+fn commit_immediate_local<F>(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
     build: F,
-) -> Result<PreparedLocalOpTx>
+) -> Result<LocalOpResult>
 where
-    F: FnOnce(&mut LocalCrdt) -> Result<PreparedLocalOp>,
+    F: FnOnce(&mut LocalCrdt) -> Result<CorePreparedLocalOp>,
 {
     begin_tx(client)?;
-    let res = (|| {
+    let result = (|| {
         let mut session = begin_local_core_op(client, doc_id, replica)?;
         let prepared = build(&mut session.crdt)?;
-        Ok(PreparedLocalOpTx {
-            session: Some(session),
-            prepared: Some(prepared),
-        })
+        let (op, plan) = session.crdt.commit_prepared_local(prepared)?;
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        Ok(LocalOpResult { op, outcome })
     })();
-    if res.is_err() {
-        let _ = rollback_tx(client);
+
+    finish_tx(client, result)
+}
+
+fn validate_local_auth_proof(proof: &LocalOpAuthProof) -> Result<()> {
+    if proof.sig.len() != 64 {
+        return Err(Error::InvalidOperation(
+            "local operation auth signature must be 64 bytes".into(),
+        ));
     }
-    res
+    if proof.proof_ref.as_ref().is_some_and(|value| value.len() != 16) {
+        return Err(Error::InvalidOperation(
+            "local operation auth proof reference must be 16 bytes".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn persist_local_auth_proof(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    op: &Operation,
+    proof: &LocalOpAuthProof,
+) -> Result<()> {
+    let op_ref = derive_op_ref_v0(doc_id, op.meta.id.replica.as_bytes(), op.meta.id.counter);
+    let mut c = client.borrow_mut();
+    c.execute(
+        "INSERT INTO treecrdt_sync_op_auth \
+           (doc_id, op_ref, sig, proof_ref, created_at_ms) \
+         VALUES ($1, $2, $3, $4, \
+           (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint) \
+         ON CONFLICT (doc_id, op_ref) DO UPDATE SET \
+           sig = EXCLUDED.sig, \
+           proof_ref = EXCLUDED.proof_ref, \
+           created_at_ms = EXCLUDED.created_at_ms",
+        &[&doc_id, &op_ref.as_slice(), &proof.sig, &proof.proof_ref],
+    )
+    .map_err(|error| Error::Storage(error.to_string()))?;
+    Ok(())
+}
+
+fn try_prepare_local_request(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &ReplicaId,
+    request: LocalOpRequest,
+) -> Result<Option<PreparedLocalOpProposal>> {
+    // Create the revision row before the short proposal transaction. The returned proposal itself
+    // retains neither this client nor any transaction state.
+    ensure_doc_meta_if_missing(client, doc_id)?;
+    begin_tx(client)?;
+    let result = (|| {
+        let Some(mut meta) = try_load_tree_meta_for_update(client, doc_id)? else {
+            return Ok(None);
+        };
+        let recovery_outcome = if meta.0.replay_from.is_some() {
+            let outcome = ensure_materialized_in_tx(client, doc_id)?;
+            meta = load_tree_meta_for_update(client, doc_id)?;
+            outcome
+        } else {
+            MaterializationOutcome::empty(meta.0.head_seq())
+        };
+
+        let revision = meta.0.clone();
+        let mut session = local_op_session(client, doc_id, replica, meta)?;
+        let prepared = request.prepare(&mut session.crdt)?;
+        Ok(Some(PreparedLocalOpProposal {
+            doc_id: doc_id.to_string(),
+            replica: replica.clone(),
+            request,
+            op: prepared.op,
+            revision,
+            recovery_outcome,
+        }))
+    })();
+
+    finish_optimistic_tx(client, result)
+}
+
+pub fn try_commit_prepared_local(
+    client: &Rc<RefCell<Client>>,
+    proposal: PreparedLocalOpProposal,
+    proof: LocalOpAuthProof,
+) -> Result<Option<LocalOpResult>> {
+    // Keep user-controlled validation work outside the short row-locked transaction.
+    validate_local_auth_proof(&proof)?;
+    let doc_id = &proposal.doc_id;
+    begin_tx(client)?;
+    let result = (|| {
+        let Some(meta) = try_load_tree_meta_for_update(client, doc_id)? else {
+            return Ok(None);
+        };
+        if meta.0.replay_from.is_some() || meta.0 != proposal.revision {
+            return Ok(None);
+        }
+
+        let mut session = local_op_session(client, doc_id, &proposal.replica, meta)?;
+        let prepared = proposal.request.prepare(&mut session.crdt)?;
+        if prepared.op != proposal.op {
+            return Ok(None);
+        }
+
+        let (op, plan) = session.crdt.commit_prepared_local(prepared)?;
+        let outcome = finish_local_core_op(&mut session, &op, plan)?;
+        persist_local_auth_proof(client, doc_id, &op, &proof)?;
+        Ok(Some(LocalOpResult { op, outcome }))
+    })();
+
+    finish_optimistic_tx(client, result)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -223,14 +406,14 @@ pub fn local_insert(
     after: Option<NodeId>,
     payload: Option<Vec<u8>>,
 ) -> Result<LocalOpResult> {
-    prepare_local_insert_tx(
-        client, doc_id, replica, parent, node, placement, after, payload,
-    )?
-    .commit()
+    commit_immediate_local(client, doc_id, replica, |crdt| {
+        let placement = LocalPlacement::from_parts(placement, after)?;
+        crdt.prepare_local_insert(parent, node, placement, payload)
+    })
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn prepare_local_insert_tx(
+pub fn try_prepare_local_insert(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
@@ -239,11 +422,18 @@ pub fn prepare_local_insert_tx(
     placement: &str,
     after: Option<NodeId>,
     payload: Option<Vec<u8>>,
-) -> Result<PreparedLocalOpTx> {
-    prepare_local_core_op(client, doc_id, replica, |crdt| {
-        let placement = LocalPlacement::from_parts(placement, after)?;
-        crdt.prepare_local_insert(parent, node, placement, payload)
-    })
+) -> Result<Option<PreparedLocalOpProposal>> {
+    try_prepare_local_request(
+        client,
+        doc_id,
+        replica,
+        LocalOpRequest::Insert {
+            parent,
+            node,
+            placement: LocalPlacement::from_parts(placement, after)?,
+            payload,
+        },
+    )
 }
 
 pub fn local_move(
@@ -255,10 +445,13 @@ pub fn local_move(
     placement: &str,
     after: Option<NodeId>,
 ) -> Result<LocalOpResult> {
-    prepare_local_move_tx(client, doc_id, replica, node, new_parent, placement, after)?.commit()
+    commit_immediate_local(client, doc_id, replica, |crdt| {
+        let placement = LocalPlacement::from_parts(placement, after)?;
+        crdt.prepare_local_move(node, new_parent, placement)
+    })
 }
 
-pub fn prepare_local_move_tx(
+pub fn try_prepare_local_move(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
@@ -266,11 +459,17 @@ pub fn prepare_local_move_tx(
     new_parent: NodeId,
     placement: &str,
     after: Option<NodeId>,
-) -> Result<PreparedLocalOpTx> {
-    prepare_local_core_op(client, doc_id, replica, |crdt| {
-        let placement = LocalPlacement::from_parts(placement, after)?;
-        crdt.prepare_local_move(node, new_parent, placement)
-    })
+) -> Result<Option<PreparedLocalOpProposal>> {
+    try_prepare_local_request(
+        client,
+        doc_id,
+        replica,
+        LocalOpRequest::Move {
+            node,
+            new_parent,
+            placement: LocalPlacement::from_parts(placement, after)?,
+        },
+    )
 }
 
 pub fn local_delete(
@@ -279,18 +478,18 @@ pub fn local_delete(
     replica: &ReplicaId,
     node: NodeId,
 ) -> Result<LocalOpResult> {
-    prepare_local_delete_tx(client, doc_id, replica, node)?.commit()
+    commit_immediate_local(client, doc_id, replica, |crdt| {
+        crdt.prepare_local_delete(node)
+    })
 }
 
-pub fn prepare_local_delete_tx(
+pub fn try_prepare_local_delete(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
     node: NodeId,
-) -> Result<PreparedLocalOpTx> {
-    prepare_local_core_op(client, doc_id, replica, |crdt| {
-        crdt.prepare_local_delete(node)
-    })
+) -> Result<Option<PreparedLocalOpProposal>> {
+    try_prepare_local_request(client, doc_id, replica, LocalOpRequest::Delete { node })
 }
 
 pub fn local_payload(
@@ -300,17 +499,22 @@ pub fn local_payload(
     node: NodeId,
     payload: Option<Vec<u8>>,
 ) -> Result<LocalOpResult> {
-    prepare_local_payload_tx(client, doc_id, replica, node, payload)?.commit()
+    commit_immediate_local(client, doc_id, replica, |crdt| {
+        crdt.prepare_local_payload(node, payload)
+    })
 }
 
-pub fn prepare_local_payload_tx(
+pub fn try_prepare_local_payload(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,
     replica: &ReplicaId,
     node: NodeId,
     payload: Option<Vec<u8>>,
-) -> Result<PreparedLocalOpTx> {
-    prepare_local_core_op(client, doc_id, replica, |crdt| {
-        crdt.prepare_local_payload(node, payload)
-    })
+) -> Result<Option<PreparedLocalOpProposal>> {
+    try_prepare_local_request(
+        client,
+        doc_id,
+        replica,
+        LocalOpRequest::Payload { node, payload },
+    )
 }

--- a/packages/treecrdt-postgres-rs/src/schema.rs
+++ b/packages/treecrdt-postgres-rs/src/schema.rs
@@ -72,6 +72,17 @@ CREATE TABLE IF NOT EXISTS treecrdt_oprefs_children (
 
 CREATE INDEX IF NOT EXISTS idx_treecrdt_oprefs_children_doc_parent_seq
   ON treecrdt_oprefs_children (doc_id, parent, seq);
+
+-- Local authenticated writes persist their exact proof in the same transaction as the operation.
+-- @treecrdt/sync-postgres uses this same table as its standard proof-material store.
+CREATE TABLE IF NOT EXISTS treecrdt_sync_op_auth (
+  doc_id TEXT NOT NULL,
+  op_ref BYTEA NOT NULL,
+  sig BYTEA NOT NULL CHECK (octet_length(sig) = 64),
+  proof_ref BYTEA NOT NULL CHECK (octet_length(proof_ref) = 16),
+  created_at_ms BIGINT NOT NULL,
+  PRIMARY KEY (doc_id, op_ref)
+);
 "#;
 
 pub fn ensure_schema(client: &mut Client) -> Result<()> {
@@ -90,6 +101,12 @@ pub fn ensure_schema(client: &mut Client) -> Result<()> {
 }
 
 pub fn reset_doc_for_tests(client: &mut Client, doc_id: &str) -> Result<()> {
+    client
+        .execute(
+            "DELETE FROM treecrdt_sync_op_auth WHERE doc_id = $1",
+            &[&doc_id],
+        )
+        .map_err(|e| Error::Storage(format!("{e:?}")))?;
     client
         .execute(
             "DELETE FROM treecrdt_oprefs_children WHERE doc_id = $1",

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -20,7 +20,7 @@ pub(crate) use self::append::ensure_materialized_in_tx;
 pub use self::append::{append_ops, append_ops_with_materialization_outcome, ensure_materialized};
 pub(crate) use self::meta::{
     ensure_doc_meta, load_tree_meta_for_update, set_tree_meta_replay_frontier,
-    update_tree_meta_head, PgCtx, TreeMeta,
+    try_load_tree_meta_for_update, update_tree_meta_head, PgCtx, TreeMeta,
 };
 
 pub(crate) fn storage_debug<E: std::fmt::Debug>(e: E) -> Error {

--- a/packages/treecrdt-postgres-rs/src/store/meta.rs
+++ b/packages/treecrdt-postgres-rs/src/store/meta.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
-use postgres::{Client, Statement};
+use postgres::{error::SqlState, Client, Row, Statement};
 
 use treecrdt_core::{
     Error, Lamport, MaterializationCursor, MaterializationFrontier, MaterializationHead,
@@ -57,7 +57,10 @@ fn load_tree_meta_row(
     let rows = c.query(&stmt, &[&doc_id]).map_err(storage_debug)?;
 
     let row = rows.first().ok_or_else(|| Error::Storage("missing treecrdt_meta row".into()))?;
+    Ok(tree_meta_from_row(row))
+}
 
+fn tree_meta_from_row(row: &Row) -> TreeMeta {
     let head_lamport = row.get::<_, i64>(0).max(0) as Lamport;
     let head_replica = row.get::<_, Vec<u8>>(1);
     let head_counter = row.get::<_, i64>(2).max(0) as u64;
@@ -88,7 +91,7 @@ fn load_tree_meta_row(
         _ => None,
     };
 
-    Ok(TreeMeta(MaterializationState { head, replay_from }))
+    TreeMeta(MaterializationState { head, replay_from })
 }
 
 pub(super) fn load_tree_meta(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<TreeMeta> {
@@ -100,6 +103,31 @@ pub(crate) fn load_tree_meta_for_update(
     doc_id: &str,
 ) -> Result<TreeMeta> {
     load_tree_meta_row(client, doc_id, true)
+}
+
+/// Try to serialize a document writer without waiting for another transaction.
+///
+/// Synchronous N-API callers must not block the JavaScript event loop behind a writer whose
+/// progress may depend on that same event loop. `None` is therefore a normal optimistic conflict;
+/// every other database error remains a hard failure.
+pub(crate) fn try_load_tree_meta_for_update(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+) -> Result<Option<TreeMeta>> {
+    let mut c = client.borrow_mut();
+    let rows = match c.query(
+        "SELECT head_lamport, head_replica, head_counter, head_seq, \
+                replay_lamport, replay_replica, replay_counter \
+         FROM treecrdt_meta WHERE doc_id = $1 FOR UPDATE NOWAIT",
+        &[&doc_id],
+    ) {
+        Ok(rows) => rows,
+        Err(error) if error.code() == Some(&SqlState::LOCK_NOT_AVAILABLE) => return Ok(None),
+        Err(error) => return Err(storage_debug(error)),
+    };
+    let row = rows.first().ok_or_else(|| Error::Storage("missing treecrdt_meta row".into()))?;
+
+    Ok(Some(tree_meta_from_row(row)))
 }
 
 pub(crate) fn set_tree_meta_replay_frontier(

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -757,7 +757,7 @@ fn postgres_optimistic_local_proposal_does_not_hold_the_document_lock() {
         proposal,
         LocalOpAuthProof {
             sig: vec![8; 64],
-            proof_ref: None,
+            proof_ref: vec![5; 16],
         },
     )
     .unwrap()
@@ -782,7 +782,7 @@ fn postgres_optimistic_local_proposal_does_not_hold_the_document_lock() {
         retry,
         LocalOpAuthProof {
             sig: vec![9; 64],
-            proof_ref: Some(vec![6; 16]),
+            proof_ref: vec![6; 16],
         },
     )
     .unwrap()
@@ -801,7 +801,7 @@ fn postgres_optimistic_local_proposal_does_not_hold_the_document_lock() {
         )
         .unwrap();
     assert_eq!(proof_row.get::<_, Vec<u8>>(0), vec![9; 64]);
-    assert_eq!(proof_row.get::<_, Option<Vec<u8>>>(1), Some(vec![6; 16]));
+    assert_eq!(proof_row.get::<_, Vec<u8>>(1), vec![6; 16]);
     assert!(proof_row.get::<_, i64>(2) > 0);
 
     let mut locker = Client::connect(&url, NoTls).unwrap();
@@ -855,7 +855,7 @@ fn postgres_invalid_local_proof_is_rejected_before_the_operation() {
         proposal,
         LocalOpAuthProof {
             sig: vec![1; 63],
-            proof_ref: None,
+            proof_ref: vec![1; 16],
         },
     )
     .unwrap_err();

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -1,6 +1,8 @@
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::sync::OnceLock;
+use std::sync::{mpsc, OnceLock};
+use std::thread;
+use std::time::Duration;
 
 use postgres::{Client, NoTls};
 use uuid::Uuid;
@@ -9,8 +11,9 @@ use treecrdt_core::{MaterializationOutcome, NodeId, Operation, ReplicaId, Versio
 use treecrdt_postgres::{
     append_ops, append_ops_with_materialization_outcome, ensure_materialized, ensure_schema,
     get_ops_by_op_refs, list_op_refs_all, list_op_refs_children, local_delete, local_insert,
-    local_move, local_payload, max_lamport, prepare_local_insert_tx, replica_max_counter,
-    reset_doc_for_tests, tree_children, tree_payload,
+    local_move, local_payload, max_lamport, replica_max_counter, reset_doc_for_tests,
+    tree_children, tree_payload, try_commit_prepared_local, try_prepare_local_insert,
+    LocalOpAuthProof,
 };
 use treecrdt_test_support::{
     self as materialization_conformance, node, order_key_from_position,
@@ -688,59 +691,183 @@ fn postgres_backend_local_ops_drive_core_materialization_flow() {
 }
 
 #[test]
-fn postgres_backend_prepared_local_tx_rolls_back_until_committed() {
+fn postgres_optimistic_local_proposal_does_not_hold_the_document_lock() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let url = std::env::var("TREECRDT_POSTGRES_URL").unwrap();
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    {
+        let mut c = client.borrow_mut();
+        reset_doc_for_tests(&mut c, &doc_id).unwrap();
+    }
+    ensure_materialized(&client, &doc_id).unwrap();
+
+    let replica = ReplicaId::new(b"optimistic-auth");
+    let proposed_node = node(1201);
+    let proposal = try_prepare_local_insert(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        proposed_node,
+        "last",
+        None,
+        None,
+    )
+    .unwrap()
+    .expect("unexpected initial prepare conflict");
+    assert_eq!(proposal.op().meta.id.counter, 1);
+    // This write uses another connection while the first proposal is waiting for authorization.
+    // The old N-API design retained the meta-row lock here and made this synchronous call wait
+    // forever, which in turn prevented the first JavaScript authorization promise from resuming.
+    let concurrent_node = node(1202);
+    let concurrent_doc = doc_id.clone();
+    let concurrent_replica = replica.clone();
+    let writer_url = url.clone();
+    let (sent, received) = mpsc::channel();
+    let writer = thread::spawn(move || {
+        let concurrent = Client::connect(&writer_url, NoTls).unwrap();
+        let concurrent = Rc::new(RefCell::new(concurrent));
+        let result = local_insert(
+            &concurrent,
+            &concurrent_doc,
+            &concurrent_replica,
+            NodeId::ROOT,
+            concurrent_node,
+            "last",
+            None,
+            None,
+        )
+        .unwrap();
+        sent.send((result.op.meta.id.counter, result.op.meta.lamport)).unwrap();
+    });
+    assert_eq!(
+        received
+            .recv_timeout(Duration::from_secs(5))
+            .expect("concurrent writer blocked behind an authorization proposal"),
+        (1, 1),
+    );
+    writer.join().unwrap();
+
+    assert!(try_commit_prepared_local(
+        &client,
+        proposal,
+        LocalOpAuthProof {
+            sig: vec![8; 64],
+            proof_ref: None,
+        },
+    )
+    .unwrap()
+    .is_none());
+
+    let retry = try_prepare_local_insert(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        proposed_node,
+        "last",
+        None,
+        None,
+    )
+    .unwrap()
+    .expect("unexpected retry prepare conflict");
+    assert_eq!(retry.op().meta.id.counter, 2);
+    assert_eq!(retry.op().meta.lamport, 2);
+    let committed = try_commit_prepared_local(
+        &client,
+        retry,
+        LocalOpAuthProof {
+            sig: vec![9; 64],
+            proof_ref: Some(vec![6; 16]),
+        },
+    )
+    .unwrap()
+    .expect("unexpected retry commit conflict");
+    assert_eq!(committed.op.meta.id.counter, 2);
+    assert_eq!(
+        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
+        vec![concurrent_node, proposed_node],
+    );
+    let proof_row = client
+        .borrow_mut()
+        .query_one(
+            "SELECT sig, proof_ref, created_at_ms \
+             FROM treecrdt_sync_op_auth WHERE doc_id = $1",
+            &[&doc_id],
+        )
+        .unwrap();
+    assert_eq!(proof_row.get::<_, Vec<u8>>(0), vec![9; 64]);
+    assert_eq!(proof_row.get::<_, Option<Vec<u8>>>(1), Some(vec![6; 16]));
+    assert!(proof_row.get::<_, i64>(2) > 0);
+
+    let mut locker = Client::connect(&url, NoTls).unwrap();
+    locker.batch_execute("BEGIN").unwrap();
+    locker
+        .query_one(
+            "SELECT 1 FROM treecrdt_meta WHERE doc_id = $1 FOR UPDATE",
+            &[&doc_id],
+        )
+        .unwrap();
+
+    let result = try_prepare_local_insert(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        node(1210),
+        "last",
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(result.is_none());
+    locker.batch_execute("ROLLBACK").unwrap();
+}
+
+#[test]
+fn postgres_invalid_local_proof_is_rejected_before_the_operation() {
     let Some(client) = connect() else {
         return;
     };
     ensure_schema_once(&client);
 
     let doc_id = format!("test-{}", Uuid::new_v4());
-    {
-        let mut c = client.borrow_mut();
-        reset_doc_for_tests(&mut c, &doc_id).unwrap();
-    }
-
-    let replica = ReplicaId::new(b"loc-auth");
-    let node_rejected = node(1101);
-    let rejected = prepare_local_insert_tx(
+    ensure_materialized(&client, &doc_id).unwrap();
+    let proposal = try_prepare_local_insert(
         &client,
         &doc_id,
-        &replica,
+        &ReplicaId::new(b"atomic-proof"),
         NodeId::ROOT,
-        node_rejected,
-        "first",
+        node(1220),
+        "last",
         None,
         None,
     )
-    .unwrap();
-    assert_eq!(rejected.op().meta.id.counter, 1);
-    rejected.rollback().unwrap();
+    .unwrap()
+    .expect("unexpected prepare conflict");
+
+    let error = try_commit_prepared_local(
+        &client,
+        proposal,
+        LocalOpAuthProof {
+            sig: vec![1; 63],
+            proof_ref: None,
+        },
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("signature must be 64 bytes"));
     assert_eq!(op_count(&client, &doc_id), 0);
-    assert!(tree_children(&client, &doc_id, NodeId::ROOT).unwrap().is_empty());
-
-    let node_committed = node(1102);
-    let committed = prepare_local_insert_tx(
-        &client,
-        &doc_id,
-        &replica,
-        NodeId::ROOT,
-        node_committed,
-        "first",
-        None,
-        Some(vec![7]),
-    )
-    .unwrap();
-    assert_eq!(committed.op().meta.id.counter, 1);
-    let result = committed.commit().unwrap();
-
-    assert_eq!(result.op.kind.node(), node_committed);
-    assert_eq!(op_count(&client, &doc_id), 1);
-    assert_eq!(
-        tree_children(&client, &doc_id, NodeId::ROOT).unwrap(),
-        vec![node_committed]
-    );
-    assert_eq!(
-        tree_payload(&client, &doc_id, node_committed).unwrap(),
-        Some(vec![7])
-    );
+    let proof_count = client
+        .borrow_mut()
+        .query_one(
+            "SELECT COUNT(*) FROM treecrdt_sync_op_auth WHERE doc_id = $1",
+            &[&doc_id],
+        )
+        .unwrap()
+        .get::<_, i64>(0);
+    assert_eq!(proof_count, 0);
 }


### PR DESCRIPTION
## Problem

The PostgreSQL N-API client held a transaction/document lock while JavaScript authorization was awaited, and operation/proof writes lacked one commit boundary.

## Fix

Authenticated writes use three phases:

1. A short transaction repairs materialization, reads the document revision, and returns an exact detached proposal.
2. `authorizeLocalOps` runs with no transaction and returns one 64-byte signature plus one 16-byte proof reference.
3. A fresh `NOWAIT` transaction verifies the complete revision and exact proposal, then commits operation, materialization, metadata, and proof together.

An explicit conflict remints and reauthorizes a fresh proposal, up to four attempts. Other failures remain terminal.

## Clean-slate choice

- Only detached `try_prepare_*` APIs are exposed.
- There is one proof-bearing `try_commit_prepared_local` API.
- Proof columns are required and length-constrained.
- The transaction-owning wrapper, four `_tx` shims, optional proof hook, nullable reference, and proofless commit are removed.

The Rust and TypeScript halves stay in one PR because the new native object replaces the old commit API; splitting them would either leave the client runtime-broken or require temporary compatibility methods.

## Fast paths

- Writes without auth retain the direct one-connection/one-transaction path.
- Authorization holds no PostgreSQL transaction or row lock.
- The co-transactional proof row is authoritative; no second proof transaction is required.

## Size

12 files, **+993/-221** relative to #192.

## Verification

- PostgreSQL Rust suite (live cases require a database URL)
- PostgreSQL and N-API Rust builds/checks
- TypeScript build
- focused optimistic helper tests: 4/4
- live PostgreSQL coverage runs in CI

## Stack

Stacked on #192. This is the PostgreSQL sibling of SQLite #193-#195.
