### PR TITLE
perf(postgres): cache replica counters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
         env:
           TREECRDT_POSTGRES_URL: postgresql://postgres:postgres@127.0.0.1:5432/treecrdt
         run: |
+          cargo test -p treecrdt-postgres
           pnpm -C packages/treecrdt-postgres-napi test
           pnpm -C packages/sync-protocol/material/postgres test
           pnpm -C packages/sync-protocol/server/postgres-node test

--- a/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
+++ b/packages/treecrdt-postgres-napi/native-rs/src/lib.rs
@@ -422,7 +422,8 @@ impl PgFactory {
         // Test-only convenience: wipe all docs.
         client
             .batch_execute(
-                "TRUNCATE treecrdt_oprefs_children, treecrdt_payload, treecrdt_nodes, treecrdt_ops, treecrdt_meta",
+                "TRUNCATE treecrdt_oprefs_children, treecrdt_payload, treecrdt_nodes, \
+                 treecrdt_ops, treecrdt_meta, treecrdt_replica_meta",
             )
             .map_err(map_err)?;
         Ok(())

--- a/packages/treecrdt-postgres-rs/src/reads.rs
+++ b/packages/treecrdt-postgres-rs/src/reads.rs
@@ -8,7 +8,7 @@ use treecrdt_core::{Error, Lamport, NodeId, Operation, Result};
 use crate::opref::{derive_op_ref_v0, OPREF_V0_WIDTH};
 use crate::store::{
     bytes_to_node, ensure_doc_meta, ensure_materialized, node_to_bytes, op_ref_from_bytes,
-    row_to_op, row_to_op_at, storage_debug, PgCtx,
+    replica_max_counter_in_tx, row_to_op, row_to_op_at, storage_debug, PgCtx,
 };
 
 pub fn max_lamport(client: &Rc<RefCell<Client>>, doc_id: &str) -> Result<Lamport> {
@@ -396,13 +396,5 @@ pub fn replica_max_counter(
     replica: &[u8],
 ) -> Result<u64> {
     ensure_doc_meta(client, doc_id)?;
-    let ctx = PgCtx::new(client.clone(), doc_id)?;
-    let mut c = client.borrow_mut();
-    let stmt = ctx.stmt(
-        &mut c,
-        "SELECT COALESCE(MAX(counter), 0) FROM treecrdt_ops WHERE doc_id = $1 AND replica = $2",
-    )?;
-    let rows = c.query(&stmt, &[&doc_id, &replica]).map_err(storage_debug)?;
-    let row = rows.first().ok_or_else(|| Error::Storage("missing MAX(counter) row".into()))?;
-    Ok(row.get::<_, i64>(0).max(0) as u64)
+    replica_max_counter_in_tx(client, doc_id, replica)
 }

--- a/packages/treecrdt-postgres-rs/src/schema.rs
+++ b/packages/treecrdt-postgres-rs/src/schema.rs
@@ -38,6 +38,13 @@ CREATE TABLE IF NOT EXISTS treecrdt_meta (
   replay_counter BIGINT
 );
 
+CREATE TABLE IF NOT EXISTS treecrdt_replica_meta (
+  doc_id TEXT NOT NULL,
+  replica BYTEA NOT NULL,
+  max_counter BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (doc_id, replica)
+);
+
 CREATE TABLE IF NOT EXISTS treecrdt_nodes (
   doc_id TEXT NOT NULL,
   node BYTEA NOT NULL,
@@ -72,6 +79,30 @@ CREATE TABLE IF NOT EXISTS treecrdt_oprefs_children (
 
 CREATE INDEX IF NOT EXISTS idx_treecrdt_oprefs_children_doc_parent_seq
   ON treecrdt_oprefs_children (doc_id, parent, seq);
+
+CREATE OR REPLACE FUNCTION treecrdt_update_replica_meta_after_insert()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path FROM CURRENT
+AS $$
+BEGIN
+  INSERT INTO treecrdt_replica_meta (doc_id, replica, max_counter)
+  SELECT doc_id, replica, MAX(counter)
+  FROM treecrdt_inserted_ops
+  GROUP BY doc_id, replica
+  ON CONFLICT (doc_id, replica) DO UPDATE
+  SET max_counter = GREATEST(treecrdt_replica_meta.max_counter, EXCLUDED.max_counter)
+  WHERE treecrdt_replica_meta.max_counter < EXCLUDED.max_counter;
+  RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS treecrdt_ops_replica_meta_after_insert ON treecrdt_ops;
+CREATE TRIGGER treecrdt_ops_replica_meta_after_insert
+AFTER INSERT ON treecrdt_ops
+REFERENCING NEW TABLE AS treecrdt_inserted_ops
+FOR EACH STATEMENT
+EXECUTE FUNCTION treecrdt_update_replica_meta_after_insert();
 "#;
 
 pub fn ensure_schema(client: &mut Client) -> Result<()> {
@@ -107,6 +138,12 @@ pub fn reset_doc_for_tests(client: &mut Client, doc_id: &str) -> Result<()> {
         .map_err(|e| Error::Storage(format!("{e:?}")))?;
     client
         .execute("DELETE FROM treecrdt_meta WHERE doc_id = $1", &[&doc_id])
+        .map_err(|e| Error::Storage(format!("{e:?}")))?;
+    client
+        .execute(
+            "DELETE FROM treecrdt_replica_meta WHERE doc_id = $1",
+            &[&doc_id],
+        )
         .map_err(|e| Error::Storage(format!("{e:?}")))?;
     Ok(())
 }

--- a/packages/treecrdt-postgres-rs/src/store.rs
+++ b/packages/treecrdt-postgres-rs/src/store.rs
@@ -27,6 +27,25 @@ pub(crate) fn storage_debug<E: std::fmt::Debug>(e: E) -> Error {
     Error::Storage(format!("{e:?}"))
 }
 
+fn load_replica_max_counter(c: &mut Client, doc_id: &str, replica: &[u8]) -> Result<u64> {
+    let row = c
+        .query_opt(
+            "SELECT max_counter FROM treecrdt_replica_meta \
+             WHERE doc_id = $1 AND replica = $2 LIMIT 1",
+            &[&doc_id, &replica],
+        )
+        .map_err(storage_debug)?;
+    Ok(row.map(|row| row.get::<_, i64>(0).max(0) as u64).unwrap_or(0))
+}
+
+pub(crate) fn replica_max_counter_in_tx(
+    client: &Rc<RefCell<Client>>,
+    doc_id: &str,
+    replica: &[u8],
+) -> Result<u64> {
+    load_replica_max_counter(&mut client.borrow_mut(), doc_id, replica)
+}
+
 pub(crate) fn node_to_bytes(node: NodeId) -> [u8; 16] {
     node.0.to_be_bytes()
 }
@@ -1012,14 +1031,7 @@ impl Storage for PgOpStorage {
 
     fn latest_counter(&self, replica: &ReplicaId) -> Result<u64> {
         let mut c = self.ctx.client.borrow_mut();
-        let stmt = self.ctx.stmt(
-            &mut c,
-            "SELECT COALESCE(MAX(counter), 0) \
-             FROM treecrdt_ops WHERE doc_id = $1 AND replica = $2",
-        )?;
-        let rows = c.query(&stmt, &[&self.ctx.doc_id, &replica.0]).map_err(storage_debug)?;
-        let row = rows.first().ok_or_else(|| Error::Storage("missing MAX(counter) row".into()))?;
-        Ok(row.get::<_, i64>(0).max(0) as u64)
+        load_replica_max_counter(&mut c, &self.ctx.doc_id, replica.as_bytes())
     }
 
     fn scan_since(

--- a/packages/treecrdt-postgres-rs/tests/postgres_test.rs
+++ b/packages/treecrdt-postgres-rs/tests/postgres_test.rs
@@ -610,6 +610,48 @@ fn postgres_backend_defensive_delete_restores_parent_after_child_insert() {
 }
 
 #[test]
+fn postgres_backend_tracks_replica_counters() {
+    let Some(client) = connect() else {
+        return;
+    };
+    ensure_schema_once(&client);
+
+    let doc_id = format!("test-{}", Uuid::new_v4());
+    let replica = ReplicaId::new(b"writer");
+    let imported = Operation::insert(
+        &replica,
+        7,
+        7,
+        NodeId::ROOT,
+        node(1000),
+        order_key_from_position(0),
+    );
+    append_ops(&client, &doc_id, std::slice::from_ref(&imported)).unwrap();
+
+    assert_eq!(
+        replica_max_counter(&client, &doc_id, replica.as_bytes()).unwrap(),
+        7
+    );
+
+    let local = local_insert(
+        &client,
+        &doc_id,
+        &replica,
+        NodeId::ROOT,
+        node(1001),
+        "last",
+        None,
+        None,
+    )
+    .unwrap();
+    assert_eq!(local.meta.id.counter, 8);
+    assert_eq!(
+        replica_max_counter(&client, &doc_id, replica.as_bytes()).unwrap(),
+        8
+    );
+}
+
+#[test]
 fn postgres_backend_local_ops_drive_core_materialization_flow() {
     let Some(client) = connect() else {
         return;


### PR DESCRIPTION
## Why

Creating a local operation needs the largest counter previously used by that replica. Reading it from the full operation table on every write makes the hot path depend on document history size.

TreeCRDT has no deployed databases yet, so this PR intentionally defines only the new schema. It does **not** migrate or backfill older schemas and it does not support old binaries writing at the same time. Existing development databases should be recreated.

## Change

- Add `treecrdt_replica_meta`, keyed by document and replica.
- Maintain its maximum counter atomically with one statement-level insert trigger, including bulk and remote inserts.
- Read the next local counter from that small table.
- Run the native PostgreSQL backend tests in CI.

## Fast path

- Counter lookup is a primary-key read independent of operation-history size.
- A bulk insert groups maxima once per replica rather than once per operation.
- The trigger is the single write path, so Rust callers do not duplicate cache bookkeeping.
- The upsert writes only when the incoming maximum is larger.

## Verification

- Regression imports counter 7, verifies the cache, and verifies the next local operation uses counter 8.
- `cargo test -p treecrdt-postgres`
- `cargo clippy -p treecrdt-postgres --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
