### PR TITLE
fix: isolate materialization listener failures

### DIFF
--- a/.changeset/isolate-materialization-listeners.md
+++ b/.changeset/isolate-materialization-listeners.md
@@ -1,0 +1,7 @@
+---
+'@treecrdt/interface': patch
+'@treecrdt/wa-sqlite': patch
+---
+
+Isolate materialization listener failures after a write or recovery has committed. One throwing
+listener no longer rejects the completed operation or prevents later listeners from observing it.

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -157,6 +157,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioMaterializationEventStructuralBatch,
     },
     {
+      name: 'materialization events: listener failures are isolated',
+      run: scenarioMaterializationListenerFailuresAreIsolated,
+    },
+    {
       name: 'materialization events: payload coalescing',
       run: scenarioMaterializationEventPayloadCoalescing,
     },
@@ -888,6 +892,47 @@ async function scenarioMaterializationEventStructuralBatch(
     [root, parent, child],
     'appendMany structural should include root+parent+child',
   );
+}
+
+async function scenarioMaterializationListenerFailuresAreIsolated(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const { engine } = ctx;
+  const replica = replicaFromLabel('listener-isolation');
+  const remoteReplica = replicaFromLabel('listener-isolation-remote');
+  const root = nodeIdFromInt(0);
+  const node = nodeIdFromInt(61);
+  const remoteNode = nodeIdFromInt(62);
+  let throwingCalls = 0;
+  const observed: MaterializationEvent[] = [];
+  const unsubscribeThrowing = engine.onMaterialized(() => {
+    throwingCalls += 1;
+    throw new Error('listener failure');
+  });
+  const unsubscribeHealthy = engine.onMaterialized((event) => observed.push(event));
+
+  try {
+    await engine.local.insert(replica, root, node, { type: 'last' }, null);
+    await engine.ops.append(
+      makeInsertOp({
+        replica: remoteReplica,
+        counter: 1,
+        lamport: 2,
+        parent: root,
+        node: remoteNode,
+        orderKey: orderKeyFromPosition(1),
+      }),
+    );
+  } finally {
+    unsubscribeThrowing();
+    unsubscribeHealthy();
+  }
+
+  assertEqual(throwingCalls, 2, 'throwing listener call count');
+  assertEqual(observed.length, 2, 'healthy listener must still receive both events');
+  assertEqual(await engine.tree.exists(node), true, 'committed node must remain visible');
+  assertEqual(await engine.tree.exists(remoteNode), true, 'appended node must remain visible');
+  assertEqual((await engine.ops.all()).length, 2, 'listener failure must not remint either write');
 }
 
 async function scenarioMaterializationEventPayloadCoalescing(

--- a/packages/treecrdt-postgres-napi/tests/conformance.test.ts
+++ b/packages/treecrdt-postgres-napi/tests/conformance.test.ts
@@ -74,6 +74,7 @@ function internalDocId(publicDocId: string, key: string): string {
 test('conformance registry includes materialization-event scenarios', () => {
   const names = treecrdtEngineConformanceScenarios().map((s) => s.name);
   expect(names).toContain('materialization events: structural batch');
+  expect(names).toContain('materialization events: listener failures are isolated');
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
   expect(names).toContain('local ops: materialization changes include writeId');

--- a/packages/treecrdt-sqlite-node/tests/conformance.test.ts
+++ b/packages/treecrdt-sqlite-node/tests/conformance.test.ts
@@ -7,6 +7,7 @@ import {
   runTreecrdtEngineConformanceScenario,
   treecrdtEngineConformanceScenarios,
 } from '@treecrdt/engine-conformance';
+import { createTreecrdtSqliteWriter } from '@treecrdt/interface/sqlite';
 import {
   createTreecrdtClient,
   defaultExtensionPath,
@@ -37,7 +38,31 @@ test('conformance registry includes materialization-event scenarios', () => {
   expect(names).toContain('materialization events: structural batch');
   expect(names).toContain('materialization events: payload coalescing');
   expect(names).toContain('materialization events: defensive restore');
+  expect(names).toContain('materialization events: listener failures are isolated');
   expect(names).toContain('local ops: materialization changes include writeId');
+});
+
+test('low-level sqlite writer isolates a direct materialization callback failure', async () => {
+  const client = await createNodeEngine({ docId: 'sqlite-direct-listener-isolation' });
+  const callback = vi.fn(() => {
+    throw new Error('listener failure');
+  });
+  const writer = createTreecrdtSqliteWriter(client.runner, {
+    replica,
+    onMaterialized: callback,
+  });
+  const node = nodeIdFromInt(9);
+
+  try {
+    await expect(writer.insert(root, node, { type: 'last' })).resolves.toMatchObject({
+      kind: { type: 'insert', node },
+    });
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(await client.tree.exists(node)).toBe(true);
+    expect(await client.ops.all()).toHaveLength(1);
+  } finally {
+    await client.close();
+  }
 });
 
 test('sqlite auth-aware local write rolls back on auth failure', async () => {

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -78,6 +78,10 @@ export function emptyMaterializationOutcome(headSeq = 0): MaterializationOutcome
  */
 export type MaterializationEvent = MaterializationOutcome;
 
+/**
+ * Synchronous observational callback. A listener failure is isolated from the committed write and
+ * from other listeners; asynchronous work must handle its own promise rejections.
+ */
 export type MaterializationListener = (event: MaterializationEvent) => void;
 
 export type MaterializationDispatcher = {
@@ -91,7 +95,13 @@ export function createMaterializationDispatcher(): MaterializationDispatcher {
 
   const emitEvent = (event: MaterializationEvent) => {
     if (event.changes.length === 0) return;
-    for (const listener of listeners) listener(event);
+    for (const listener of listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Materialization is already committed. Listeners are observational and independent.
+      }
+    }
   };
 
   const emitOutcome = (outcome: MaterializationOutcome, writeId?: string) => {

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -76,12 +76,25 @@ function decodeLocalOpResult(
   };
 }
 
+function notifyMaterializationCallback(
+  callback: ((event: MaterializationEvent) => void) | undefined,
+  event: MaterializationEvent,
+): void {
+  try {
+    callback?.(event);
+  } catch {
+    // The database change is already committed; this callback is observational only.
+  }
+}
+
 function emitLocalOutcome(
   outcome: MaterializationOutcome,
   emit?: (event: MaterializationEvent) => void,
   writeId?: string,
 ): void {
-  if (outcome.changes.length > 0) emit?.(addMaterializationWriteId(outcome, writeId));
+  if (outcome.changes.length > 0) {
+    notifyMaterializationCallback(emit, addMaterializationWriteId(outcome, writeId));
+  }
 }
 
 const ROOT_NODE_BYTES = nodeIdToBytes16(ROOT_NODE_ID_HEX);
@@ -295,7 +308,7 @@ export function createTreecrdtSqliteAdapter(
 ): TreecrdtAdapter {
   const emitOutcome = (outcome: MaterializationOutcome) => {
     if (outcome.changes.length === 0) return;
-    opts.onMaterialized?.({ ...outcome });
+    notifyMaterializationCallback(opts.onMaterialized, { ...outcome });
   };
   return {
     setDocId: (docId) => treecrdtSetDocId(runner, docId),


### PR DESCRIPTION
## What problem does this solve?

Materialization callbacks run after the operation and derived state have committed. A callback exception nevertheless escaped through the write promise. That produced three misleading failure modes:

- a successful local write or remote append could reject after commit, inviting the caller to retry and mint another operation;
- the first throwing listener prevented later listeners from observing the event;
- sync ingestion could treat an already-applied batch as failed and tear down the session.

Two low-level SQLite callback paths also bypass the shared dispatcher: direct local writers and read-triggered recovery.

## What changes?

- The shared dispatcher invokes every listener independently and isolates each synchronous exception.
- The direct SQLite local-write and recovery callbacks use the same observational boundary.
- Empty outcomes still emit nothing.
- Listener failures are intentionally silent in this correctness patch. The repository has no generic listener-error hook, and adding one would expand the public API for a secondary reporting concern.

Materialization listeners are documented as synchronous observational callbacks. Returned promises are not awaited; asynchronous listeners must handle their own rejections.

## Why is swallowing the exception correct?

By the time a listener runs, the operation, materialized rows, metadata, and any atomic auth proof are already committed. The callback cannot roll them back. Rejecting the operation promise therefore reports the opposite of what happened and makes retry behavior unsafe. Listener code remains free to report its own error, but it cannot change operation success or another listener's delivery.

## What fast paths remain?

- Empty outcomes return before listener work.
- An empty listener set performs no callback calls.
- Successful synchronous listeners add only a `try/catch`; there is no clone, await, transaction, or storage work.
- Write, authorization, replay, and materialization code paths are otherwise unchanged.

## Validation

Cross-engine conformance now registers a throwing listener before a healthy listener, then performs both a local insert and a remote append. It verifies that both promises resolve, the healthy listener receives both events, both nodes exist, and exactly two operations were persisted.

A focused low-level SQLite writer regression verifies that a direct throwing callback cannot reject or duplicate a committed insert. The scenario runs through SQLite Node and is registered for wa-sqlite and PostgreSQL CI as well.

Local validation:

- interface, conformance, SQLite Node, and PostgreSQL TypeScript checks
- SQLite Node conformance: **38/38**
- SQLite sync backend: **4/4**
- Prettier and diff checks

The local wa-sqlite build reached the existing WebAssembly extension step but could not run because `emcc` is not installed; CI provides that toolchain.

Production diff: **+26/-3**. Tests/conformance: **+71**. Changeset: **7 lines**.
