### PR TITLE
docs: define Lamport since query semantics

### DIFF
--- a/.changeset/clarify-ops-since.md
+++ b/.changeset/clarify-ops-since.md
@@ -1,0 +1,6 @@
+---
+'@treecrdt/interface': patch
+---
+
+Clarify that Lamport `since` queries use an exclusive threshold and are not resumable arrival
+cursors.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ pnpm test
 
 See the package READMEs for package-specific setup and API details.
 
+For the exact `ops.since(lamport)` and `headLamport()` contracts, see
+[Operation queries](docs/OPERATION_QUERIES.md).
+
 ## Playground
 
 - Live demo: https://cybersemics.github.io/treecrdt/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,7 +99,9 @@ flowchart TD
 ## Trait contracts (Rust)
 - `Clock`: lamport/HLC pluggable (`LamportClock` provided).
 - `AccessControl`: guards apply/read.
-- `Storage`: append operations, load since lamport, latest_lamport.
+- `Storage`: append operations, query the current log with the exclusive threshold
+  `op.lamport > lamport`, and report the current maximum Lamport value. See
+  [Operation queries](OPERATION_QUERIES.md).
 - `IndexProvider`: optional acceleration for subtree queries and existence checks.
 - These traits are the seam for SQLite/wa-sqlite implementations; extension just implements them over tables/indexes.
 
@@ -112,6 +114,8 @@ flowchart TD
 - **Protocol & runtime** (`@treecrdt/sync-protocol`, `packages/sync-protocol/protocol`): transport-agnostic peer, codecs, in-memory test helpers, and generated Protobuf types.
 - **Client integration** (`@treecrdt/sync`, `packages/treecrdt-sync`): optional wiring for spec `WebSocket` clients (browser global, or `webSocketCtor` e.g. from `undici` in Node; see `packages/treecrdt-sync` README)—uses `@treecrdt/discovery` to resolve docs to websocket URLs, `@treecrdt/sync-protocol` for the wire session, and `@treecrdt/sync-sqlite` for a `SyncBackend` backed by the SQLite material layer. App code that wants full control can depend on the protocol and discovery packages only.
 - Transport-agnostic: push/pull batches with causal metadata + optional subtree filters.
-- Progress hooks for UI, resumable checkpoints via lamport/head.
+- Progress hooks for UI; operation-reference set reconciliation provides convergence using RIBLT
+  or the tiny-scope direct-send fast path. A Lamport head observes the logical clock but is not a
+  resumable arrival checkpoint.
 - Access control enforced at responder using subtree filters and ACL callbacks.
 - Draft protocol: [`sync/v0.md`](sync/v0.md)

--- a/docs/OPERATION_QUERIES.md
+++ b/docs/OPERATION_QUERIES.md
@@ -1,0 +1,29 @@
+# Operation queries
+
+`ops.since(lamport)` is an exclusive Lamport-threshold query over the operations currently stored:
+
+```text
+op.meta.lamport > lamport
+```
+
+The same contract applies to adapter `opsSince`, Rust `load_since`/`operations_since`, PostgreSQL
+`ops_since`, WASM `opsSince`, and SQLite `treecrdt_ops_since`. Result ordering is not part of this
+shared contract; only APIs that explicitly document an order guarantee one.
+
+This is not an arrival cursor. For example, suppose `headLamport()` returns `10`. A remote operation
+with Lamport `7` can arrive later, as can an operation from another replica with Lamport `10`.
+`ops.since(10)` returns neither. Changing the predicate to `>=` would repeat operations at `10` but
+would still miss the late operation at `7`.
+
+Use the API that matches the job:
+
+- `ops.all()` reads the complete operation snapshot currently stored.
+- Sync reconciles operation-reference sets using RIBLT, with a direct-send fast path for tiny
+  clean-slate scopes.
+- `onMaterialized` observes materialization changes in the current session; it is not durable or
+  resumable.
+- `headLamport()` reports the current maximum for clock observation and metadata, not ingestion
+  progress.
+
+A durable arrival feed would need a backend-assigned monotonic sequence and a separate API such as
+`changesAfter(sequence)`. That API is not currently provided.

--- a/packages/treecrdt-core/src/traits.rs
+++ b/packages/treecrdt-core/src/traits.rs
@@ -24,7 +24,10 @@ pub trait Storage {
     /// Persist a single operation. Returns `true` if the op was inserted, or `false` if it was
     /// already present (idempotent).
     fn apply(&mut self, op: Operation) -> Result<bool>;
+    /// Return currently stored operations whose Lamport timestamp is strictly greater than
+    /// `lamport`. This is an exclusive threshold query, not an arrival cursor.
     fn load_since(&self, lamport: Lamport) -> Result<Vec<Operation>>;
+    /// Return the current maximum stored Lamport timestamp, not an ingestion checkpoint.
     fn latest_lamport(&self) -> Lamport;
     /// Return the maximum counter observed for `replica`, or 0 if absent.
     ///
@@ -40,7 +43,8 @@ pub trait Storage {
             .unwrap_or(0))
     }
 
-    /// Iterate operations since `lamport` in canonical op-key order.
+    /// Iterate operations with Lamport timestamps strictly greater than `lamport` in canonical
+    /// op-key order.
     ///
     /// Default implementation loads into memory and sorts; storage backends can override this
     /// to stream rows in sorted order (e.g. via SQL `ORDER BY`).

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -755,6 +755,8 @@ where
         Ok(changed)
     }
 
+    /// Return currently stored operations whose Lamport timestamp is strictly greater than
+    /// `lamport`. This is an exclusive threshold query, not an arrival cursor.
     pub fn operations_since(&self, lamport: Lamport) -> Result<Vec<Operation>> {
         self.storage.load_since(lamport)
     }

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -145,6 +145,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioAppendIdempotentAndHeadLamportMonotonic,
     },
     {
+      name: 'ops.since: exclusive Lamport threshold after late/equal arrivals',
+      run: scenarioOpsSinceExclusiveLamportThreshold,
+    },
+    {
       name: 'append/appendMany: rejects operation id equivocation atomically',
       run: scenarioRejectsOperationIdEquivocationAtomically,
     },
@@ -686,6 +690,50 @@ async function scenarioAppendIdempotentAndHeadLamportMonotonic(
   const refs = await engine.opRefs.all();
   assertEqual(refs.length, 2, 'opRefs.all length after duplicate append');
   assertEqual(await engine.meta.headLamport(), 7, 'meta.headLamport after duplicate append');
+}
+
+async function scenarioOpsSinceExclusiveLamportThreshold(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const root = nodeIdFromInt(0);
+  const makeOp = (label: string, node: number, lamport: number, position: number) =>
+    makeInsertOp({
+      replica: replicaFromLabel(label),
+      counter: 1,
+      lamport,
+      parent: root,
+      node: nodeIdFromInt(node),
+      orderKey: orderKeyFromPosition(position),
+    });
+
+  await engine.ops.append(makeOp('since-head', 501, 7, 0));
+  const observedHead = await engine.meta.headLamport();
+  assertEqual(observedHead, 7, 'observed head');
+
+  await engine.ops.appendMany([makeOp('since-late', 502, 3, 1), makeOp('since-equal', 503, 7, 2)]);
+  assertEqual(await engine.meta.headLamport(), 7, 'head remains the current maximum');
+
+  const lamportsSince = async (lamport: number) =>
+    (await engine.ops.since(lamport))
+      .map((op) => String(op.meta.lamport))
+      .sort((a, b) => Number(a) - Number(b));
+
+  assertArrayEqual(
+    await lamportsSince(observedHead),
+    [],
+    'ops.since(head) excludes late lower and equal Lamport arrivals',
+  );
+  assertArrayEqual(
+    await lamportsSince(3),
+    ['7', '7'],
+    'ops.since(3) uses a strict greater-than threshold',
+  );
+  assertArrayEqual(
+    await lamportsSince(2),
+    ['3', '7', '7'],
+    'ops.since(2) returns every currently stored operation above the threshold',
+  );
 }
 
 async function scenarioRejectsOperationIdEquivocationAtomically(

--- a/packages/treecrdt-postgres-rs/src/reads.rs
+++ b/packages/treecrdt-postgres-rs/src/reads.rs
@@ -171,6 +171,8 @@ pub fn get_ops_by_op_refs(
     Ok(out)
 }
 
+/// Return currently stored operations whose Lamport timestamp is strictly greater than `lamport`,
+/// ordered by `(lamport, replica, counter)`. This is not an arrival cursor.
 pub fn ops_since(
     client: &Rc<RefCell<Client>>,
     doc_id: &str,

--- a/packages/treecrdt-ts/src/adapter.ts
+++ b/packages/treecrdt-ts/src/adapter.ts
@@ -81,7 +81,9 @@ export interface TreecrdtAdapter {
    */
   treePayload(node: Uint8Array): Promise<Uint8Array | null>;
   /**
-   * Fetch the maximum lamport seen in the op log.
+   * Fetch the current maximum Lamport timestamp in the op log.
+   *
+   * Lower or equal timestamps can arrive later, so this is not a durable ingestion checkpoint.
    */
   headLamport(): Promise<number> | number;
   /**
@@ -105,6 +107,11 @@ export interface TreecrdtAdapter {
     serializeNodeId: SerializeNodeId,
     serializeReplica: SerializeReplica,
   ): Promise<MaterializationOutcome> | MaterializationOutcome;
+  /**
+   * Fetch currently stored operations with `op.meta.lamport > lamport`.
+   *
+   * This is an exclusive threshold query, not a resumable arrival cursor.
+   */
   opsSince(lamport: number, root?: string): Promise<unknown[]>;
   close?(): Promise<void> | void;
 }

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -161,6 +161,12 @@ export type TreecrdtEngineOps = {
   append: (op: Operation, opts?: WriteOptions) => Promise<void>;
   appendMany: (ops: Operation[], opts?: WriteOptions) => Promise<void>;
   all: () => Promise<Operation[]>;
+  /**
+   * Reads currently stored operations with `op.meta.lamport > lamport`.
+   *
+   * This is an exclusive threshold query, not a resumable arrival cursor. Operations with lower or
+   * equal Lamport timestamps can arrive after this call.
+   */
   since: (lamport: number, root?: string) => Promise<Operation[]>;
   children: (parent: string) => Promise<Operation[]>;
   get: (opRefs: Uint8Array[]) => Promise<Operation[]>;
@@ -191,6 +197,7 @@ export type TreecrdtEngineTree = {
 };
 
 export type TreecrdtEngineMeta = {
+  /** Current maximum stored Lamport timestamp; not a durable ingestion checkpoint. */
   headLamport: () => Promise<number>;
   replicaMaxCounter: (replica: ReplicaId) => Promise<number>;
 };

--- a/packages/treecrdt-ts/src/index.ts
+++ b/packages/treecrdt-ts/src/index.ts
@@ -84,12 +84,15 @@ export interface AccessControl {
 
 export interface StorageAdapter {
   apply(op: Operation): Promise<void> | void;
+  /** Exclusive threshold read (`op.meta.lamport > lamport`), not an arrival cursor. */
   loadSince(lamport: Lamport): Promise<Operation[]> | Operation[];
+  /** Current maximum stored Lamport timestamp, not a durable ingestion checkpoint. */
   latestLamport(): Promise<Lamport> | Lamport;
 }
 
 export interface SyncProtocol {
   push(ops: Operation[]): Promise<void> | void;
+  /** Exclusive Lamport-threshold read; callers must not use it as a resumable arrival cursor. */
   pull(since: Lamport, filter?: SubtreeFilter): Promise<Operation[]> | Operation[];
 }
 

--- a/packages/treecrdt-wasm/src/lib.rs
+++ b/packages/treecrdt-wasm/src/lib.rs
@@ -262,6 +262,8 @@ impl WasmTree {
         to_value(&affected).map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
+    /// Return currently stored operations whose Lamport timestamp is strictly greater than
+    /// `lamport`. This is an exclusive threshold query, not an arrival cursor.
     #[wasm_bindgen(js_name = opsSince)]
     pub fn ops_since(&self, lamport: u64) -> Result<JsValue, JsValue> {
         let ops = self


### PR DESCRIPTION
## Why

`ops.since(headLamport())` looks like a resumable cursor, but it is not one. It is a point-in-time threshold read with the exclusive predicate `op.meta.lamport > threshold`.

For example, after the observed head is `7`, remote operations stamped `3` or `7` can still arrive. `since(7)` returns neither. Changing the query to `>=` only repeats operations at `7`; it still misses the late operation at `3`.

## What changes

- Documents the exact contract across the TypeScript, Rust, WASM, SQLite, and PostgreSQL public surfaces.
- Corrects the architecture guide so a Lamport head is no longer described as a resumable checkpoint.
- Adds one shared engine-conformance scenario for lower/equal late arrivals.
- Documents the right alternatives: `ops.all()` for a complete current read, op-ref set reconciliation for sync, and `onMaterialized` for current-session materialization observation.

## Runtime behavior and fast paths

No executable code, schema, wire protocol, or query changes.

- SQLite and PostgreSQL keep the existing strict `>` query and Lamport/order indexes.
- Sync keeps RIBLT reconciliation and its tiny clean-slate direct-send fast path.
- `ops.all()` and `headLamport()` are unchanged.
- A true durable arrival feed would need a backend-assigned monotonic sequence and a separate API such as `changesAfter(sequence)`; that larger feature is intentionally out of scope.

## Size

121 additions and 4 deletions across 12 files. The only executable diff is a 48-line shared conformance scenario; everything else is documentation, API comments, and a changeset.

## Validation

- `cargo test --workspace --all-targets`
- TypeScript interface and engine-conformance builds
- Native SQLite engine conformance: 39/39 passing
- `cargo fmt --check --all`
- `git diff --check`