### PR TITLE
feat(crypto): add keyed payload encryption

### DIFF
--- a/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
+++ b/examples/playground/src/playground/hooks/usePlaygroundPayloads.ts
@@ -1,10 +1,17 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { base64urlDecode } from '@treecrdt/auth';
-import { encryptTreecrdtPayloadV1, maybeDecryptTreecrdtPayloadV1 } from '@treecrdt/crypto';
+import {
+  createTreecrdtPayloadKeyringV1,
+  decryptTreecrdtPayloadWithKeyring,
+  encryptTreecrdtPayloadWithKeyring,
+  type TreecrdtPayloadKeyringV1,
+} from '@treecrdt/crypto';
 import type { TreecrdtClient } from '@treecrdt/wa-sqlite';
 
 import { loadOrCreateDocPayloadKeyB64 } from '../../auth';
 import { ROOT_ID } from '../constants';
+
+const INITIAL_PAYLOAD_KEY_ID = 'initial';
 
 type PayloadRecord = {
   payload: Uint8Array | null;
@@ -35,7 +42,7 @@ export function usePlaygroundPayloads(opts: {
   const { docId, setError } = opts;
   const [payloadVersion, setPayloadVersion] = useState(0);
   const textDecoder = useMemo(() => new TextDecoder(), []);
-  const docPayloadKeyRef = useRef<Uint8Array | null>(null);
+  const docPayloadKeyringRef = useRef<TreecrdtPayloadKeyringV1 | null>(null);
   const payloadByNodeRef = useRef<Map<string, PayloadRecord>>(new Map());
   const payloadEventQueueRef = useRef<Promise<void>>(Promise.resolve());
 
@@ -47,12 +54,16 @@ export function usePlaygroundPayloads(opts: {
 
   const refreshDocPayloadKey = React.useCallback(async () => {
     const keyB64 = await loadOrCreateDocPayloadKeyB64(docId);
-    docPayloadKeyRef.current = base64urlDecode(keyB64);
-    return docPayloadKeyRef.current;
+    const payloadKey = base64urlDecode(keyB64);
+    docPayloadKeyringRef.current = createTreecrdtPayloadKeyringV1({
+      payloadKey,
+      activeKid: INITIAL_PAYLOAD_KEY_ID,
+    });
+    return payloadKey;
   }, [docId]);
 
   useEffect(() => {
-    docPayloadKeyRef.current = null;
+    docPayloadKeyringRef.current = null;
     resetPayloadCache();
     let cancelled = false;
     void (async () => {
@@ -68,29 +79,30 @@ export function usePlaygroundPayloads(opts: {
     };
   }, [refreshDocPayloadKey, resetPayloadCache, setError]);
 
-  const requireDocPayloadKey = React.useCallback(async (): Promise<Uint8Array> => {
-    if (docPayloadKeyRef.current) return docPayloadKeyRef.current;
-    const next = await refreshDocPayloadKey();
-    if (!next) throw new Error('doc payload key is missing');
-    return next;
-  }, [refreshDocPayloadKey]);
+  const requireDocPayloadKeyring =
+    React.useCallback(async (): Promise<TreecrdtPayloadKeyringV1> => {
+      if (docPayloadKeyringRef.current) return docPayloadKeyringRef.current;
+      await refreshDocPayloadKey();
+      if (!docPayloadKeyringRef.current) throw new Error('doc payload keyring is missing');
+      return docPayloadKeyringRef.current;
+    }, [refreshDocPayloadKey]);
 
   const decodePayloadRecord = React.useCallback(
     async (raw: Uint8Array | null): Promise<PayloadRecord> => {
       if (raw === null) return { payload: null, encrypted: false };
       try {
-        const key = await requireDocPayloadKey();
-        const res = await maybeDecryptTreecrdtPayloadV1({
+        const keyring = await requireDocPayloadKeyring();
+        const plaintext = await decryptTreecrdtPayloadWithKeyring({
           docId,
-          payloadKey: key,
-          bytes: raw,
+          keyring,
+          ciphertext: raw,
         });
-        return { payload: res.plaintext, encrypted: res.encrypted };
+        return { payload: plaintext, encrypted: true };
       } catch {
         return { payload: null, encrypted: true };
       }
     },
-    [docId, requireDocPayloadKey],
+    [docId, requireDocPayloadKeyring],
   );
 
   const applyPayloadUpdatesFromRaw = React.useCallback(
@@ -137,10 +149,10 @@ export function usePlaygroundPayloads(opts: {
   const encryptPayloadBytes = React.useCallback(
     async (payload: Uint8Array | null): Promise<Uint8Array | null> => {
       if (payload === null) return null;
-      const key = await requireDocPayloadKey();
-      return await encryptTreecrdtPayloadV1({ docId, payloadKey: key, plaintext: payload });
+      const keyring = await requireDocPayloadKeyring();
+      return await encryptTreecrdtPayloadWithKeyring({ docId, keyring, plaintext: payload });
     },
-    [docId, requireDocPayloadKey],
+    [docId, requireDocPayloadKeyring],
   );
 
   const payloadDisplayForNode = React.useCallback(

--- a/packages/treecrdt-crypto/src/e2ee.ts
+++ b/packages/treecrdt-crypto/src/e2ee.ts
@@ -1,5 +1,3 @@
-import { utf8ToBytes } from '@noble/hashes/utils';
-
 import {
   aesGcmDecrypt,
   aesGcmEncrypt,
@@ -7,7 +5,6 @@ import {
   assertLen,
   assertMap,
   assertString,
-  concatBytes,
   decodeCbor,
   encodeCbor,
   mapGet,
@@ -16,120 +13,237 @@ import {
 
 const DOC_PAYLOAD_KEY_LEN = 32;
 const AES_GCM_NONCE_LEN = 12;
-
 const ENCRYPTED_PAYLOAD_V1_TAG = 'treecrdt/payload-encrypted/v1';
-const ENCRYPTED_PAYLOAD_V1_AAD_DOMAIN = utf8ToBytes('treecrdt/payload-encrypted/v1');
+const ENCRYPTED_PAYLOAD_ALG = 'A256GCM';
+const PAYLOAD_KEY_ID_MAX_LEN = 128;
+const PAYLOAD_KEY_ID_PATTERN = /^[A-Za-z0-9._:-]+$/;
 
-function payloadAadV1(docId: string): Uint8Array {
-  return concatBytes(ENCRYPTED_PAYLOAD_V1_AAD_DOMAIN, utf8ToBytes(docId));
+function payloadAadV1(docId: string, keyId: string): Uint8Array {
+  return encodeCbor([ENCRYPTED_PAYLOAD_V1_TAG, 1, ENCRYPTED_PAYLOAD_ALG, docId, keyId]);
 }
 
-function tryDecodeEncryptedPayloadV1(
-  bytes: Uint8Array,
-): { nonce: Uint8Array; ct: Uint8Array } | null {
-  let decoded: unknown;
-  try {
-    decoded = decodeCbor(bytes);
-  } catch {
-    return null;
+function bytesToHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const b of bytes) out += b.toString(16).padStart(2, '0');
+  return out;
+}
+
+function randomPayloadKeyIdV1(): string {
+  return `k${bytesToHex(randomBytes(8))}`;
+}
+
+function assertDocId(docId: string): string {
+  if (!docId || docId.trim().length === 0) throw new Error('docId must not be empty');
+  return docId;
+}
+
+function assertPayloadKeyIdV1(kid: string, field: string): string {
+  if (typeof kid !== 'string') throw new Error(`${field} must be a string`);
+  if (kid.length === 0) throw new Error(`${field} must not be empty`);
+  if (kid !== kid.trim()) throw new Error(`${field} must be canonical (no surrounding space)`);
+  if (kid.length > PAYLOAD_KEY_ID_MAX_LEN) {
+    throw new Error(`${field} too long (max ${PAYLOAD_KEY_ID_MAX_LEN})`);
   }
-  if (!(decoded instanceof Map)) return null;
-
-  const map = decoded as Map<unknown, unknown>;
-  const v = mapGet(map, 'v');
-  if (v !== 1) return null;
-  const t = mapGet(map, 't');
-  if (t !== ENCRYPTED_PAYLOAD_V1_TAG) return null;
-
-  const alg = mapGet(map, 'alg');
-  if (alg !== 'A256GCM') return null;
-
-  const nonce = mapGet(map, 'nonce');
-  if (!(nonce instanceof Uint8Array)) return null;
-  if (nonce.length !== AES_GCM_NONCE_LEN) return null;
-
-  const ct = mapGet(map, 'ct');
-  if (!(ct instanceof Uint8Array)) return null;
-
-  return { nonce, ct };
+  if (!PAYLOAD_KEY_ID_PATTERN.test(kid)) {
+    throw new Error(`${field} contains unsupported characters`);
+  }
+  return kid;
 }
 
-export function isTreecrdtEncryptedPayloadV1(bytes: Uint8Array): boolean {
-  return tryDecodeEncryptedPayloadV1(bytes) !== null;
+function emptyPayloadKeys(): Record<string, Uint8Array> {
+  return Object.create(null) as Record<string, Uint8Array>;
 }
 
-export async function encryptTreecrdtPayloadV1(opts: {
-  docId: string;
+function hasPayloadKey(keys: Record<string, Uint8Array>, kid: string): boolean {
+  return Object.prototype.hasOwnProperty.call(keys, kid);
+}
+
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let different = 0;
+  for (let i = 0; i < a.length; i += 1) different |= a[i]! ^ b[i]!;
+  return different === 0;
+}
+
+export type TreecrdtPayloadKeyringV1 = {
+  activeKid: string;
+  keys: Record<string, Uint8Array>;
+};
+
+function clonePayloadKeyringV1(keyring: TreecrdtPayloadKeyringV1): TreecrdtPayloadKeyringV1 {
+  if (!keyring || typeof keyring !== 'object') throw new Error('keyring must be an object');
+
+  const activeKid = assertPayloadKeyIdV1(keyring.activeKid, 'keyring.activeKid');
+  const entries = Object.entries(keyring.keys ?? {});
+  if (entries.length === 0) throw new Error('keyring.keys must not be empty');
+
+  const keys = emptyPayloadKeys();
+  for (const [rawKid, rawKey] of entries) {
+    const kid = assertPayloadKeyIdV1(rawKid, 'keyring.keys[<kid>]');
+    if (hasPayloadKey(keys, kid)) throw new Error(`duplicate keyring key id: ${kid}`);
+    assertLen(rawKey, DOC_PAYLOAD_KEY_LEN, `keyring.keys[${kid}]`);
+    keys[kid] = new Uint8Array(rawKey);
+  }
+
+  if (!hasPayloadKey(keys, activeKid)) {
+    throw new Error('keyring.activeKid does not exist in keyring.keys');
+  }
+
+  return { activeKid, keys };
+}
+
+function payloadKeyFromKeyringV1(
+  keyring: TreecrdtPayloadKeyringV1,
+  kid: string,
+): Uint8Array | null {
+  if (!keyring || typeof keyring !== 'object') throw new Error('keyring must be an object');
+  assertPayloadKeyIdV1(keyring.activeKid, 'keyring.activeKid');
+  if (!keyring.keys || typeof keyring.keys !== 'object') {
+    throw new Error('keyring.keys must be an object');
+  }
+  if (!hasPayloadKey(keyring.keys, kid)) return null;
+  const payloadKey = keyring.keys[kid];
+  if (!payloadKey) return null;
+  assertLen(payloadKey, DOC_PAYLOAD_KEY_LEN, `keyring.keys[${kid}]`);
+  return new Uint8Array(payloadKey);
+}
+
+function decodeEncryptedPayloadV1(bytes: Uint8Array): {
+  nonce: Uint8Array;
+  ct: Uint8Array;
+  kid: string;
+} {
+  const map = assertMap(decodeCbor(bytes), 'EncryptedPayloadV1');
+  const version = mapGet(map, 'v');
+  if (version !== 1) throw new Error('EncryptedPayloadV1.v must be 1');
+
+  const tag = assertString(mapGet(map, 't'), 'EncryptedPayloadV1.t');
+  if (tag !== ENCRYPTED_PAYLOAD_V1_TAG) throw new Error('EncryptedPayloadV1.t mismatch');
+
+  const alg = assertString(mapGet(map, 'alg'), 'EncryptedPayloadV1.alg');
+  if (alg !== ENCRYPTED_PAYLOAD_ALG) throw new Error('EncryptedPayloadV1.alg unsupported');
+
+  const kid = assertPayloadKeyIdV1(
+    assertString(mapGet(map, 'kid'), 'EncryptedPayloadV1.kid'),
+    'EncryptedPayloadV1.kid',
+  );
+  const nonce = assertLen(
+    assertBytes(mapGet(map, 'nonce'), 'EncryptedPayloadV1.nonce'),
+    AES_GCM_NONCE_LEN,
+    'EncryptedPayloadV1.nonce',
+  );
+  const ct = assertBytes(mapGet(map, 'ct'), 'EncryptedPayloadV1.ct');
+  return { nonce, ct, kid };
+}
+
+export function createTreecrdtPayloadKeyringV1(opts: {
   payloadKey: Uint8Array;
+  activeKid?: string;
+}): TreecrdtPayloadKeyringV1 {
+  assertLen(opts.payloadKey, DOC_PAYLOAD_KEY_LEN, 'payloadKey');
+  const activeKid = assertPayloadKeyIdV1(opts.activeKid ?? randomPayloadKeyIdV1(), 'activeKid');
+  const keys = emptyPayloadKeys();
+  keys[activeKid] = new Uint8Array(opts.payloadKey);
+  return { activeKid, keys };
+}
+
+export function upsertTreecrdtPayloadKeyringKeyV1(opts: {
+  keyring: TreecrdtPayloadKeyringV1;
+  kid: string;
+  payloadKey: Uint8Array;
+  makeActive?: boolean;
+}): TreecrdtPayloadKeyringV1 {
+  const keyring = clonePayloadKeyringV1(opts.keyring);
+  const kid = assertPayloadKeyIdV1(opts.kid, 'kid');
+  assertLen(opts.payloadKey, DOC_PAYLOAD_KEY_LEN, 'payloadKey');
+
+  if (hasPayloadKey(keyring.keys, kid)) {
+    const existing = keyring.keys[kid];
+    if (!existing || !equalBytes(existing, opts.payloadKey)) {
+      throw new Error(`key id already exists with different key bytes: ${kid}`);
+    }
+  } else {
+    keyring.keys[kid] = new Uint8Array(opts.payloadKey);
+  }
+  if (opts.makeActive ?? false) keyring.activeKid = kid;
+
+  return keyring;
+}
+
+export function rotateTreecrdtPayloadKeyringV1(opts: {
+  keyring: TreecrdtPayloadKeyringV1;
+  nextKid?: string;
+  nextPayloadKey?: Uint8Array;
+}): {
+  keyring: TreecrdtPayloadKeyringV1;
+  rotatedKid: string;
+  rotatedPayloadKey: Uint8Array;
+} {
+  const current = clonePayloadKeyringV1(opts.keyring);
+  const rotatedKid = assertPayloadKeyIdV1(opts.nextKid ?? randomPayloadKeyIdV1(), 'nextKid');
+  if (hasPayloadKey(current.keys, rotatedKid)) {
+    throw new Error(`nextKid already exists in keyring: ${rotatedKid}`);
+  }
+  const rotatedPayloadKey = opts.nextPayloadKey
+    ? new Uint8Array(opts.nextPayloadKey)
+    : randomBytes(DOC_PAYLOAD_KEY_LEN);
+  assertLen(rotatedPayloadKey, DOC_PAYLOAD_KEY_LEN, 'nextPayloadKey');
+
+  const keyring = upsertTreecrdtPayloadKeyringKeyV1({
+    keyring: current,
+    kid: rotatedKid,
+    payloadKey: rotatedPayloadKey,
+    makeActive: true,
+  });
+
+  return { keyring, rotatedKid, rotatedPayloadKey };
+}
+
+export async function encryptTreecrdtPayloadWithKeyring(opts: {
+  docId: string;
+  keyring: TreecrdtPayloadKeyringV1;
   plaintext: Uint8Array;
 }): Promise<Uint8Array> {
-  if (!opts.docId || opts.docId.trim().length === 0) throw new Error('docId must not be empty');
-  assertLen(opts.payloadKey, DOC_PAYLOAD_KEY_LEN, 'payloadKey');
+  const docId = assertDocId(opts.docId);
+  if (!opts.keyring || typeof opts.keyring !== 'object') {
+    throw new Error('keyring must be an object');
+  }
+  const activeKid = assertPayloadKeyIdV1(opts.keyring.activeKid, 'keyring.activeKid');
+  const payloadKey = payloadKeyFromKeyringV1(opts.keyring, activeKid);
+  if (!payloadKey) throw new Error('active payload key is missing');
 
   const nonce = randomBytes(AES_GCM_NONCE_LEN);
   const ciphertext = await aesGcmEncrypt({
-    key: opts.payloadKey,
+    key: payloadKey,
     nonce,
     plaintext: opts.plaintext,
-    aad: payloadAadV1(opts.docId),
+    aad: payloadAadV1(docId, activeKid),
   });
 
   const envelope = new Map<unknown, unknown>();
   envelope.set('v', 1);
   envelope.set('t', ENCRYPTED_PAYLOAD_V1_TAG);
-  envelope.set('alg', 'A256GCM');
+  envelope.set('alg', ENCRYPTED_PAYLOAD_ALG);
   envelope.set('nonce', nonce);
   envelope.set('ct', ciphertext);
+  envelope.set('kid', activeKid);
   return encodeCbor(envelope);
 }
 
-export async function decryptTreecrdtPayloadV1(opts: {
+export async function decryptTreecrdtPayloadWithKeyring(opts: {
   docId: string;
-  payloadKey: Uint8Array;
+  keyring: TreecrdtPayloadKeyringV1;
   ciphertext: Uint8Array;
 }): Promise<Uint8Array> {
-  if (!opts.docId || opts.docId.trim().length === 0) throw new Error('docId must not be empty');
-  assertLen(opts.payloadKey, DOC_PAYLOAD_KEY_LEN, 'payloadKey');
-
-  const decoded = decodeCbor(opts.ciphertext);
-  const map = assertMap(decoded, 'EncryptedPayloadV1');
-
-  const v = mapGet(map, 'v');
-  if (v !== 1) throw new Error('EncryptedPayloadV1.v must be 1');
-  const t = assertString(mapGet(map, 't'), 'EncryptedPayloadV1.t');
-  if (t !== ENCRYPTED_PAYLOAD_V1_TAG) throw new Error('EncryptedPayloadV1.t mismatch');
-  const alg = assertString(mapGet(map, 'alg'), 'EncryptedPayloadV1.alg');
-  if (alg !== 'A256GCM') throw new Error('EncryptedPayloadV1.alg unsupported');
-
-  const nonce = assertLen(
-    assertBytes(mapGet(map, 'nonce'), 'EncryptedPayloadV1.nonce'),
-    AES_GCM_NONCE_LEN,
-    'nonce',
-  );
-  const ct = assertBytes(mapGet(map, 'ct'), 'EncryptedPayloadV1.ct');
+  const docId = assertDocId(opts.docId);
+  const encrypted = decodeEncryptedPayloadV1(opts.ciphertext);
+  const payloadKey = payloadKeyFromKeyringV1(opts.keyring, encrypted.kid);
+  if (!payloadKey) throw new Error(`payload key not found: ${encrypted.kid}`);
 
   return await aesGcmDecrypt({
-    key: opts.payloadKey,
-    nonce,
-    ciphertext: ct,
-    aad: payloadAadV1(opts.docId),
+    key: payloadKey,
+    nonce: encrypted.nonce,
+    ciphertext: encrypted.ct,
+    aad: payloadAadV1(docId, encrypted.kid),
   });
-}
-
-export async function maybeDecryptTreecrdtPayloadV1(opts: {
-  docId: string;
-  payloadKey: Uint8Array;
-  bytes: Uint8Array;
-}): Promise<{ plaintext: Uint8Array; encrypted: boolean }> {
-  const parsed = tryDecodeEncryptedPayloadV1(opts.bytes);
-  if (!parsed) return { plaintext: opts.bytes, encrypted: false };
-
-  const plaintext = await aesGcmDecrypt({
-    key: opts.payloadKey,
-    nonce: parsed.nonce,
-    ciphertext: parsed.ct,
-    aad: payloadAadV1(opts.docId),
-  });
-
-  return { plaintext, encrypted: true };
 }

--- a/packages/treecrdt-crypto/tests/e2ee.test.ts
+++ b/packages/treecrdt-crypto/tests/e2ee.test.ts
@@ -1,41 +1,223 @@
 import { expect, test } from 'vitest';
 
 import { generateTreecrdtDocPayloadKeyV1 } from '../dist/keystore.js';
-import { encryptTreecrdtPayloadV1, maybeDecryptTreecrdtPayloadV1 } from '../dist/e2ee.js';
+import { decodeCbor, encodeCbor } from '../dist/internal/util.js';
+import {
+  createTreecrdtPayloadKeyringV1,
+  decryptTreecrdtPayloadWithKeyring,
+  encryptTreecrdtPayloadWithKeyring,
+  rotateTreecrdtPayloadKeyringV1,
+  upsertTreecrdtPayloadKeyringKeyV1,
+} from '../dist/e2ee.js';
 
-function bytesToHex(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString('hex');
+function rewriteEncryptedEnvelope(
+  bytes: Uint8Array,
+  rewrite: (envelope: Map<unknown, unknown>) => void,
+): Uint8Array {
+  const envelope = decodeCbor(bytes);
+  if (!(envelope instanceof Map)) throw new Error('encrypted payload is not a CBOR map');
+  rewrite(envelope);
+  return encodeCbor(envelope);
 }
 
-test('e2ee v1: encrypt/decrypt payload roundtrip', async () => {
-  const docId = 'doc-e2ee-1';
+test('e2ee v1 keyring: encrypts and decrypts with the active key id', async () => {
+  const docId = 'doc-e2ee-kid';
   const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
-  const plaintext = new TextEncoder().encode('hello');
+  const keyring = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
 
-  const encrypted = await encryptTreecrdtPayloadV1({ docId, payloadKey, plaintext });
-  const res = await maybeDecryptTreecrdtPayloadV1({ docId, payloadKey, bytes: encrypted });
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring,
+    plaintext: new TextEncoder().encode('payload with kid'),
+  });
+  const envelope = decodeCbor(encrypted);
+  if (!(envelope instanceof Map)) throw new Error('encrypted payload is not a CBOR map');
+  expect(envelope.get('v')).toBe(1);
+  expect(envelope.get('t')).toBe('treecrdt/payload-encrypted/v1');
+  expect(envelope.get('alg')).toBe('A256GCM');
+  expect(envelope.get('kid')).toBe('epoch-1');
 
-  expect(res.encrypted).toBe(true);
-  expect(new TextDecoder().decode(res.plaintext)).toBe('hello');
+  const plaintext = await decryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring,
+    ciphertext: encrypted,
+  });
+  expect(new TextDecoder().decode(plaintext)).toBe('payload with kid');
 });
 
-test('e2ee v1: decrypt fails with wrong docId (AAD mismatch)', async () => {
+test('e2ee v1 keyring: authenticates the document id', async () => {
   const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId: 'doc-a' });
-  const plaintext = new TextEncoder().encode('hello');
-  const encrypted = await encryptTreecrdtPayloadV1({ docId: 'doc-a', payloadKey, plaintext });
+  const keyring = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId: 'doc-a',
+    keyring,
+    plaintext: new TextEncoder().encode('hello'),
+  });
 
   await expect(
-    maybeDecryptTreecrdtPayloadV1({ docId: 'doc-b', payloadKey, bytes: encrypted }),
+    decryptTreecrdtPayloadWithKeyring({
+      docId: 'doc-b',
+      keyring,
+      ciphertext: encrypted,
+    }),
   ).rejects.toThrow();
 });
 
-test('e2ee v1: maybeDecrypt returns bytes unchanged if not encrypted', async () => {
-  const docId = 'doc-e2ee-2';
+test('e2ee v1 keyring: authenticates the key id even when aliases share key bytes', async () => {
+  const docId = 'doc-e2ee-authenticated-kid';
   const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
-  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const sender = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring: sender,
+    plaintext: new TextEncoder().encode('bound to epoch-1'),
+  });
+  const relabeled = rewriteEncryptedEnvelope(encrypted, (envelope) => {
+    envelope.set('kid', 'epoch-2');
+  });
+  const aliasedKeyring = {
+    activeKid: 'epoch-2',
+    keys: { 'epoch-1': payloadKey, 'epoch-2': payloadKey },
+  };
 
-  const res = await maybeDecryptTreecrdtPayloadV1({ docId, payloadKey, bytes });
+  await expect(
+    decryptTreecrdtPayloadWithKeyring({
+      docId,
+      keyring: aliasedKeyring,
+      ciphertext: relabeled,
+    }),
+  ).rejects.toThrow();
+});
 
-  expect(res.encrypted).toBe(false);
-  expect(bytesToHex(res.plaintext)).toBe(bytesToHex(bytes));
+test('e2ee v1 keyring: malformed envelopes fail closed', async () => {
+  const docId = 'doc-e2ee-malformed';
+  const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
+  const keyring = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring,
+    plaintext: new TextEncoder().encode('not plaintext'),
+  });
+
+  for (const [rewrite, expected] of [
+    [(envelope: Map<unknown, unknown>) => envelope.set('v', 2), /must be 1/],
+    [(envelope: Map<unknown, unknown>) => envelope.set('t', 'not-a-treecrdt-envelope'), /mismatch/],
+    [(envelope: Map<unknown, unknown>) => envelope.set('alg', 'A128GCM'), /unsupported/],
+  ] as const) {
+    await expect(
+      decryptTreecrdtPayloadWithKeyring({
+        docId,
+        keyring,
+        ciphertext: rewriteEncryptedEnvelope(encrypted, rewrite),
+      }),
+    ).rejects.toThrow(expected);
+  }
+
+  await expect(
+    decryptTreecrdtPayloadWithKeyring({
+      docId,
+      keyring,
+      ciphertext: new Uint8Array([1, 2, 3, 4]),
+    }),
+  ).rejects.toThrow();
+});
+
+test('e2ee v1 keyring: key ids are canonical and prototype-safe', async () => {
+  const docId = 'doc-e2ee-canonical-kid';
+  const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
+  expect(() => createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: ' epoch-1 ' })).toThrow(
+    /canonical/,
+  );
+
+  const keyring = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: '__proto__' });
+  expect(Object.getPrototypeOf(keyring.keys)).toBeNull();
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring,
+    plaintext: new TextEncoder().encode('prototype-safe'),
+  });
+  const plaintext = await decryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring,
+    ciphertext: encrypted,
+  });
+  expect(new TextDecoder().decode(plaintext)).toBe('prototype-safe');
+
+  const noncanonical = rewriteEncryptedEnvelope(encrypted, (envelope) => {
+    envelope.set('kid', ' __proto__ ');
+  });
+  await expect(
+    decryptTreecrdtPayloadWithKeyring({ docId, keyring, ciphertext: noncanonical }),
+  ).rejects.toThrow(/canonical/);
+});
+
+test('e2ee v1 keyring: rejects ciphertext for an unavailable key id', async () => {
+  const docId = 'doc-e2ee-missing-key';
+  const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
+  const sender = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
+  const encrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring: sender,
+    plaintext: new TextEncoder().encode('secret'),
+  });
+
+  const { payloadKey: otherKey } = generateTreecrdtDocPayloadKeyV1({ docId });
+  const receiver = createTreecrdtPayloadKeyringV1({ payloadKey: otherKey, activeKid: 'epoch-2' });
+  await expect(
+    decryptTreecrdtPayloadWithKeyring({
+      docId,
+      keyring: receiver,
+      ciphertext: encrypted,
+    }),
+  ).rejects.toThrow(/payload key not found: epoch-1/);
+});
+
+test('e2ee v1 keyring: retained keys decrypt payloads written before rotation', async () => {
+  const docId = 'doc-e2ee-rotate';
+  const { payloadKey } = generateTreecrdtDocPayloadKeyV1({ docId });
+  const keyringV1 = createTreecrdtPayloadKeyringV1({ payloadKey, activeKid: 'epoch-1' });
+  const oldEncrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring: keyringV1,
+    plaintext: new TextEncoder().encode('before rotate'),
+  });
+
+  const { keyring: keyringV2 } = rotateTreecrdtPayloadKeyringV1({
+    keyring: keyringV1,
+    nextKid: 'epoch-2',
+  });
+  const newEncrypted = await encryptTreecrdtPayloadWithKeyring({
+    docId,
+    keyring: keyringV2,
+    plaintext: new TextEncoder().encode('after rotate'),
+  });
+
+  const [oldPlaintext, newPlaintext] = await Promise.all([
+    decryptTreecrdtPayloadWithKeyring({ docId, keyring: keyringV2, ciphertext: oldEncrypted }),
+    decryptTreecrdtPayloadWithKeyring({ docId, keyring: keyringV2, ciphertext: newEncrypted }),
+  ]);
+  expect(new TextDecoder().decode(oldPlaintext)).toBe('before rotate');
+  expect(new TextDecoder().decode(newPlaintext)).toBe('after rotate');
+
+  expect(() => rotateTreecrdtPayloadKeyringV1({ keyring: keyringV2, nextKid: 'epoch-2' })).toThrow(
+    /already exists/,
+  );
+
+  const currentKey = keyringV2.keys['epoch-2'];
+  if (!currentKey) throw new Error('rotated key is missing');
+  expect(
+    upsertTreecrdtPayloadKeyringKeyV1({
+      keyring: keyringV2,
+      kid: 'epoch-2',
+      payloadKey: currentKey,
+    }).keys['epoch-2'],
+  ).toEqual(currentKey);
+
+  expect(() =>
+    upsertTreecrdtPayloadKeyringKeyV1({
+      keyring: keyringV2,
+      kid: 'epoch-2',
+      payloadKey: new Uint8Array(32).fill(0xff),
+    }),
+  ).toThrow(/different key bytes/);
 });


### PR DESCRIPTION
## What

Add one authenticated payload-encryption format and the keyring primitives needed for rotation.

- `treecrdt/payload-encrypted/v1` always carries a key id.
- AES-GCM AAD authenticates the tag, version, algorithm, document id, and key id.
- Keyrings can be created, extended, and rotated while retaining old keys for existing ciphertext.
- Strict decryption parses one envelope, performs one exact key-id lookup, and attempts one AES-GCM decrypt.

## Why

Rotation needs a ciphertext key id so readers can select the correct retained key. That id is security-sensitive routing metadata: if it is not authenticated, an attacker can relabel ciphertext to another key slot.

## Clean-slate contract

TreeCRDT has no deployed ciphertext, so this PR ships one keyed v1 format only. It does not accept an older keyless envelope, scan keys for legacy ciphertext, expose raw old-format helpers, or treat plaintext as an implicit migration input. Existing development payload data must be reset.

## Fast paths

- Encryption reads the active key directly.
- Decryption performs one own-property key lookup and one AES-GCM operation.
- Rotation adds one new active key without scanning or re-encrypting history.
- Retained keys remain available for payloads written earlier in the same document.

## Safety details

- Key ids are canonical, length-bounded, prototype-safe, and authenticated.
- Key storage uses null-prototype records and own-property lookups.
- Rotation rejects reused key ids; importing the same id is idempotent only when key bytes match.
- Malformed, unknown-version, wrong-document, relabeled, and unavailable-key ciphertext fails closed.

## Size

3 files, **+429/-121**. Removing dual-format compatibility and migration APIs cut 359 physical lines from the crypto implementation and tests.

## Verification

- `@treecrdt/crypto`: 16/16 tests pass.
- Playground payload consumer uses the strict keyed API and type-checks.
- Formatting and diff checks pass.
