### PR TITLE
feat(api): add application-owned undo and redo

### DIFF
--- a/.changeset/tall-planes-undo.md
+++ b/.changeset/tall-planes-undo.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/interface': minor
+---
+
+Add `@treecrdt/interface/edits` helpers for capturing, undoing, and redoing local edits.

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1,6 +1,12 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
-import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
+import { edits, PartialEditError } from '@treecrdt/interface/edits';
+import {
+  bytesToHex,
+  nodeIdToBytes16,
+  replicaIdToBytes,
+  TRASH_NODE_ID_HEX,
+} from '@treecrdt/interface/ids';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 
 import type { Filter, OpRef, SyncBackend } from '@treecrdt/sync-protocol';
@@ -139,6 +145,18 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
     {
       name: 'local ops: materialization changes include writeId',
       run: scenarioLocalOpsMaterializationWriteId,
+    },
+    {
+      name: 'local undo: capture/apply supports undo and redo',
+      run: scenarioLocalUndoCaptureApply,
+    },
+    {
+      name: 'local undo: history replay derives undo lazily',
+      run: scenarioLocalUndoHistoryReplay,
+    },
+    {
+      name: 'local undo: imported ops survive history undo/redo',
+      run: scenarioLocalUndoImportedOpsSurvive,
     },
     {
       name: 'append/appendMany: idempotent + headLamport monotonic',
@@ -633,6 +651,254 @@ async function scenarioLocalOpsMaterializationWriteId(
     'bound local insert',
   );
   assertChangeSource(boundInsertEvents[0]!, boundNode, boundInsertOp!, 'bound local insert');
+}
+
+async function scenarioLocalUndoCaptureApply(ctx: TreecrdtEngineConformanceContext): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parentA = nodeIdFromInt(51);
+  const parentB = nodeIdFromInt(52);
+  const sibling = nodeIdFromInt(53);
+  const node = nodeIdFromInt(54);
+  const inserted = nodeIdFromInt(55);
+  const payloadOnly = nodeIdFromInt(56);
+  const originalPayload = new Uint8Array();
+  const nextPayload = new TextEncoder().encode('next-payload');
+  const insertedPayload = new TextEncoder().encode('inserted-payload');
+
+  await engine.local.insert(replica, root, parentA, { type: 'last' }, null);
+  await engine.local.insert(replica, root, parentB, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, sibling, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, node, { type: 'last' }, originalPayload);
+
+  const captured = await edits.capturePlan(engine, replica, async (local) => {
+    await local.move(node, parentB, { type: 'last' });
+    await local.payload(node, nextPayload);
+  });
+  assertEqual(captured.operations.length, 2, 'captured operation count');
+
+  const undone = await edits.undo(engine, replica, captured);
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'parentA after undo');
+  assertBytesEqual(await engine.tree.getPayload(node), originalPayload, 'payload after undo');
+
+  await edits.redo(engine, replica, undone);
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'parentB after redo');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'payload after redo');
+
+  const insertCapture = await edits.capturePlan(engine, replica, async (local) =>
+    local.insert(parentB, inserted, { type: 'last' }, insertedPayload),
+  );
+  const insertUndone = await edits.undo(engine, replica, insertCapture);
+  assertEqual(insertUndone.operations.length, 2, 'insert undo operation count');
+  assertBytesEqual(await engine.tree.getPayload(inserted), null, 'insert payload cleared by undo');
+
+  await edits.redo(engine, replica, insertUndone);
+  assertBytesEqual(await engine.tree.getPayload(inserted), insertedPayload, 'insert redo payload');
+
+  const reinsertCapture = await edits.capturePlan(engine, replica, (local) =>
+    local.insert(parentA, inserted, { type: 'last' }, nextPayload),
+  );
+  await edits.undo(engine, replica, reinsertCapture);
+  assertArrayEqual(await engine.tree.children(parentB), [node, inserted], 'reinsert undo parent');
+  assertBytesEqual(
+    await engine.tree.getPayload(inserted),
+    insertedPayload,
+    'reinsert undo payload',
+  );
+
+  const partialPayload = new TextEncoder().encode('partial-payload');
+  let partial: PartialEditError | undefined;
+  try {
+    await edits.undo(engine, replica, {
+      undo: {
+        actions: [
+          { type: 'payload', node, payload: partialPayload },
+          {
+            type: 'move',
+            node,
+            parent: 'invalid-node-id',
+            index: 0,
+            placement: { type: 'first' },
+          },
+        ],
+      },
+    });
+  } catch (error) {
+    if (error instanceof PartialEditError) partial = error;
+    else throw error;
+  }
+  assert(partial, 'partial edit error');
+  assertEqual(partial.operations.length, 1, 'partial edit committed operation count');
+  assertEqual(partial.undo?.actions.length, 1, 'partial edit inverse count');
+  assertEqual(partial.remaining?.actions.length, 1, 'partial edit remaining action count');
+  assertBytesEqual(await engine.tree.getPayload(node), partialPayload, 'partial edit state');
+
+  await engine.local.delete(replica, node);
+  const revivedPayload = new TextEncoder().encode('revived-payload');
+  const payloadRevival = await edits.capturePlan(engine, replica, (local) =>
+    local.payload(node, revivedPayload),
+  );
+  const payloadRevivalUndone = await edits.undo(engine, replica, payloadRevival);
+  assertEqual(await engine.tree.exists(node), false, 'payload undo restores deleted state');
+  await edits.redo(engine, replica, payloadRevivalUndone);
+  assertBytesEqual(await engine.tree.getPayload(node), revivedPayload, 'payload redo value');
+
+  const payloadOnlyEdit = await edits.capturePlan(engine, replica, (local) =>
+    local.payload(payloadOnly, revivedPayload),
+  );
+  const payloadOnlyUndone = await edits.undo(engine, replica, payloadOnlyEdit);
+  assertEqual(await engine.tree.exists(payloadOnly), false, 'first payload undo');
+  const payloadOnlyRedone = await edits.redo(engine, replica, payloadOnlyUndone);
+  assertBytesEqual(await engine.tree.getPayload(payloadOnly), revivedPayload, 'first payload redo');
+  assertEqual(payloadOnlyRedone.undo.actions.length, 2, 'first payload undo plan stays compact');
+}
+
+async function scenarioLocalUndoHistoryReplay(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  if (!engine.history) return;
+  const historyEngine = engine as typeof engine & { history: NonNullable<typeof engine.history> };
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const parentA = nodeIdFromInt(151);
+  const parentB = nodeIdFromInt(152);
+  const sibling = nodeIdFromInt(153);
+  const node = nodeIdFromInt(154);
+  const inserted = nodeIdFromInt(155);
+  const payloadOnly = nodeIdFromInt(156);
+  const trashMoved = nodeIdFromInt(157);
+  const originalPayload = new Uint8Array();
+  const nextPayload = new TextEncoder().encode('lazy-next-payload');
+  const insertedPayload = new TextEncoder().encode('lazy-inserted-payload');
+  const chainPayload = new TextEncoder().encode('lazy-chain-payload');
+  const replacementPayload = new TextEncoder().encode('lazy-replacement-payload');
+
+  await engine.local.insert(replica, root, parentA, { type: 'last' }, null);
+  await engine.local.insert(replica, root, parentB, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, sibling, { type: 'last' }, null);
+  await engine.local.insert(replica, parentA, node, { type: 'last' }, originalPayload);
+
+  const captured = await edits.capture(engine, replica, async (local) => {
+    await local.move(node, parentB, { type: 'last' });
+    await local.payload(node, nextPayload);
+  });
+  assertEqual(captured.operations.length, 2, 'lazy captured operation count');
+
+  const undoResult = await edits.undo(historyEngine, replica, captured);
+  assertArrayEqual(await engine.tree.children(parentA), [sibling, node], 'lazy parentA after undo');
+  assertBytesEqual(await engine.tree.getPayload(node), originalPayload, 'lazy payload after undo');
+
+  await edits.redo(engine, replica, undoResult);
+  assertArrayEqual(await engine.tree.children(parentB), [node], 'lazy parentB after redo');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'lazy payload after redo');
+
+  const insertCapture = await edits.capture(engine, replica, async (local) =>
+    local.insert(parentB, inserted, { type: 'last' }, insertedPayload),
+  );
+  const insertUndone = await edits.undo(historyEngine, replica, insertCapture);
+  assertBytesEqual(await engine.tree.getPayload(inserted), null, 'lazy insert undo payload');
+
+  await edits.redo(engine, replica, insertUndone);
+  assertBytesEqual(await engine.tree.getPayload(inserted), insertedPayload, 'lazy insert redo');
+
+  const deleteCapture = await edits.capture(engine, replica, (local) => local.delete(node));
+  await edits.undo(historyEngine, replica, deleteCapture);
+  assertArrayEqual(await engine.tree.children(parentB), [node, inserted], 'lazy delete undo');
+
+  const repeatedPayload = await edits.capture(engine, replica, async (local) => {
+    await local.payload(node, chainPayload);
+    await local.payload(node, replacementPayload);
+  });
+  const repeatedUndone = await edits.undo(historyEngine, replica, repeatedPayload);
+  assertEqual(repeatedUndone.operations.length, 1, 'lazy repeated payload undo coalesces');
+  assertBytesEqual(await engine.tree.getPayload(node), nextPayload, 'lazy repeated payload undo');
+  await edits.redo(engine, replica, repeatedUndone);
+  assertBytesEqual(await engine.tree.getPayload(node), replacementPayload, 'lazy repeated redo');
+
+  const payloadOnlyEdit = await edits.capture(engine, replica, (local) =>
+    local.payload(payloadOnly, replacementPayload),
+  );
+  const payloadOnlyUndone = await edits.undo(historyEngine, replica, payloadOnlyEdit);
+  assertEqual(await engine.tree.exists(payloadOnly), false, 'lazy first payload undo');
+  await edits.redo(engine, replica, payloadOnlyUndone);
+  assertBytesEqual(
+    await engine.tree.getPayload(payloadOnly),
+    replacementPayload,
+    'lazy first payload redo',
+  );
+
+  await engine.local.insert(replica, parentA, trashMoved, { type: 'last' }, null);
+  await engine.local.move(replica, trashMoved, TRASH_NODE_ID_HEX, { type: 'first' });
+  const moveFromTrash = await edits.capture(engine, replica, (local) =>
+    local.move(trashMoved, parentA, { type: 'last' }),
+  );
+  const moveFromTrashUndone = await edits.undo(historyEngine, replica, moveFromTrash);
+  assertEqual(await engine.tree.parent(trashMoved), TRASH_NODE_ID_HEX, 'lazy undo restores trash');
+  await edits.redo(engine, replica, moveFromTrashUndone);
+  assertEqual(await engine.tree.parent(trashMoved), parentA, 'lazy redo restores moved node');
+}
+
+async function scenarioLocalUndoImportedOpsSurvive(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const a = ctx.engine;
+  if (!a.history) return;
+  const historyA = a as typeof a & { history: NonNullable<typeof a.history> };
+  const b = await ctx.createEngine({ docId: ctx.docId, name: 'peer-b' });
+
+  const rA = replicaFromLabel('rA');
+  const rB = replicaFromLabel('rB');
+  const root = nodeIdFromInt(0);
+  const anchor = nodeIdFromInt(170);
+  const parentA = nodeIdFromInt(171);
+  const parentB = nodeIdFromInt(172);
+  const target = nodeIdFromInt(173);
+  const remoteSibling = nodeIdFromInt(174);
+  const textEncoder = new TextEncoder();
+  const originalPayload = textEncoder.encode('imported-ops-original');
+  const nextPayload = textEncoder.encode('imported-ops-next');
+  const remotePayload = textEncoder.encode('imported-ops-remote');
+
+  await a.local.insert(rA, root, parentA, { type: 'last' }, null);
+  await a.local.insert(rA, root, parentB, { type: 'last' }, null);
+  await a.local.insert(rA, parentA, anchor, { type: 'last' }, null);
+  await a.local.insert(rA, parentA, target, { type: 'last' }, originalPayload);
+
+  // Bring B to the same initial state, then let A and B diverge.
+  await b.ops.appendMany(await a.ops.all());
+
+  const captured = await edits.capture(a, rA, async (local) => {
+    await local.move(target, parentB, { type: 'last' });
+    await local.payload(target, nextPayload);
+  });
+
+  // This simulates a sync/import that happens after the local edit was captured but before undo.
+  await b.local.delete(rB, anchor);
+  await b.local.insert(rB, parentA, remoteSibling, { type: 'last' }, remotePayload);
+  await a.ops.appendMany(await b.ops.all());
+
+  const undone = await edits.undo(historyA, rA, captured);
+  assertArrayEqual(
+    await a.tree.children(parentA),
+    [target, remoteSibling],
+    'undo rebases missing sibling anchor',
+  );
+  assertBytesEqual(await a.tree.getPayload(target), originalPayload, 'imported undo payload');
+  assertBytesEqual(
+    await a.tree.getPayload(remoteSibling),
+    remotePayload,
+    'remote payload survives undo',
+  );
+
+  await edits.redo(a, rA, undone);
+  assertArrayEqual(await a.tree.children(parentA), [remoteSibling], 'imported redo parent');
+  assertBytesEqual(await a.tree.getPayload(target), nextPayload, 'imported redo payload');
+
+  await b.ops.appendMany(await a.ops.all());
+  assertArrayEqual(await b.tree.children(parentB), [target], 'peer receives redo');
+  assertBytesEqual(await b.tree.getPayload(remoteSibling), remotePayload, 'peer keeps remote op');
 }
 
 async function scenarioAppendIdempotentAndHeadLamportMonotonic(

--- a/packages/treecrdt-ts/package.json
+++ b/packages/treecrdt-ts/package.json
@@ -24,6 +24,10 @@
     "./engine": {
       "import": "./dist/src/engine.js",
       "types": "./dist/src/engine.d.ts"
+    },
+    "./edits": {
+      "import": "./dist/src/edits.js",
+      "types": "./dist/src/edits.d.ts"
     }
   },
   "files": [

--- a/packages/treecrdt-ts/src/edits.ts
+++ b/packages/treecrdt-ts/src/edits.ts
@@ -1,0 +1,404 @@
+import type { Operation, ReplicaId } from './index.js';
+import type { TreecrdtSqlitePlacement } from './sqlite.js';
+import type {
+  BoundTreecrdtEngineLocal,
+  EngineHistory,
+  LocalEditAction,
+  LocalEditPlan,
+  LocalMoveAction,
+  LocalWriteOptions,
+  OperationEdit,
+  TreecrdtEngineLocal,
+  TreecrdtEngineTree,
+} from './engine.js';
+
+/**
+ * A forward local write that reverses a previously captured local write.
+ *
+ * These are intentionally not oplog rewinds. Applying a plan mints new local ops, so undo/redo
+ * remains mergeable with remote peers.
+ */
+type Action = LocalEditAction;
+
+export type Plan = LocalEditPlan;
+
+type Target = {
+  tree: TreecrdtEngineTree;
+  local: TreecrdtEngineLocal;
+};
+
+type HistoryTarget = Target & {
+  history: EngineHistory;
+};
+
+export type CapturedPlan<T> = {
+  result: T;
+  operations: Operation[];
+  undo: Plan;
+};
+
+export type Captured<T> = {
+  result: T;
+  operations: Operation[];
+};
+
+export type { OperationEdit };
+
+export type Undoable = {
+  undo: Plan;
+};
+
+export type Redoable = {
+  redo: Plan;
+};
+
+export type UndoResult = {
+  operations: Operation[];
+  redo: Plan;
+};
+
+export type RedoResult = {
+  operations: Operation[];
+  undo: Plan;
+};
+
+/**
+ * A callback or plan failed after one or more local operations had already committed.
+ *
+ * Callers must publish `operations`. `undo` reverses the committed prefix, and `remaining`
+ * contains the failed plan action plus any actions that were not attempted.
+ */
+export class PartialEditError extends Error {
+  readonly cause: unknown;
+  readonly operations: Operation[];
+  readonly undo?: Plan;
+  readonly remaining?: Plan;
+
+  constructor(cause: unknown, details: { operations: Operation[]; undo?: Plan; remaining?: Plan }) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(`treecrdt: edit partially applied: ${message}`);
+    this.name = 'PartialEditError';
+    this.cause = cause;
+    this.operations = [...details.operations];
+    this.undo = details.undo;
+    this.remaining = details.remaining;
+  }
+}
+
+class PlanApplyError extends Error {
+  readonly cause: unknown;
+  readonly remaining: Plan;
+
+  constructor(cause: unknown, remaining: Plan) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    super(message);
+    this.name = 'PlanApplyError';
+    this.cause = cause;
+    this.remaining = remaining;
+  }
+}
+
+function cloneBytes(bytes: Uint8Array | null): Uint8Array | null {
+  return bytes === null ? null : new Uint8Array(bytes);
+}
+
+async function visiblePlacementBefore(
+  tree: TreecrdtEngineTree,
+  parent: string,
+  node: string,
+): Promise<{ index: number; placement: TreecrdtSqlitePlacement }> {
+  const siblings = await tree.children(parent);
+  const index = siblings.indexOf(node);
+  if (index < 0) {
+    throw new Error(`treecrdt: cannot capture undo position for non-visible node ${node}`);
+  }
+  return {
+    index,
+    placement: index === 0 ? { type: 'first' } : { type: 'after', after: siblings[index - 1]! },
+  };
+}
+
+async function currentStructuralUndoAction(
+  tree: TreecrdtEngineTree,
+  node: string,
+  detached: 'reject' | 'payload',
+): Promise<Action> {
+  if (!(await tree.exists(node))) return { type: 'delete', node };
+
+  const parent = await tree.parent(node);
+  if (parent === null) {
+    if (detached === 'payload') {
+      return { type: 'payload', node, payload: cloneBytes(await tree.getPayload(node)) };
+    }
+    throw new Error(`treecrdt: cannot capture undo for detached node ${node}`);
+  }
+  const position = await visiblePlacementBefore(tree, parent, node);
+  return {
+    type: 'move',
+    node,
+    parent,
+    ...position,
+  };
+}
+
+function reverseActionGroups(groups: Action[][]): Plan {
+  const actions: Action[] = [];
+  for (const action of [...groups].reverse().flat()) {
+    const previous = actions[actions.length - 1];
+    if (
+      action.type === 'payload' &&
+      previous?.type === 'payload' &&
+      action.node === previous.node
+    ) {
+      actions[actions.length - 1] = action;
+    } else {
+      actions.push(action);
+    }
+  }
+  return { actions };
+}
+
+/**
+ * Capture the inverse plan eagerly while local writes are performed.
+ *
+ * This is useful when a caller wants undo metadata immediately, but it may read current
+ * parent/sibling/payload state on the write path. App integrations that have `engine.history`
+ * should prefer `capture(...)` and defer inversion until undo time.
+ */
+export async function capturePlan<T>(
+  target: Target,
+  replica: ReplicaId,
+  fn: (local: BoundTreecrdtEngineLocal) => Promise<T>,
+  defaults: LocalWriteOptions = {},
+): Promise<CapturedPlan<T>> {
+  const base = target.local.forReplica(replica, defaults);
+  const operations: Operation[] = [];
+  const actionGroups: Action[][] = [];
+
+  const record = (op: Operation, actions: Action[]) => {
+    operations.push(op);
+    actionGroups.push(actions);
+  };
+
+  const local: BoundTreecrdtEngineLocal = {
+    insert: async (parent, node, placement, payload, opts) => {
+      const wasVisible = await target.tree.exists(node);
+      const previousParent = wasVisible ? await target.tree.parent(node) : null;
+      if (wasVisible && previousParent === null) {
+        throw new Error(`treecrdt: cannot capture undo for insert over detached node ${node}`);
+      }
+      const previousPayload =
+        payload !== null ? cloneBytes(await target.tree.getPayload(node)) : null;
+      const undo: Action[] =
+        previousParent === null
+          ? [
+              ...(payload !== null
+                ? ([{ type: 'payload', node, payload: previousPayload }] satisfies Action[])
+                : []),
+              { type: 'delete', node },
+            ]
+          : [
+              ...(payload !== null
+                ? ([
+                    {
+                      type: 'payload',
+                      node,
+                      payload: previousPayload,
+                    },
+                  ] satisfies Action[])
+                : []),
+              {
+                type: 'move',
+                node,
+                parent: previousParent,
+                ...(await visiblePlacementBefore(target.tree, previousParent, node)),
+              },
+            ];
+      const op = await base.insert(parent, node, placement, payload, opts);
+      record(op, undo);
+      return op;
+    },
+    move: async (node, newParent, placement, opts) => {
+      const undo = await currentStructuralUndoAction(target.tree, node, 'reject');
+      const op = await base.move(node, newParent, placement, opts);
+      record(op, [undo]);
+      return op;
+    },
+    delete: async (node, opts) => {
+      const undo = await currentStructuralUndoAction(target.tree, node, 'payload');
+      const op = await base.delete(node, opts);
+      record(op, [undo]);
+      return op;
+    },
+    payload: async (node, payload, opts) => {
+      const wasVisible = await target.tree.exists(node);
+      const previous = await target.tree.getPayload(node);
+      const op = await base.payload(node, payload, opts);
+      record(op, [
+        { type: 'payload', node, payload: cloneBytes(previous) },
+        ...(!wasVisible ? ([{ type: 'delete', node }] satisfies Action[]) : []),
+      ]);
+      return op;
+    },
+  };
+
+  try {
+    const result = await fn(local);
+    return { result, operations, undo: reverseActionGroups(actionGroups) };
+  } catch (error) {
+    if (operations.length === 0) {
+      throw error instanceof PlanApplyError ? error.cause : error;
+    }
+    throw new PartialEditError(error instanceof PlanApplyError ? error.cause : error, {
+      operations,
+      undo: reverseActionGroups(actionGroups),
+      ...(error instanceof PlanApplyError ? { remaining: error.remaining } : {}),
+    });
+  }
+}
+
+/**
+ * Capture the local operations produced by the callback.
+ *
+ * This avoids inverse reads on the write path. Use `undo(...)` with a history-capable engine to
+ * derive the inverse later from the operation log.
+ */
+export async function capture<T>(
+  target: Target,
+  replica: ReplicaId,
+  fn: (local: BoundTreecrdtEngineLocal) => Promise<T>,
+  defaults: LocalWriteOptions = {},
+): Promise<Captured<T>> {
+  const base = target.local.forReplica(replica, defaults);
+  const operations: Operation[] = [];
+
+  const local: BoundTreecrdtEngineLocal = {
+    insert: async (parent, node, placement, payload, opts) => {
+      const op = await base.insert(parent, node, placement, payload, opts);
+      operations.push(op);
+      return op;
+    },
+    move: async (node, newParent, placement, opts) => {
+      const op = await base.move(node, newParent, placement, opts);
+      operations.push(op);
+      return op;
+    },
+    delete: async (node, opts) => {
+      const op = await base.delete(node, opts);
+      operations.push(op);
+      return op;
+    },
+    payload: async (node, payload, opts) => {
+      const op = await base.payload(node, payload, opts);
+      operations.push(op);
+      return op;
+    },
+  };
+
+  try {
+    const result = await fn(local);
+    return { result, operations };
+  } catch (error) {
+    if (operations.length === 0) throw error;
+    throw new PartialEditError(error, { operations });
+  }
+}
+
+async function resolveMovePlacement(tree: TreecrdtEngineTree, action: LocalMoveAction) {
+  if (action.placement.type !== 'after') return action.placement;
+
+  const siblings = (await tree.children(action.parent)).filter((node) => node !== action.node);
+  if (siblings.includes(action.placement.after)) {
+    return action.placement;
+  }
+
+  const index = Math.max(0, Math.min(action.index - 1, siblings.length));
+  return index === 0
+    ? ({ type: 'first' } as const)
+    : ({ type: 'after', after: siblings[index - 1]! } as const);
+}
+
+async function applyPlan(
+  target: Target,
+  local: BoundTreecrdtEngineLocal,
+  plan: Plan,
+  opts?: LocalWriteOptions,
+): Promise<void> {
+  for (const [index, action] of plan.actions.entries()) {
+    try {
+      switch (action.type) {
+        case 'delete':
+          await local.delete(action.node, opts);
+          break;
+        case 'move':
+          await local.move(
+            action.node,
+            action.parent,
+            await resolveMovePlacement(target.tree, action),
+            opts,
+          );
+          break;
+        case 'payload':
+          await local.payload(action.node, cloneBytes(action.payload), opts);
+          break;
+      }
+    } catch (error) {
+      throw new PlanApplyError(error, { actions: plan.actions.slice(index) });
+    }
+  }
+}
+
+/**
+ * Revert a captured edit by minting new local operations.
+ *
+ * This is a force-revert: a newer undo operation can replace later remote writes to the same
+ * node or payload. Applications that need selective undo should detect those conflicts first.
+ * Structural edits whose prior state was a live, parentless node cannot be represented and reject.
+ */
+export async function undo(
+  target: HistoryTarget,
+  replica: ReplicaId,
+  edit: OperationEdit,
+  opts?: LocalWriteOptions,
+): Promise<UndoResult>;
+export async function undo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Undoable,
+  opts?: LocalWriteOptions,
+): Promise<UndoResult>;
+export async function undo(
+  target: Target | HistoryTarget,
+  replica: ReplicaId,
+  edit: OperationEdit | Undoable,
+  opts?: LocalWriteOptions,
+): Promise<UndoResult> {
+  const undo =
+    'undo' in edit ? edit.undo : await (target as Partial<HistoryTarget>).history?.invert(edit);
+  if (!undo) {
+    throw new Error('treecrdt: history inversion is not implemented by this engine');
+  }
+  const applied = await capturePlan(target, replica, (local) =>
+    applyPlan(target, local, undo, opts),
+  );
+  return { operations: applied.operations, redo: applied.undo };
+}
+
+export async function redo(
+  target: Target,
+  replica: ReplicaId,
+  edit: Redoable,
+  opts?: LocalWriteOptions,
+): Promise<RedoResult> {
+  const applied = await capturePlan(target, replica, (local) =>
+    applyPlan(target, local, edit.redo, opts),
+  );
+  return { operations: applied.operations, undo: applied.undo };
+}
+
+export const edits = {
+  capture,
+  capturePlan,
+  redo,
+  undo,
+};

--- a/packages/treecrdt-ts/src/engine.ts
+++ b/packages/treecrdt-ts/src/engine.ts
@@ -159,6 +159,40 @@ export type TreecrdtEngineOpRefs = {
   children: (parent: string) => Promise<Uint8Array[]>;
 };
 
+export type LocalDeleteAction = {
+  type: 'delete';
+  node: string;
+};
+
+export type LocalMoveAction = {
+  type: 'move';
+  node: string;
+  parent: string;
+  /** Zero-based position before the captured operation; used if the sibling anchor disappears. */
+  index: number;
+  placement: TreecrdtSqlitePlacement;
+};
+
+export type LocalPayloadAction = {
+  type: 'payload';
+  node: string;
+  payload: Uint8Array | null;
+};
+
+export type LocalEditAction = LocalDeleteAction | LocalMoveAction | LocalPayloadAction;
+
+export type LocalEditPlan = {
+  actions: LocalEditAction[];
+};
+
+export type OperationEdit = {
+  operations: Operation[];
+};
+
+export type EngineHistory = {
+  invert: (edit: OperationEdit) => Promise<LocalEditPlan>;
+};
+
 export type TreecrdtEngineTree = {
   children: (parent: string) => Promise<string[]>;
   childrenPage?: (
@@ -273,6 +307,7 @@ export type TreecrdtEngine = {
   tree: TreecrdtEngineTree;
   meta: TreecrdtEngineMeta;
   local: TreecrdtEngineLocal;
+  history?: EngineHistory;
   onMaterialized: (listener: MaterializationListener) => () => void;
   close: () => Promise<void>;
 };


### PR DESCRIPTION
## What this does

Adds the application-facing edit, undo, and redo helpers on top of the history primitive in #175.

- `edits.capture(...)` records the local operation IDs produced by one edit and derives its inverse lazily when undo is requested.
- `edits.capturePlan(...)` eagerly captures an inverse plan for engines that do not expose history.
- `edits.undo(...)` applies an inverse as normal forward CRDT operations and returns a redo plan.
- `edits.redo(...)` applies that redo plan and returns a fresh undo plan.

The application owns the undo/redo stacks. The library does not impose UI grouping, persistence, or stack limits.

## Semantics

Undo is equivalent to a collaborative revert: it never deletes or rewrites oplog entries. Because the inverse is a newer write, it is a force-revert and may replace later remote writes to the same node or payload. Applications that want selective undo should check for those conflicts before invoking it.

Multi-action edits report `PartialEditError` if an adapter fails after some operations have committed. The error includes the committed operations, their inverse, and the remaining actions so callers can recover explicitly.

## Fast paths

- `capture(...)` only records operation IDs on the write path; it does not derive or store snapshots until undo.
- `first`/`last` placement does not read current children; only an `after` anchor needs sibling lookup and stale-anchor rebasing.
- Consecutive payload inverses are coalesced by the history layer.

## Scope

This PR contains the public TypeScript API and cross-engine conformance coverage. Backend-specific SQLite client bindings are split into the next PR.

## Validation

- Interface TypeScript build
- Engine conformance build and tests

## Dependency

Review only the incremental diff. This is stacked on the mirror of #175, which is itself stacked on #177.
