### PR TITLE
fix: keep reserved sentinels virtual

### DIFF
--- a/.changeset/keep-reserved-sentinels-virtual.md
+++ b/.changeset/keep-reserved-sentinels-virtual.md
@@ -1,0 +1,9 @@
+---
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+---
+
+Keep the reserved TRASH node virtual across in-memory, SQLite, and PostgreSQL materialization.
+Operations that target TRASH, and structural operations that target ROOT, now remain deterministic
+no-ops without creating sentinel rows, payloads, or materialization events. ROOT payload operations
+remain supported.

--- a/packages/treecrdt-core/src/materialization.rs
+++ b/packages/treecrdt-core/src/materialization.rs
@@ -640,7 +640,8 @@ fn node_change_between(
                 }),
                 (Some(parent_before), Some(parent_after))
                     if parent_before != parent_after
-                        || previous.order_key != final_state.order_key =>
+                        || (parent_after != NodeId::TRASH
+                            && previous.order_key != final_state.order_key) =>
                 {
                     Some(MaterializationChange::Move {
                         node,
@@ -666,7 +667,10 @@ fn visible_changes_between(
 
     let mut changes = Vec::new();
     for node in all_nodes {
-        if node == NodeId::ROOT || node == NodeId::TRASH {
+        if node == NodeId::TRASH {
+            continue;
+        }
+        if node == NodeId::ROOT {
             changes.extend(payload_change_between(
                 node,
                 before.get(&node),

--- a/packages/treecrdt-core/src/traits.rs
+++ b/packages/treecrdt-core/src/traits.rs
@@ -419,7 +419,6 @@ impl NodeStore for MemoryNodeStore {
     }
 
     fn attach(&mut self, node: NodeId, parent: NodeId, order_key: Vec<u8>) -> Result<()> {
-        self.ensure_node(parent)?;
         self.ensure_node(node)?;
         self.get_state_mut(node)?.parent = Some(parent);
         self.get_state_mut(node)?.order_key = Some(order_key.clone());
@@ -427,6 +426,8 @@ impl NodeStore for MemoryNodeStore {
         if parent == NodeId::TRASH {
             return Ok(());
         }
+
+        self.ensure_node(parent)?;
 
         let existing = self.get_state(parent)?.children.clone();
         let mut idx = existing.len();

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -16,7 +16,7 @@ use crate::types::{
 };
 use crate::version_vector::VersionVector;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 struct NodeSnapshot {
     parent: Option<NodeId>,
     order_key: Option<Vec<u8>>,
@@ -62,6 +62,9 @@ fn rejected_structural_fallback_change(
     op: &Operation,
     source: Option<MaterializationSource>,
 ) -> Vec<MaterializationChange> {
+    if reserved_target_is_noop(op) {
+        return Vec::new();
+    }
     match &op.kind {
         // Insert payloads retain their independent LWW semantics even when the requested tree
         // attachment is rejected. Report the payload change without claiming the insert occurred.
@@ -77,6 +80,13 @@ fn rejected_structural_fallback_change(
         OperationKind::Insert { .. } | OperationKind::Move { .. } => Vec::new(),
         _ => direct_materialization_changes(None, op),
     }
+}
+
+/// TRASH and structural ROOT targets are virtual sentinels, not materialized nodes.
+fn reserved_target_is_noop(op: &Operation) -> bool {
+    let node = op.kind.node();
+    node == NodeId::TRASH
+        || (node == NodeId::ROOT && !matches!(&op.kind, OperationKind::Payload { .. }))
 }
 
 /// Generic Tree CRDT facade that wires clock and storage together.
@@ -183,6 +193,7 @@ where
                 }
                 Ok(Some(after_id))
             }
+            LocalPlacement::Last if parent == NodeId::TRASH => Ok(None),
             LocalPlacement::Last => {
                 let mut children = self.children(parent)?;
                 if let Some(excluded) = exclude {
@@ -569,7 +580,8 @@ where
                 node != NodeId::ROOT
                     && node != NodeId::TRASH
                     && self.nodes.parent(node)? == Some(*parent)
-                    && self.nodes.order_key(node)?.as_deref() == Some(order_key.as_slice())
+                    && (*parent == NodeId::TRASH
+                        || self.nodes.order_key(node)?.as_deref() == Some(order_key.as_slice()))
             }
             _ => false,
         };
@@ -919,10 +931,7 @@ where
                     order_key: self.nodes.order_key(node)?,
                 }
             } else {
-                NodeSnapshot {
-                    parent: None,
-                    order_key: None,
-                }
+                NodeSnapshot::default()
             };
             return Ok((
                 op,
@@ -1034,6 +1043,9 @@ where
         payloads: &mut P,
         op: &Operation,
     ) -> Result<(NodeSnapshot, bool)> {
+        if reserved_target_is_noop(op) {
+            return Ok((NodeSnapshot::default(), false));
+        }
         let snapshot = Self::snapshot(nodes, op)?;
         let emit_direct_change = match &op.kind {
             OperationKind::Insert {
@@ -1054,7 +1066,8 @@ where
                 order_key,
             } => {
                 let changes_position = snapshot.parent != Some(*new_parent)
-                    || snapshot.order_key.as_deref() != Some(order_key.as_slice());
+                    || (*new_parent != NodeId::TRASH
+                        && snapshot.order_key.as_deref() != Some(order_key.as_slice()));
                 Self::apply_move(nodes, op, *node, *new_parent, order_key.clone())?
                     && changes_position
             }
@@ -1102,12 +1115,16 @@ where
         {
             return Ok(false);
         }
-        nodes.ensure_node(parent)?;
+        if parent != NodeId::TRASH {
+            nodes.ensure_node(parent)?;
+        }
         nodes.ensure_node(node)?;
         nodes.detach(node)?;
         nodes.attach(node, parent, order_key)?;
         Self::update_structural_last_change(nodes, op, node)?;
-        Self::update_structural_last_change(nodes, op, parent)?;
+        if parent != NodeId::TRASH {
+            Self::update_structural_last_change(nodes, op, parent)?;
+        }
         Ok(true)
     }
 
@@ -1122,7 +1139,9 @@ where
             return Ok(false);
         }
         nodes.ensure_node(node)?;
-        nodes.ensure_node(new_parent)?;
+        if new_parent != NodeId::TRASH {
+            nodes.ensure_node(new_parent)?;
+        }
         if new_parent != NodeId::TRASH
             && (Self::introduces_cycle(nodes, node, new_parent)? || node == new_parent)
         {

--- a/packages/treecrdt-core/src/validation.rs
+++ b/packages/treecrdt-core/src/validation.rs
@@ -14,6 +14,16 @@ where
 {
     pub fn validate_invariants(&self) -> Result<()> {
         let nodes = self.node_store();
+        if nodes.exists(NodeId::TRASH)? {
+            return Err(Error::InvalidOperation(
+                "TRASH must remain a virtual sentinel".into(),
+            ));
+        }
+        if nodes.parent(NodeId::ROOT)?.is_some() {
+            return Err(Error::InvalidOperation(
+                "ROOT must not have a parent".into(),
+            ));
+        }
         for pid in nodes.all_nodes()? {
             let pchildren = nodes.children(pid)?;
             let mut seen = HashSet::new();

--- a/packages/treecrdt-core/tests/operations.rs
+++ b/packages/treecrdt-core/tests/operations.rs
@@ -215,33 +215,70 @@ fn rejected_cycle_move_emits_no_visible_change() {
     ));
     assert_eq!(crdt.parent(child).unwrap(), Some(parent));
     assert_eq!(crdt.payload(child).unwrap(), Some(vec![9]));
+}
 
-    for op in [
-        Operation::insert(
-            &ReplicaId::new(b"remote"),
-            4,
-            6,
-            NodeId::TRASH,
+#[test]
+fn reserved_sentinel_targets_never_materialize() {
+    let mut crdt = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let replica = ReplicaId::new(b"remote");
+    let orphan_parent = NodeId(42);
+    let mut seq = 0;
+    let mut index = NoopParentOpIndex;
+
+    let root_payload = Operation::set_payload(&replica, 1, 1, NodeId::ROOT, vec![7]);
+    crdt.apply_remote_with_materialization_seq(root_payload, &mut index, &mut seq)
+        .unwrap();
+    assert_eq!(crdt.payload(NodeId::ROOT).unwrap(), Some(vec![7]));
+
+    let mut known_state = treecrdt_core::VersionVector::new();
+    known_state.observe(&replica, 3);
+    let rejected = [
+        Operation::insert_with_payload(
+            &replica,
+            2,
+            2,
             NodeId::ROOT,
-            Vec::new(),
-        ),
-        Operation::move_node(
-            &ReplicaId::new(b"remote"),
-            5,
-            7,
             NodeId::TRASH,
-            root,
             vec![0, 1],
+            vec![9],
         ),
-    ] {
+        Operation::move_node(&replica, 3, 3, NodeId::TRASH, NodeId::ROOT, vec![0, 1]),
+        Operation::delete(&replica, 4, 4, NodeId::TRASH, Some(known_state.clone())),
+        Operation::tombstone(&replica, 5, 5, NodeId::TRASH),
+        Operation::set_payload(&replica, 6, 6, NodeId::TRASH, vec![9]),
+        Operation::insert_with_payload(
+            &replica,
+            7,
+            7,
+            orphan_parent,
+            NodeId::ROOT,
+            vec![0, 1],
+            vec![8],
+        ),
+        Operation::move_node(&replica, 8, 8, NodeId::ROOT, NodeId::TRASH, Vec::new()),
+        Operation::delete(&replica, 9, 9, NodeId::ROOT, Some(known_state)),
+        Operation::tombstone(&replica, 10, 10, NodeId::ROOT),
+    ];
+
+    for op in rejected {
         let delta = crdt
             .apply_remote_with_materialization_seq(op, &mut index, &mut seq)
             .unwrap()
             .unwrap();
         assert!(delta.changes.is_empty());
     }
+
+    assert!(!crdt.is_known(NodeId::TRASH).unwrap());
+    assert!(!crdt.is_known(orphan_parent).unwrap());
+    assert_eq!(crdt.payload(NodeId::TRASH).unwrap(), None);
     assert_eq!(crdt.parent(NodeId::ROOT).unwrap(), None);
-    assert_eq!(crdt.parent(NodeId::TRASH).unwrap(), None);
+    assert_eq!(crdt.payload(NodeId::ROOT).unwrap(), Some(vec![7]));
+    crdt.validate_invariants().unwrap();
 }
 
 #[test]

--- a/packages/treecrdt-core/tests/order_key_validation.rs
+++ b/packages/treecrdt-core/tests/order_key_validation.rs
@@ -13,6 +13,8 @@ fn structural_operation_validation_is_state_independent() {
         Operation::insert(&replica, 4, 4, NodeId::TRASH, NodeId(4), vec![0, 1]),
         Operation::move_node(&replica, 5, 5, NodeId(5), NodeId::ROOT, vec![]),
         Operation::move_node(&replica, 6, 6, NodeId(6), NodeId::TRASH, vec![0, 1]),
+        Operation::insert(&replica, 11, 11, NodeId::ROOT, NodeId::TRASH, vec![]),
+        Operation::move_node(&replica, 12, 12, NodeId::ROOT, NodeId::ROOT, vec![]),
     ];
     for op in invalid {
         assert!(
@@ -87,4 +89,7 @@ fn local_move_to_trash_uses_the_empty_sentinel_key() {
         unreachable!();
     };
     assert!(order_key.is_empty());
+    assert_eq!(tree.parent(node).unwrap(), None);
+    assert!(tree.children(NodeId::ROOT).unwrap().is_empty());
+    assert!(!tree.is_known(NodeId::TRASH).unwrap());
 }

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -149,6 +149,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioRejectsOperationIdEquivocationAtomically,
     },
     {
+      name: 'reserved sentinels stay virtual under remote operations',
+      run: scenarioReservedSentinelsStayVirtual,
+    },
+    {
       name: 'materialization events: structural batch',
       run: scenarioMaterializationEventStructuralBatch,
     },
@@ -736,6 +740,115 @@ async function scenarioRejectsOperationIdEquivocationAtomically(
     'null versus empty payload',
   );
   assertEqual((await engine.opRefs.all()).length, 2, 'conflicts must leave the op log unchanged');
+}
+
+async function scenarioReservedSentinelsStayVirtual(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('reserved-sentinel');
+  const trashParentReplica = replicaFromLabel('virtual-trash-parent');
+  const root = nodeIdFromInt(0);
+  const trash = 'f'.repeat(32);
+  const trashedNode = nodeIdFromInt(51);
+  const insertedUnderTrash = nodeIdFromInt(52);
+  const orphanParent = nodeIdFromInt(53);
+  const rootPayload = new Uint8Array([7]);
+
+  await engine.ops.append(
+    makePayloadOp({ replica, counter: 1, lamport: 1, node: root, payload: rootPayload }),
+  );
+  await engine.local.insert(trashParentReplica, root, trashedNode, { type: 'last' }, null);
+  const trashMoveEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.move(trashParentReplica, trashedNode, trash, { type: 'last' });
+  });
+  assertEqual(trashMoveEvents.length, 1, 'local TRASH move must emit one event');
+  const trashMoveChanges = trashMoveEvents
+    .flatMap((event) => event.changes)
+    .filter(
+      (change) =>
+        change.kind === 'move' && change.node === trashedNode && change.parentAfter === trash,
+    );
+  assertEqual(trashMoveChanges.length, 1, 'local move to virtual TRASH must emit exactly once');
+  const rootOps = await engine.ops.get(await engine.opRefs.children(root));
+  assert(
+    rootOps.some((op) => op.kind.type === 'move' && op.kind.node === trashedNode),
+    'move to virtual TRASH must remain discoverable from its former parent',
+  );
+  const directTrashInsertEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.insert(
+      trashParentReplica,
+      trash,
+      insertedUnderTrash,
+      { type: 'last' },
+      null,
+    );
+  });
+  assertEqual(directTrashInsertEvents.length, 1, 'insert under virtual TRASH must emit once');
+  const repeatedTrashMoveEvents = await captureMaterializationEvents(engine, async () => {
+    await engine.local.move(trashParentReplica, trashedNode, trash, { type: 'last' });
+  });
+  assertEqual(repeatedTrashMoveEvents.length, 0, 'repeated TRASH move must not emit a false move');
+
+  const events = await captureMaterializationEvents(engine, () =>
+    engine.ops.appendMany([
+      makeInsertOp({
+        replica,
+        counter: 2,
+        lamport: 2,
+        parent: root,
+        node: trash,
+        orderKey: orderKeyFromPosition(0),
+        payload: new Uint8Array([9]),
+      }),
+      makeInsertOp({
+        replica,
+        counter: 3,
+        lamport: 7,
+        parent: orphanParent,
+        node: root,
+        orderKey: orderKeyFromPosition(2),
+        payload: new Uint8Array([8]),
+      }),
+    ]),
+  );
+
+  assertEqual(events.length, 0, 'reserved-target operations must not emit visible changes');
+  assertEqual(await engine.tree.exists(trash), false, 'TRASH must not exist as a tree row');
+  assertEqual(
+    await engine.tree.exists(trashedNode),
+    true,
+    'a node under virtual TRASH must remain',
+  );
+  assertEqual(
+    await engine.tree.exists(insertedUnderTrash),
+    true,
+    'a node inserted under virtual TRASH must remain',
+  );
+  assertEqual(await engine.tree.nodeCount(), 2, 'TRASH itself must not contribute to nodeCount');
+  assertEqual(await engine.tree.parent(root), null, 'ROOT must remain parentless');
+  assertEqual(await engine.tree.exists(orphanParent), false, 'ROOT insert must not create parent');
+  assertBytesEqual(await engine.tree.getPayload(trash), null, 'TRASH payload must stay absent');
+  assertBytesEqual(
+    await engine.tree.getPayload(root),
+    rootPayload,
+    'structural ROOT operations must not overwrite its supported payload',
+  );
+  const dump = await engine.tree.dump();
+  assert(!dump.some((row) => row.node === trash), 'tree.dump must not expose TRASH');
+  assert(
+    dump.some((row) => row.node === trashedNode && row.parent === trash),
+    'the normal node must retain virtual TRASH as its stored parent',
+  );
+  assert(
+    dump.some((row) => row.node === insertedUnderTrash && row.parent === trash),
+    'a direct child must retain virtual TRASH as its stored parent',
+  );
+  const replayedRootOps = await engine.ops.get(await engine.opRefs.children(root));
+  assert(
+    replayedRootOps.some((op) => op.kind.type === 'move' && op.kind.node === trashedNode),
+    'canonical replay must preserve former-parent discovery for the TRASH move',
+  );
 }
 
 async function scenarioMaterializationEventStructuralBatch(

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -473,14 +473,13 @@ impl treecrdt_core::NodeStore for PgNodeStore {
             return Ok(());
         }
         self.ensure_node(node)?;
-        self.ensure_node(parent)?;
 
         let started_at = Instant::now();
         let node_bytes = node_to_bytes(node);
         let parent_bytes = node_to_bytes(parent);
-        let mut c = self.ctx.client.borrow_mut();
 
         if parent == NodeId::TRASH {
+            let mut c = self.ctx.client.borrow_mut();
             let stmt = self.ctx.stmt(
                 &mut c,
                 "UPDATE treecrdt_nodes \
@@ -509,6 +508,9 @@ impl treecrdt_core::NodeStore for PgNodeStore {
             }
             return Ok(());
         }
+
+        self.ensure_node(parent)?;
+        let mut c = self.ctx.client.borrow_mut();
 
         let stmt = self.ctx.stmt(
             &mut c,

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
@@ -382,7 +382,6 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             return Ok(());
         }
         self.ensure_node(node)?;
-        self.ensure_node(parent)?;
 
         let node_bytes = sqlite_node_id_bytes(node);
         let parent_bytes = sqlite_node_id_bytes(parent);
@@ -414,6 +413,8 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             }
             return Ok(());
         }
+
+        self.ensure_node(parent)?;
 
         unsafe {
             sqlite_clear_bindings(self.set_parent_order_key);

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
@@ -246,7 +246,9 @@ fn read_row(stmt: *mut sqlite3_stmt) -> Result<JsonOp, c_int> {
         } else {
             let ptr = sqlite_column_blob(stmt, 7) as *const u8;
             let len = sqlite_column_bytes(stmt, 7) as usize;
-            if ptr.is_null() {
+            if len == 0 {
+                Some(Vec::new())
+            } else if ptr.is_null() {
                 None
             } else {
                 Some(slice::from_raw_parts(ptr, len).to_vec())


### PR DESCRIPTION
## Problem

`ROOT` and `TRASH` are protocol sentinels, but materialization could treat them like application nodes before rejecting an operation. That could create physical sentinel rows, lose former-parent metadata, suppress the first move-to-Trash event, or emit false replay moves.

## Fix

- Canonical operations targeting `TRASH` are deterministic no-ops.
- Canonical structural inserts, moves, deletes, and tombstones targeting `ROOT` are deterministic no-ops.
- `Payload(ROOT, ...)` remains the supported document-level payload.
- Normal nodes may attach to virtual `TRASH` without creating a TRASH row.
- First/repeated moves and former-parent opRefs remain correct through canonical replay.
- Invariant validation rejects a physical TRASH row or parented ROOT.
- Empty SQLite order-key BLOBs round-trip as empty bytes.

## Strict input contract

Reserved targets do not bypass #218's structural-key validation. Malformed ROOT/TRASH operations are rejected before no-op handling; only canonical operations reach the sentinel fast path.

There is no old-log exception, schema version, migration marker, row scan, backfill, or upgrade replay. Development databases containing the earlier shape must be recreated.

## Fast paths

- Schema initialization performs no sentinel scan or replay scheduling.
- Ordinary application-node operations add only reserved-ID comparisons.
- Canonical reserved-target operations return before snapshotting or touching node/payload stores.
- A node attached to virtual TRASH stores no sibling order key and creates no sentinel parent row.

## Size

**11 files, +234/-31** relative to #186. Removing the prior compatibility/migration design cut the PR by more than 400 lines.

## Verification

- `cargo test --workspace`
- strict workspace Clippy
- Rust and TypeScript formatting
- interface and engine-conformance TypeScript builds
- malformed ROOT/TRASH rejection and canonical no-op coverage
- `git diff --check`

## Stack

Stacked on #186.