### PR TITLE
feat(sqlite): expose history-derived undo

### DIFF
--- a/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
@@ -246,7 +246,9 @@ fn read_row(stmt: *mut sqlite3_stmt) -> Result<JsonOp, c_int> {
         } else {
             let ptr = sqlite_column_blob(stmt, 7) as *const u8;
             let len = sqlite_column_bytes(stmt, 7) as usize;
-            if ptr.is_null() {
+            if len == 0 {
+                Some(Vec::new())
+            } else if ptr.is_null() {
                 None
             } else {
                 Some(slice::from_raw_parts(ptr, len).to_vec())

--- a/packages/treecrdt-sqlite-node/src/index.ts
+++ b/packages/treecrdt-sqlite-node/src/index.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 import {
   createTreecrdtSqliteAdapter,
   createTreecrdtSqliteWriter,
+  decodeSqliteLocalEditPlan,
   decodeSqliteNodeIds,
   decodeSqliteOpRefs,
   decodeSqliteOps,
@@ -23,7 +24,12 @@ import {
   createMaterializationDispatcher,
   createTreecrdtEngineLocal,
 } from '@treecrdt/interface/engine';
-import type { LocalWriteOptions, TreecrdtEngine, WriteOptions } from '@treecrdt/interface/engine';
+import type {
+  EngineHistory,
+  LocalWriteOptions,
+  TreecrdtEngine,
+  WriteOptions,
+} from '@treecrdt/interface/engine';
 import {
   createTreecrdtSqliteAuthApi,
   type TreecrdtSqliteAuthApi,
@@ -126,7 +132,13 @@ export function createSqliteNodeApi(db: any, opts: { maxBulkOps?: number } = {})
 export function createTreecrdtClient(
   db: any,
   opts: { docId?: string; maxBulkOps?: number } = {},
-): Promise<TreecrdtEngine & { runner: SqliteRunner; auth: TreecrdtSqliteAuthApi }> {
+): Promise<
+  Omit<TreecrdtEngine, 'history'> & {
+    history: EngineHistory;
+    runner: SqliteRunner;
+    auth: TreecrdtSqliteAuthApi;
+  }
+> {
   const runner = createRunner(db);
   const materialized = createMaterializationDispatcher();
   const adapter = createTreecrdtSqliteAdapter(runner, {
@@ -248,6 +260,12 @@ export function createTreecrdtClient(
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
     auth: createTreecrdtSqliteAuthApi({ runner, docId }),
     local,
+    history: {
+      invert: async (edit) =>
+        decodeSqliteLocalEditPlan(
+          await adapter.historyInvert!(edit.operations.map((operation) => operation.meta.id)),
+        ),
+    },
     onMaterialized: materialized.onMaterialized,
     runner,
     close: async () => {

--- a/packages/treecrdt-ts/src/adapter.ts
+++ b/packages/treecrdt-ts/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { Operation } from './index.js';
+import type { Operation, OperationId } from './index.js';
 import type { MaterializationOutcome } from './engine.js';
 
 export type SerializeNodeId = (id: string) => Uint8Array;
@@ -77,6 +77,12 @@ export interface TreecrdtAdapter {
    * Returns the opaque byte payload or null if the node has no payload.
    */
   treePayload(node: Uint8Array): Promise<Uint8Array | null>;
+  /**
+   * Derive a local edit plan that inverts the operations with these ids.
+   *
+   * Returns raw JSON-decoded plan rows from the backend's operation history.
+   */
+  historyInvert?(operationIds: OperationId[]): Promise<unknown>;
   /**
    * Fetch the maximum lamport seen in the op log.
    */

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -5,6 +5,7 @@ import type {
   MaterializationEvent,
   MaterializationOutcome,
   MaterializationSource,
+  LocalEditPlan,
 } from './engine.js';
 import {
   decodeNodeId,
@@ -14,7 +15,7 @@ import {
   ROOT_NODE_ID_HEX,
   replicaIdToBytes,
 } from './ids.js';
-import type { Operation, OperationKind, ReplicaId } from './index.js';
+import type { Operation, OperationId, OperationKind, ReplicaId } from './index.js';
 
 export type SqlCall = {
   sql: string;
@@ -348,6 +349,7 @@ export function createTreecrdtSqliteAdapter(
     treeParent: (node) => treecrdtTreeParent(runner, node, emitOutcome),
     treeExists: (node) => treecrdtTreeExists(runner, node, emitOutcome),
     treePayload: (node) => treecrdtTreePayload(runner, node, emitOutcome),
+    historyInvert: (edit) => treecrdtHistoryInvert(runner, edit),
     headLamport: () => treecrdtHeadLamport(runner),
     replicaMaxCounter: (replica) => treecrdtReplicaMaxCounter(runner, replica),
     appendOp: (op, serializeNodeId, serializeReplica) =>
@@ -564,6 +566,19 @@ async function treecrdtTreePayload(
   );
   if (encoded === null || encoded === undefined || encoded === 'n') return null;
   return hexToBytes(encoded.slice(1));
+}
+
+async function treecrdtHistoryInvert(
+  runner: SqliteRunner,
+  operationIds: OperationId[],
+): Promise<unknown> {
+  const ids = operationIds.map((id) => ({
+    replica: Array.from(id.replica),
+    counter: id.counter,
+  }));
+  return sqliteGetJson<unknown>(runner, 'SELECT treecrdt_history_invert(?1)', [
+    JSON.stringify(ids),
+  ]);
 }
 
 /**
@@ -874,6 +889,41 @@ export function decodeSqliteTreeRows(raw: unknown): SqliteTreeRow[] {
     const tombstone = Boolean(row.tombstone);
     return { node, parent, orderKey, tombstone };
   });
+}
+
+export function decodeSqliteLocalEditPlan(raw: unknown): LocalEditPlan {
+  const value = (raw ?? {}) as any;
+  const actions = Array.isArray(value.actions) ? value.actions : [];
+  return {
+    actions: actions.map((action: any) => {
+      const type = String(action.type);
+      if (type === 'delete') {
+        return { type, node: decodeNodeId(action.node) };
+      }
+      if (type === 'move') {
+        const placement = action.placement as any;
+        const placementType = String(placement?.type);
+        return {
+          type,
+          node: decodeNodeId(action.node),
+          parent: decodeNodeId(action.parent),
+          index: Math.max(0, Number(action.index) || 0),
+          placement:
+            placementType === 'after'
+              ? { type: 'after', after: decodeNodeId(placement.after) }
+              : { type: 'first' },
+        };
+      }
+      if (type === 'payload') {
+        return {
+          type,
+          node: decodeNodeId(action.node),
+          payload: decodeSqlitePayload(action.payload),
+        };
+      }
+      throw new Error(`unknown local edit action type: ${type}`);
+    }),
+  };
 }
 
 export function decodeSqliteOps(raw: unknown): Operation[] {

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -2,6 +2,7 @@ import { clearOpfsStorage, detectOpfsSupport } from './opfs.js';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
 import {
   createTreecrdtSqliteWriter,
+  decodeSqliteLocalEditPlan,
   decodeSqliteNodeIds,
   decodeSqliteOpRefs,
   decodeSqliteOps,
@@ -720,6 +721,10 @@ export async function buildDirectClient(
           const [node] = params as RpcParams<'treeExists'>;
           return (await adapter.treeExists(nodeIdToBytes16(node))) as any;
         }
+        case 'historyInvert': {
+          const [edit] = params as RpcParams<'historyInvert'>;
+          return (await adapter.historyInvert!(edit)) as any;
+        }
         case 'headLamport':
           return (await adapter.headLamport()) as any;
         case 'replicaMaxCounter': {
@@ -840,6 +845,10 @@ function makeTreecrdtClientFromCall(opts: {
     const result = await call('treePayload', [node]);
     return result === null ? null : toRpcBytes(result);
   };
+  const historyInvertImpl = async (edit: { operations: Operation[] }) =>
+    decodeSqliteLocalEditPlan(
+      await call('historyInvert', [edit.operations.map((operation) => operation.meta.id)]),
+    );
   const headLamportImpl = async () => Number(await call('headLamport', []));
   const replicaMaxCounterImpl = async (replica: Operation['meta']['id']['replica']) =>
     Number(await call('replicaMaxCounter', [Array.from(encodeReplica(replica))]));
@@ -949,6 +958,7 @@ function makeTreecrdtClientFromCall(opts: {
     },
     meta: { headLamport: headLamportImpl, replicaMaxCounter: replicaMaxCounterImpl },
     local,
+    history: { invert: historyInvertImpl },
     onMaterialized: materialized.onMaterialized,
     close: closeImpl,
     drop: dropImpl,

--- a/packages/treecrdt-wa-sqlite/src/common-worker.ts
+++ b/packages/treecrdt-wa-sqlite/src/common-worker.ts
@@ -1,7 +1,7 @@
 import { dbGetText } from './sql.js';
 import type { Database } from './types.js';
 import { nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
-import type { Operation } from '@treecrdt/interface';
+import type { Operation, OperationId } from '@treecrdt/interface';
 import type { TreecrdtAdapter } from '@treecrdt/interface';
 import type { OpenTreecrdtDbResult } from './open.js';
 import { clearOpfsStorage } from './opfs.js';
@@ -134,6 +134,10 @@ export class CommonWorkerSession {
     return await this.ensureApi().treeExists(nodeIdToBytes16(node));
   }
 
+  async historyInvert(operationIds: OperationId[]) {
+    return await this.ensureApi().historyInvert!(operationIds);
+  }
+
   async headLamport() {
     return await this.ensureApi().headLamport();
   }
@@ -165,6 +169,7 @@ export function createCommonWorkerRpcHandlers(session: CommonWorkerSession) {
     treeParent: (node: string) => session.treeParent(node),
     treeExists: (node: string) => session.treeExists(node),
     treePayload: (node: string) => session.treePayload(node),
+    historyInvert: (operationIds: OperationId[]) => session.historyInvert(operationIds),
     headLamport: () => session.headLamport(),
     replicaMaxCounter: (replica: number[]) => session.replicaMaxCounter(replica),
   } as const;

--- a/packages/treecrdt-wa-sqlite/src/rpc.ts
+++ b/packages/treecrdt-wa-sqlite/src/rpc.ts
@@ -1,4 +1,4 @@
-import type { Operation } from '@treecrdt/interface';
+import type { Operation, OperationId } from '@treecrdt/interface';
 import type { MaterializationEvent, MaterializationOutcome } from '@treecrdt/interface/engine';
 
 export type RpcStorageMode = 'memory' | 'opfs';
@@ -42,6 +42,10 @@ export type RpcSchema = {
   treeParent: { params: [node: string]; result: Uint8Array | null };
   treeExists: { params: [node: string]; result: boolean };
   treePayload: { params: [node: string]; result: Uint8Array | null };
+  historyInvert: {
+    params: [operationIds: OperationId[]];
+    result: unknown;
+  };
   headLamport: { params: []; result: number };
   replicaMaxCounter: { params: [replica: number[]]; result: number };
   close: { params: []; result: void };

--- a/packages/treecrdt-wa-sqlite/src/types.ts
+++ b/packages/treecrdt-wa-sqlite/src/types.ts
@@ -1,4 +1,8 @@
-import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
+import type {
+  EngineHistory,
+  MaterializationEvent,
+  TreecrdtEngine,
+} from '@treecrdt/interface/engine';
 import { createMaterializationDispatcher } from '@treecrdt/interface/engine';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 import type { RpcMethod, RpcParams, RpcRequest, RpcResult } from './rpc.js';
@@ -32,7 +36,8 @@ export type TreecrdtAssets = {
   baseUrl?: string;
 };
 
-export type TreecrdtClient = TreecrdtEngine & {
+export type TreecrdtClient = Omit<TreecrdtEngine, 'history'> & {
+  history: EngineHistory;
   mode: ClientMode;
   runtime: RuntimeMode;
   storage: StorageMode;


### PR DESCRIPTION
## What this does

Connects the history-derived undo primitive from #175 to the SQLite-backed clients.

- `@treecrdt/sqlite-node` exposes lazy `engine.history.invert(...)`.
- `@treecrdt/wa-sqlite` exposes the same capability in direct and worker runtimes.
- The shared SQLite adapter sends exact operation IDs to the extension and decodes the returned inverse plan.

This keeps the public edit API backend-neutral while allowing SQLite engines to use lazy history inversion.

## Fast path

JavaScript sends compact operation IDs through one SQLite call. Canonical history and prior-state reconstruction stay inside the native/WASM extension; the full oplog is not copied across the JavaScript boundary.

## Backend scope

This PR implements the lazy history capability for SQLite-backed engines. Postgres and interface-only engines use the backend-neutral eager `capturePlan(...)` API from the preceding PR; no compatibility adapter is added.

## Validation

- Interface, conformance, sqlite-node, and wa-sqlite TypeScript builds
- sqlite-node conformance: 34/34
- Native extension tests: 24/24

## Dependency

Review only the incremental diff. This is stacked on the edit/undo API PR, which is stacked on #175 and #177.