### PR TITLE
refactor(sync): deduplicate protocol validation helpers

### DIFF
--- a/packages/sync-protocol/protocol/src/sync.ts
+++ b/packages/sync-protocol/protocol/src/sync.ts
@@ -32,6 +32,7 @@ import type {
   Subscribe,
   SubscribeAck,
   SyncBackend,
+  SyncError,
   SyncMessage,
   Unsubscribe,
 } from './types.js';
@@ -288,6 +289,12 @@ function peerAdvertisedOpAuth(capabilities: readonly Capability[]): boolean {
   return capabilities.some(isAnyAuthCapability);
 }
 
+function assertOutgoingFilterLength(allowed: readonly boolean[], expected: number): void {
+  if (allowed.length !== expected) {
+    throw new Error(`filterOutgoingOps returned ${allowed.length} flags for ${expected} ops`);
+  }
+}
+
 export class SyncPeer<Op> {
   private readonly maxCodewords: number;
   private readonly maxOpsPerBatch: number;
@@ -344,6 +351,17 @@ export class SyncPeer<Op> {
     }
     this.requireAuthForFilters = opts.requireAuthForFilters ?? Boolean(opts.auth);
     this.deriveOpRef = opts.deriveOpRef;
+  }
+
+  private async sendProtocolError(
+    transport: DuplexTransport<SyncMessage<Op>>,
+    error: SyncError,
+  ): Promise<void> {
+    await transport.send({
+      v: 0,
+      docId: this.backend.docId,
+      payload: { case: 'error', value: error },
+    });
   }
 
   /**
@@ -583,11 +601,7 @@ export class SyncPeer<Op> {
           filter: sub.filter,
           capabilities: peerCaps,
         });
-        if (allowed.length !== ops.length) {
-          throw new Error(
-            `filterOutgoingOps returned ${allowed.length} flags for ${ops.length} ops`,
-          );
-        }
+        assertOutgoingFilterLength(allowed, ops.length);
 
         const allowedRefs: OpRef[] = [];
         const allowedOps: Op[] = [];
@@ -666,11 +680,7 @@ export class SyncPeer<Op> {
           filter,
           capabilities: peerCaps,
         });
-        if (allowed.length !== ops.length) {
-          throw new Error(
-            `filterOutgoingOps returned ${allowed.length} flags for ${ops.length} ops`,
-          );
-        }
+        assertOutgoingFilterLength(allowed, ops.length);
 
         const allowedRefs: OpRef[] = [];
         const allowedOps: Op[] = [];
@@ -786,11 +796,7 @@ export class SyncPeer<Op> {
           filter,
           capabilities: peerCaps,
         });
-        if (allowed.length !== ops.length) {
-          throw new Error(
-            `filterOutgoingOps returned ${allowed.length} flags for ${ops.length} ops`,
-          );
-        }
+        assertOutgoingFilterLength(allowed, ops.length);
         opRefs = opRefs.filter((_r, idx) => allowed[idx] === true);
       }
 
@@ -961,11 +967,7 @@ export class SyncPeer<Op> {
           filter,
           capabilities: peerCaps,
         });
-        if (allowed.length !== ops.length) {
-          throw new Error(
-            `filterOutgoingOps returned ${allowed.length} flags for ${ops.length} ops`,
-          );
-        }
+        assertOutgoingFilterLength(allowed, ops.length);
 
         const nextOps: Op[] = [];
         for (let i = 0; i < ops.length; i += 1) {
@@ -1204,18 +1206,11 @@ export class SyncPeer<Op> {
           ...(subscriptionId ? { subscriptionId } : {}),
         });
 
-        await transport.send({
-          v: 0,
-          docId: this.backend.docId,
-          payload: {
-            case: 'error',
-            value: {
-              code: ErrorCode.ERROR_CODE_UNSPECIFIED,
-              message: String(err?.message ?? err ?? 'error'),
-              ...(filterId ? { filterId } : {}),
-              ...(subscriptionId ? { subscriptionId } : {}),
-            },
-          },
+        await this.sendProtocolError(transport, {
+          code: ErrorCode.ERROR_CODE_UNSPECIFIED,
+          message: String(err?.message ?? err ?? 'error'),
+          ...(filterId ? { filterId } : {}),
+          ...(subscriptionId ? { subscriptionId } : {}),
         });
       } catch {
         // ignore transport failures while reporting errors
@@ -1245,16 +1240,9 @@ export class SyncPeer<Op> {
         ackCapabilities: ackCapabilities.length,
       });
     } catch (err: any) {
-      await transport.send({
-        v: 0,
-        docId: this.backend.docId,
-        payload: {
-          case: 'error',
-          value: {
-            code: ErrorCode.ERROR_CODE_UNSPECIFIED,
-            message: String(err?.message ?? err ?? 'auth error'),
-          },
-        },
+      await this.sendProtocolError(transport, {
+        code: ErrorCode.ERROR_CODE_UNSPECIFIED,
+        message: String(err?.message ?? err ?? 'auth error'),
       });
       return;
     }
@@ -1335,11 +1323,7 @@ export class SyncPeer<Op> {
             filter,
             capabilities: hello.capabilities,
           });
-          if (allowed.length !== ops.length) {
-            throw new Error(
-              `filterOutgoingOps returned ${allowed.length} flags for ${ops.length} ops`,
-            );
-          }
+          assertOutgoingFilterLength(allowed, ops.length);
           localOpRefs = localOpRefs.filter((_r, idx) => allowed[idx] === true);
           traceHello(this.backend.docId, traceStartedAt, 'after-filterOutgoingOps', {
             filterId: id,
@@ -1593,17 +1577,10 @@ export class SyncPeer<Op> {
     if (!msg.filter) return;
 
     if (this.requireAuthForFilters && !this.transportHasAuth.get(transport)) {
-      await transport.send({
-        v: 0,
-        docId: this.backend.docId,
-        payload: {
-          case: 'error',
-          value: {
-            code: ErrorCode.UNAUTHORIZED,
-            message: `missing "${AUTH_CAPABILITY_NAME}" token; send Hello before Subscribe`,
-            subscriptionId: msg.subscriptionId,
-          },
-        },
+      await this.sendProtocolError(transport, {
+        code: ErrorCode.UNAUTHORIZED,
+        message: `missing "${AUTH_CAPABILITY_NAME}" token; send Hello before Subscribe`,
+        subscriptionId: msg.subscriptionId,
       });
       return;
     }
@@ -1616,17 +1593,10 @@ export class SyncPeer<Op> {
         capabilities: peerCaps,
       });
     } catch (err: any) {
-      await transport.send({
-        v: 0,
-        docId: this.backend.docId,
-        payload: {
-          case: 'error',
-          value: {
-            code: ErrorCode.UNAUTHORIZED,
-            message: String(err?.message ?? err ?? 'unauthorized filter'),
-            subscriptionId: msg.subscriptionId,
-          },
-        },
+      await this.sendProtocolError(transport, {
+        code: ErrorCode.UNAUTHORIZED,
+        message: String(err?.message ?? err ?? 'unauthorized filter'),
+        subscriptionId: msg.subscriptionId,
       });
       return;
     }
@@ -1661,17 +1631,10 @@ export class SyncPeer<Op> {
       // without explicit `notifyLocalUpdate()` calls for every writer.
       void this.notifyLocalUpdate();
     } catch (err: any) {
-      await transport.send({
-        v: 0,
-        docId: this.backend.docId,
-        payload: {
-          case: 'error',
-          value: {
-            code: ErrorCode.FILTER_NOT_SUPPORTED,
-            message: String(err?.message ?? err ?? 'subscribe failed'),
-            subscriptionId: msg.subscriptionId,
-          },
-        },
+      await this.sendProtocolError(transport, {
+        code: ErrorCode.FILTER_NOT_SUPPORTED,
+        message: String(err?.message ?? err ?? 'subscribe failed'),
+        subscriptionId: msg.subscriptionId,
       });
     }
   }


### PR DESCRIPTION
## Why

PR #191 needs terminal-aware protocol errors and repeated outbound validation checks. Those changes are easier to review if the existing duplication is removed first in a behavior-preserving commit.

## What changes

- Extract the five identical `filterOutgoingOps` result-length checks into one helper.
- Extract the five repeated protocol error envelopes into one send helper.
- Keep every error code, message, filter/subscription id, and send location unchanged.
- Add no capability, authorization, queueing, or terminal-state behavior.

## Size

One production file, +43/-80 (net -37 lines).

## Fast paths

There is no new I/O or state. The helpers replace inline code and call the same transport sends and validations.

## Tests

- protocol TypeScript build
- full protocol suite

## Stack

Stacked on #190. PR #191 will add its terminal/capability semantics on top of these helpers.
