### PR TITLE
fix(wa-sqlite): recover cleanly from OPFS initialization failure

### DIFF
--- a/.changeset/wa-sqlite-opfs-init-fallback.md
+++ b/.changeset/wa-sqlite-opfs-init-fallback.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Close failed SQLite and OPFS resources, honor memory fallback after initialization failures, and clean up failed worker lifecycles.

--- a/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
@@ -17,6 +17,7 @@ type LifecycleOptions = {
   docId: string;
   filename: string;
   runtime: LifecycleRuntime;
+  sharedWorkerName?: string;
 };
 
 export type LifecycleState = {
@@ -39,7 +40,10 @@ async function createOpfsLifecycleClient(opts: LifecycleOptions): Promise<Treecr
   return createTreecrdtClient({
     docId: opts.docId,
     storage: { type: 'opfs', filename: opts.filename, fallback: 'throw' },
-    runtime: { type: opts.runtime },
+    runtime:
+      opts.runtime === 'shared-worker' && opts.sharedWorkerName
+        ? { type: 'shared-worker', name: opts.sharedWorkerName }
+        : { type: opts.runtime },
   });
 }
 

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -2,6 +2,12 @@ import { test, expect, type Page } from '@playwright/test';
 
 type LifecycleHarness = NonNullable<Window['__treecrdtLifecycle']>;
 type LifecycleRuntime = 'direct' | 'dedicated-worker' | 'shared-worker';
+type LifecycleOptions = {
+  docId: string;
+  filename: string;
+  runtime: LifecycleRuntime;
+  sharedWorkerName?: string;
+};
 
 const scenarios: Array<{
   runtime: LifecycleRuntime;
@@ -39,10 +45,7 @@ async function support(page: Page): Promise<ReturnType<LifecycleHarness['support
   });
 }
 
-async function drop(
-  page: Page,
-  opts: { docId: string; filename: string; runtime: LifecycleRuntime },
-) {
+async function drop(page: Page, opts: LifecycleOptions) {
   await page.evaluate(async (dropOpts) => {
     const harness = window.__treecrdtLifecycle;
     if (!harness) throw new Error('__treecrdtLifecycle not available');
@@ -50,15 +53,7 @@ async function drop(
   }, opts);
 }
 
-async function write(
-  page: Page,
-  opts: {
-    docId: string;
-    filename: string;
-    runtime: LifecycleRuntime;
-    closeBeforeReload?: boolean;
-  },
-) {
+async function write(page: Page, opts: LifecycleOptions & { closeBeforeReload?: boolean }) {
   return page.evaluate(async (writeOpts) => {
     const harness = window.__treecrdtLifecycle;
     if (!harness) throw new Error('__treecrdtLifecycle not available');
@@ -66,10 +61,7 @@ async function write(
   }, opts);
 }
 
-async function read(
-  page: Page,
-  opts: { docId: string; filename: string; runtime: LifecycleRuntime },
-) {
+async function read(page: Page, opts: LifecycleOptions) {
   return page.evaluate(async (readOpts) => {
     const harness = window.__treecrdtLifecycle;
     if (!harness) throw new Error('__treecrdtLifecycle not available');
@@ -143,4 +135,55 @@ test.describe('browser OPFS lifecycle', () => {
       });
     }
   }
+
+  test('releases a SharedWorker port after failed OPFS initialization', async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name !== 'chromium-dev') test.skip();
+    test.setTimeout(120_000);
+    page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));
+
+    const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+    const sharedWorkerName = `lifecycle-recovery-${suffix}`;
+    const failedOpts: LifecycleOptions = {
+      docId: `lifecycle-recovery-failed-${suffix}`,
+      filename: `/${'x'.repeat(512)}.db`,
+      runtime: 'shared-worker',
+      sharedWorkerName,
+    };
+    const firstOpts: LifecycleOptions = {
+      docId: `lifecycle-recovery-first-${suffix}`,
+      filename: `/lifecycle-recovery-first-${suffix}.db`,
+      runtime: 'shared-worker',
+      sharedWorkerName,
+    };
+    const secondOpts: LifecycleOptions = {
+      docId: `lifecycle-recovery-second-${suffix}`,
+      filename: `/lifecycle-recovery-second-${suffix}.db`,
+      runtime: 'shared-worker',
+      sharedWorkerName,
+    };
+
+    await waitForHarness(page);
+    const opfsSupport = await support(page);
+    if (!opfsSupport.available) test.skip(true, `OPFS unavailable: ${opfsSupport.reason}`);
+    expect(new TextEncoder().encode(failedOpts.filename).byteLength).toBeGreaterThan(512);
+
+    try {
+      await expect(write(page, failedOpts)).rejects.toThrow(/sqlite3_open_v2|OPFS requested/);
+
+      expectReloadedTree(await write(page, { ...firstOpts, closeBeforeReload: true }), {
+        mode: 'worker',
+        runtime: 'shared-worker',
+      });
+
+      expectReloadedTree(await write(page, { ...secondOpts, closeBeforeReload: true }), {
+        mode: 'worker',
+        runtime: 'shared-worker',
+      });
+    } finally {
+      await drop(page, { ...firstOpts, runtime: 'direct' }).catch(() => {});
+      await drop(page, { ...secondOpts, runtime: 'direct' }).catch(() => {});
+    }
+  });
 });

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -367,24 +367,8 @@ async function createWorkerClient(opts: {
     for (const { reject } of pending.values()) reject(err);
     pending.clear();
   };
-  worker.addEventListener('message', onMessage);
-  worker.addEventListener('error', onError);
-
-  // init
-  const initResult = (await call('init', [
-    opts.baseUrl ?? '/',
-    opts.filename,
-    opts.storage,
-    opts.docId,
-  ])) as { storage?: StorageMode; filename?: string; opfsError?: string } | undefined;
-  const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
-  const effectiveFilename =
-    initResult?.filename ??
-    (effectiveStorage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:');
-  if (effectiveStorage === 'opfs') {
-    materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
-  }
   const cleanup = () => {
+    if (closed) return;
     closed = true;
     materialized.close();
     for (const { reject } of pending.values()) reject(closedError);
@@ -393,9 +377,23 @@ async function createWorkerClient(opts: {
     worker.removeEventListener('message', onMessage);
     worker.terminate();
   };
+  worker.addEventListener('message', onMessage);
+  worker.addEventListener('error', onError);
 
+  // init
+  let initResult: RpcResult<'init'>;
+  try {
+    initResult = await call('init', [opts.baseUrl ?? '/', opts.filename, opts.storage, opts.docId]);
+  } catch (err) {
+    cleanup();
+    throw err;
+  }
+  const { storage: effectiveStorage, filename: effectiveFilename, opfsError } = initResult;
+  if (effectiveStorage === 'opfs') {
+    materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
+  }
   if (opts.requireOpfs && effectiveStorage !== 'opfs') {
-    const reason = initResult?.opfsError ? `: ${initResult.opfsError}` : '';
+    const reason = opfsError ? `: ${opfsError}` : '';
     try {
       if (!terminalError) await call('close', [] as RpcParams<'close'>);
     } catch {
@@ -410,9 +408,8 @@ async function createWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('close', [] as RpcParams<'close'>);
-      cleanup();
     } finally {
-      // noop: cleanup already handles terminal teardown, and repeated close is idempotent
+      cleanup();
     }
   };
 
@@ -420,9 +417,8 @@ async function createWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('drop', [] as RpcParams<'drop'>);
-      cleanup();
     } finally {
-      // noop: cleanup already handles terminal teardown, and repeated drop is idempotent
+      cleanup();
     }
   };
 
@@ -512,18 +508,8 @@ async function createSharedWorkerClient(opts: {
     for (const { reject } of pending.values()) reject(err);
     pending.clear();
   };
-  port.addEventListener('message', onMessage);
-  port.addEventListener('messageerror', onMessageError);
-  port.start();
-
-  const initResult = (await call('init', [
-    opts.baseUrl ?? '/',
-    opts.filename,
-    opts.storage,
-    opts.docId,
-  ])) as { storage?: StorageMode; filename?: string; opfsError?: string } | undefined;
-  const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
   const cleanup = () => {
+    if (closed) return;
     closed = true;
     materialized.close();
     for (const { reject } of pending.values()) reject(closedError);
@@ -532,9 +518,27 @@ async function createSharedWorkerClient(opts: {
     port.removeEventListener('messageerror', onMessageError);
     port.close();
   };
+  port.addEventListener('message', onMessage);
+  port.addEventListener('messageerror', onMessageError);
+  port.start();
+
+  let initResult: RpcResult<'init'>;
+  try {
+    initResult = await call('init', [opts.baseUrl ?? '/', opts.filename, opts.storage, opts.docId]);
+  } catch (err) {
+    try {
+      if (!terminalError) await call('close', [] as RpcParams<'close'>);
+    } catch {
+      // Initialization may not have completed, but the shared worker still needs its port removed.
+    } finally {
+      cleanup();
+    }
+    throw err;
+  }
+  const { storage: effectiveStorage, opfsError } = initResult;
 
   if (opts.requireOpfs && effectiveStorage !== 'opfs') {
-    const reason = initResult?.opfsError ? `: ${initResult.opfsError}` : '';
+    const reason = opfsError ? `: ${opfsError}` : '';
     try {
       if (!terminalError) await call('close', [] as RpcParams<'close'>);
     } catch {
@@ -549,9 +553,8 @@ async function createSharedWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('close', [] as RpcParams<'close'>);
-      cleanup();
     } finally {
-      // noop
+      cleanup();
     }
   };
 
@@ -559,9 +562,8 @@ async function createSharedWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('drop', [] as RpcParams<'drop'>);
-      cleanup();
     } finally {
-      // noop
+      cleanup();
     }
   };
 

--- a/packages/treecrdt-wa-sqlite/src/node/open.ts
+++ b/packages/treecrdt-wa-sqlite/src/node/open.ts
@@ -12,6 +12,7 @@ export async function openTreecrdtDbNode(
   if (opts.storage === 'opfs' && opts.requireOpfs) {
     throw new Error('OPFS is not supported in Node');
   }
-  const loaded = await loadWaSqliteNode(opts.baseUrl);
-  return openTreecrdtDbFromLoaded({ ...opts, storage: 'memory' }, loaded);
+  const loadFresh = () => loadWaSqliteNode(opts.baseUrl);
+  const loaded = await loadFresh();
+  return openTreecrdtDbFromLoaded({ ...opts, storage: 'memory' }, loaded, loadFresh);
 }

--- a/packages/treecrdt-wa-sqlite/src/open-core.ts
+++ b/packages/treecrdt-wa-sqlite/src/open-core.ts
@@ -24,78 +24,135 @@ export type OpenTreecrdtDbResult = {
   opfsError?: string;
 };
 
+export type LoadedWaSqlite = { sqlite3: any; module: any };
+export type LoadFreshWaSqlite = () => Promise<LoadedWaSqlite>;
+
 const OPFS_VFS_NAME = 'opfs';
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function memoryFallbackError(opfsFailure: unknown, fallbackFailure: unknown): Error {
+  const error = new Error(
+    `OPFS initialization failed: ${errorMessage(opfsFailure)}; memory fallback failed: ${errorMessage(fallbackFailure)}`,
+  ) as Error & { cause?: unknown; opfsCause?: unknown };
+  error.cause = fallbackFailure;
+  error.opfsCause = opfsFailure;
+  return error;
+}
 
 async function closeIgnoringErrors(close: (() => Promise<void> | void) | undefined): Promise<void> {
   if (!close) return;
   try {
     await close();
   } catch {
-    // Preserve the initialization error.
+    // Preserve the error that made initialization fail.
+  }
+}
+
+async function openInitializedDatabase(
+  sqlite3: any,
+  module: any,
+  filename: string,
+  opts: OpenTreecrdtDbOptions,
+  vfsName?: string,
+): Promise<{ db: Database; api: TreecrdtAdapter }> {
+  let db: Database | undefined;
+  try {
+    const handle = vfsName
+      ? await sqlite3.open_v2(filename, undefined, vfsName)
+      : await sqlite3.open_v2(filename);
+    db = makeDbAdapter(sqlite3, handle);
+    await initializeTreecrdtExtension(module, handle);
+    const api = createWaSqliteApi(db, { onMaterialized: opts.onMaterialized });
+    await api.setDocId(opts.docId);
+    return { db, api };
+  } catch (err) {
+    await closeIgnoringErrors(db?.close ? () => db!.close!() : undefined);
+    throw err;
   }
 }
 
 function closeDatabaseWithVfs(db: Database, vfs: { close?: () => Promise<void> | void }): Database {
   if (!vfs.close) return db;
-  let closePromise: Promise<void> | undefined;
+  let closePromise: Promise<void> | null = null;
   return {
     ...db,
-    close: () =>
-      (closePromise ??= (async () => {
+    close: () => {
+      closePromise ??= (async () => {
         try {
           await db.close?.();
         } finally {
-          await vfs.close?.();
+          await vfs.close!();
         }
-      })()),
+      })();
+      return closePromise;
+    },
   };
 }
 
 export async function openTreecrdtDbFromLoaded(
   opts: OpenTreecrdtDbOptions,
-  loaded: { sqlite3: any; module: any },
+  loaded: LoadedWaSqlite,
+  loadFresh: LoadFreshWaSqlite,
 ): Promise<OpenTreecrdtDbResult> {
   const { sqlite3, module } = loaded;
-
-  let storage: 'memory' | 'opfs' = opts.storage === 'opfs' ? 'opfs' : 'memory';
   let opfsError: string | undefined;
-  let vfs: { close?: () => Promise<void> | void } | undefined;
+  let opfsFailure: unknown;
+  const requestedFilename = opts.filename ?? '/treecrdt.db';
 
-  if (storage === 'opfs') {
+  if (opts.storage === 'opfs') {
+    let vfs: { close?: () => Promise<void> | void } | undefined;
     try {
-      vfs = await createOpfsVfs(module, { name: OPFS_VFS_NAME, kind: opts.opfsVfs });
+      const initializedVfs = await createOpfsVfs(module, {
+        name: OPFS_VFS_NAME,
+        kind: opts.opfsVfs,
+      });
+      vfs = initializedVfs;
       // Keep SQLite's default VFS unchanged; open_v2 selects OPFS explicitly by name.
-      sqlite3.vfs_register(vfs, false);
+      sqlite3.vfs_register(initializedVfs, false);
+      const opened = await openInitializedDatabase(
+        sqlite3,
+        module,
+        requestedFilename,
+        opts,
+        OPFS_VFS_NAME,
+      );
+      return {
+        ...opened,
+        db: closeDatabaseWithVfs(opened.db, initializedVfs),
+        storage: 'opfs',
+        filename: requestedFilename,
+      };
     } catch (err) {
-      opfsError = err instanceof Error ? err.message : String(err);
+      opfsFailure = err;
+      opfsError = errorMessage(err);
       await closeIgnoringErrors(vfs?.close ? () => vfs!.close!() : undefined);
-      vfs = undefined;
       if (opts.requireOpfs) {
-        throw new Error(`OPFS requested but could not be initialized: ${opfsError}`);
+        const requiredError = new Error(
+          `OPFS requested but could not be initialized: ${opfsError}`,
+        ) as Error & { cause?: unknown };
+        requiredError.cause = err;
+        throw requiredError;
       }
-      storage = 'memory';
     }
   }
 
-  const filename = storage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:';
-  let db: Database | undefined;
+  // A failed OPFS attempt leaves its registered VFS and callback state on the module even after
+  // the VFS is closed. Isolate the memory fallback in a fresh module instead of reusing that state.
   try {
-    const handle =
-      storage === 'opfs'
-        ? await sqlite3.open_v2(filename, undefined, OPFS_VFS_NAME)
-        : await sqlite3.open_v2(filename);
-    db = makeDbAdapter(sqlite3, handle);
-    await initializeTreecrdtExtension(module, handle);
-    const api = createWaSqliteApi(db, { onMaterialized: opts.onMaterialized });
-    await api.setDocId(opts.docId);
-    const resultDb = vfs ? closeDatabaseWithVfs(db, vfs) : db;
-
-    return opfsError
-      ? { db: resultDb, api, storage, filename, opfsError }
-      : { db: resultDb, api, storage, filename };
-  } catch (err) {
-    await closeIgnoringErrors(db?.close ? () => db!.close!() : undefined);
-    await closeIgnoringErrors(vfs?.close ? () => vfs!.close!() : undefined);
-    throw err;
+    const memoryLoaded = opfsError !== undefined ? await loadFresh() : loaded;
+    const opened = await openInitializedDatabase(
+      memoryLoaded.sqlite3,
+      memoryLoaded.module,
+      ':memory:',
+      opts,
+    );
+    const result = { ...opened, storage: 'memory' as const, filename: ':memory:' };
+    return opfsError !== undefined ? { ...result, opfsError } : result;
+  } catch (fallbackFailure) {
+    if (opfsError === undefined) throw fallbackFailure;
+    throw memoryFallbackError(opfsFailure, fallbackFailure);
   }
 }

--- a/packages/treecrdt-wa-sqlite/src/open.ts
+++ b/packages/treecrdt-wa-sqlite/src/open.ts
@@ -9,6 +9,7 @@ export type { OpenTreecrdtDbOptions, OpenTreecrdtDbResult };
 
 /** Browser/worker entry: loads wa-sqlite assets from public URLs. */
 export async function openTreecrdtDb(opts: OpenTreecrdtDbOptions): Promise<OpenTreecrdtDbResult> {
-  const loaded = await loadWaSqliteBrowser({ assetsDir: opts.baseUrl });
-  return openTreecrdtDbFromLoaded(opts, loaded);
+  const loadFresh = () => loadWaSqliteBrowser({ assetsDir: opts.baseUrl });
+  const loaded = await loadFresh();
+  return openTreecrdtDbFromLoaded(opts, loaded, loadFresh);
 }

--- a/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+vi.mock('../src/opfs.js', () => ({ createOpfsVfs: vi.fn() }));
+
+import { createOpfsVfs } from '../src/opfs.js';
+import { openTreecrdtDbFromLoaded } from '../src/open-core.js';
+
+function createFakeModule(initResult = 0) {
+  return {
+    cwrap: vi.fn(() => vi.fn(async () => initResult)),
+    retryOps: [] as Promise<unknown>[],
+    pendingOps: [] as Promise<unknown>[],
+  };
+}
+
+function createFakeSqlite(
+  opts: { failOpen?: string; failOpenError?: Error; failInitializationHandle?: number } = {},
+) {
+  const statementHandles = new Map<number, number>();
+  let nextHandle = 1;
+  let nextStatement = 100;
+
+  return {
+    vfs_register: vi.fn(),
+    open_v2: vi.fn(async (filename: string, _flags?: number, _vfs?: string) => {
+      if (filename === opts.failOpen) throw opts.failOpenError ?? new Error('OPFS open failed');
+      return nextHandle++;
+    }),
+    statements: vi.fn((handle: number) => {
+      const statement = nextStatement++;
+      statementHandles.set(statement, handle);
+      return {
+        next: async () => ({ value: statement }),
+        return: async () => undefined,
+      };
+    }),
+    bind: vi.fn(),
+    step: vi.fn(async (statement: number) => {
+      if (statementHandles.get(statement) === opts.failInitializationHandle) {
+        throw new Error('TreeCRDT initialization failed');
+      }
+      return 101;
+    }),
+    column_text: vi.fn(),
+    finalize: vi.fn(),
+    exec: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.mocked(createOpfsVfs).mockReset();
+});
+
+test('keeps the memory path single-pass without creating an OPFS VFS', async () => {
+  const sqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn();
+
+  const opened = await openTreecrdtDbFromLoaded(
+    { storage: 'memory', docId: 'memory-fast-path' },
+    { sqlite3, module: createFakeModule() },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(sqlite3.open_v2).toHaveBeenCalledOnce();
+  expect(sqlite3.open_v2).toHaveBeenCalledWith(':memory:');
+  expect(sqlite3.vfs_register).not.toHaveBeenCalled();
+  expect(createOpfsVfs).not.toHaveBeenCalled();
+  expect(loadFresh).not.toHaveBeenCalled();
+});
+
+test('falls back to memory when opening the OPFS database fails', async () => {
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite({ failOpen: '/fallback.db' });
+  const memorySqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn(async () => ({ sqlite3: memorySqlite3, module: createFakeModule() }));
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/fallback.db',
+      docId: 'fallback-open',
+      requireOpfs: false,
+    },
+    { sqlite3, module: createFakeModule() },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(opened.filename).toBe(':memory:');
+  expect(opened.opfsError).toBe('OPFS open failed');
+  expect(sqlite3.open_v2).toHaveBeenCalledOnce();
+  expect(sqlite3.open_v2).toHaveBeenCalledWith('/fallback.db', undefined, 'opfs');
+  expect(memorySqlite3.open_v2).toHaveBeenCalledOnce();
+  expect(memorySqlite3.open_v2).toHaveBeenCalledWith(':memory:');
+  expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
+  expect(vfs.close).toHaveBeenCalledOnce();
+  expect(loadFresh).toHaveBeenCalledOnce();
+});
+
+test('closes a partially initialized OPFS database before falling back', async () => {
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite({ failInitializationHandle: 1 });
+  const memorySqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn(async () => ({ sqlite3: memorySqlite3, module: createFakeModule() }));
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/fallback-init.db',
+      docId: 'fallback-init',
+      requireOpfs: false,
+    },
+    { sqlite3, module: createFakeModule() },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(opened.opfsError).toBe('TreeCRDT initialization failed');
+  expect(sqlite3.close).toHaveBeenCalledWith(1);
+  expect(memorySqlite3.open_v2).toHaveBeenCalledWith(':memory:');
+  expect(vfs.close).toHaveBeenCalledOnce();
+  expect(loadFresh).toHaveBeenCalledOnce();
+});
+
+test('falls back after explicit extension initialization fails', async () => {
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite();
+  const memorySqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn(async () => ({
+    sqlite3: memorySqlite3,
+    module: createFakeModule(),
+  }));
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/fallback-extension.db',
+      docId: 'fallback-extension',
+      requireOpfs: false,
+    },
+    { sqlite3, module: createFakeModule(10) },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(opened.opfsError).toBe('TreeCRDT SQLite extension init failed (rc=10)');
+  expect(sqlite3.close).toHaveBeenCalledWith(1);
+  expect(vfs.close).toHaveBeenCalledOnce();
+  expect(memorySqlite3.open_v2).toHaveBeenCalledWith(':memory:');
+});
+
+test('preserves both errors when the fresh memory fallback also fails', async () => {
+  const opfsFailure = new Error('OPFS open failed');
+  const fallbackFailure = new Error('memory module load failed');
+  const sqlite3 = createFakeSqlite({ failOpen: '/both-fail.db', failOpenError: opfsFailure });
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+
+  const result = openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/both-fail.db',
+      docId: 'both-fail',
+      requireOpfs: false,
+    },
+    { sqlite3, module: createFakeModule() },
+    vi.fn().mockRejectedValue(fallbackFailure),
+  );
+
+  await expect(result).rejects.toMatchObject({
+    message:
+      'OPFS initialization failed: OPFS open failed; memory fallback failed: memory module load failed',
+    cause: fallbackFailure,
+    opfsCause: opfsFailure,
+  });
+  expect(vfs.close).toHaveBeenCalledOnce();
+});
+
+test('keeps the successful OPFS path single-pass and closes its database and VFS once', async () => {
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const sqlite3 = createFakeSqlite();
+  const loadFresh = vi.fn();
+
+  const opened = await openTreecrdtDbFromLoaded(
+    {
+      storage: 'opfs',
+      filename: '/success.db',
+      docId: 'success',
+      requireOpfs: true,
+    },
+    { sqlite3, module: createFakeModule() },
+    loadFresh,
+  );
+
+  expect(opened.storage).toBe('opfs');
+  expect(sqlite3.open_v2).toHaveBeenCalledOnce();
+  expect(sqlite3.open_v2).toHaveBeenCalledWith('/success.db', undefined, 'opfs');
+  expect(sqlite3.vfs_register).toHaveBeenCalledWith(vfs, false);
+  expect(loadFresh).not.toHaveBeenCalled();
+
+  await opened.db.close?.();
+  await opened.db.close?.();
+  expect(sqlite3.close).toHaveBeenCalledOnce();
+  expect(vfs.close).toHaveBeenCalledOnce();
+});
+
+test('required OPFS closes the VFS and does not attempt memory fallback', async () => {
+  const vfs = {
+    close: vi.fn(() => {
+      throw new Error('VFS close failed');
+    }),
+  };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const opfsFailure = new Error('OPFS open failed');
+  const sqlite3 = createFakeSqlite({ failOpen: '/required.db', failOpenError: opfsFailure });
+  const loadFresh = vi.fn();
+
+  await expect(
+    openTreecrdtDbFromLoaded(
+      {
+        storage: 'opfs',
+        filename: '/required.db',
+        docId: 'required',
+        requireOpfs: true,
+      },
+      { sqlite3, module: createFakeModule() },
+      loadFresh,
+    ),
+  ).rejects.toMatchObject({
+    message: 'OPFS requested but could not be initialized: OPFS open failed',
+    cause: opfsFailure,
+  });
+
+  expect(sqlite3.open_v2).toHaveBeenCalledOnce();
+  expect(vfs.close).toHaveBeenCalledOnce();
+  expect(loadFresh).not.toHaveBeenCalled();
+});

--- a/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/worker-cleanup.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+import { createTreecrdtClient } from '../src/client.js';
+import type { RpcRequest } from '../src/rpc.js';
+
+type Runtime = 'dedicated-worker' | 'shared-worker';
+type RpcResponse =
+  | { id: number; ok: true; result?: unknown }
+  | { id: number; ok: false; error: string };
+
+class FakeEndpoint {
+  readonly listeners = new Map<string, Set<(event: any) => void>>();
+  readonly requests: RpcRequest[] = [];
+  terminated = false;
+  portClosed = false;
+
+  constructor(private readonly respond: (request: RpcRequest) => RpcResponse) {}
+
+  addEventListener(type: string, listener: (event: any) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: any) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  postMessage(request: RpcRequest) {
+    this.requests.push(request);
+    const response = this.respond(request);
+    queueMicrotask(() => {
+      for (const listener of this.listeners.get('message') ?? []) listener({ data: response });
+    });
+  }
+
+  start() {}
+
+  terminate() {
+    this.terminated = true;
+  }
+
+  close() {
+    this.portClosed = true;
+  }
+}
+
+function installEndpoint(runtime: Runtime, respond: (request: RpcRequest) => RpcResponse) {
+  const endpoint = new FakeEndpoint(respond);
+  if (runtime === 'dedicated-worker') {
+    vi.stubGlobal(
+      'Worker',
+      class {
+        constructor() {
+          return endpoint;
+        }
+      },
+    );
+  } else {
+    vi.stubGlobal(
+      'SharedWorker',
+      class {
+        port = endpoint;
+      },
+    );
+  }
+  return endpoint;
+}
+
+function clientOptions(runtime: Runtime) {
+  return {
+    storage: { type: 'memory' as const },
+    runtime:
+      runtime === 'dedicated-worker'
+        ? ({ type: runtime } as const)
+        : ({ type: runtime, name: 'cleanup-test' } as const),
+    docId: `cleanup-${runtime}`,
+  };
+}
+
+function expectCleaned(runtime: Runtime, endpoint: FakeEndpoint) {
+  expect(runtime === 'dedicated-worker' ? endpoint.terminated : endpoint.portClosed).toBe(true);
+  expect([...endpoint.listeners.values()].every((listeners) => listeners.size === 0)).toBe(true);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+for (const runtime of ['dedicated-worker', 'shared-worker'] as const) {
+  test(`${runtime} cleans up after rejected initialization`, async () => {
+    const endpoint = installEndpoint(runtime, (request) => ({
+      id: request.id,
+      ok: false,
+      error: 'init failed',
+    }));
+
+    await expect(createTreecrdtClient(clientOptions(runtime))).rejects.toThrow('init failed');
+
+    expectCleaned(runtime, endpoint);
+    expect(endpoint.requests.map((request) => request.method)).toEqual(
+      runtime === 'shared-worker' ? ['init', 'close'] : ['init'],
+    );
+  });
+
+  test(`${runtime} cleans up when close RPC fails`, async () => {
+    const endpoint = installEndpoint(runtime, (request) =>
+      request.method === 'init'
+        ? { id: request.id, ok: true, result: { storage: 'memory', filename: ':memory:' } }
+        : { id: request.id, ok: false, error: 'close failed' },
+    );
+    const client = await createTreecrdtClient(clientOptions(runtime));
+
+    await client.close();
+
+    expectCleaned(runtime, endpoint);
+  });
+
+  test(`${runtime} cleans up when drop RPC fails`, async () => {
+    const endpoint = installEndpoint(runtime, (request) =>
+      request.method === 'init'
+        ? { id: request.id, ok: true, result: { storage: 'memory', filename: ':memory:' } }
+        : { id: request.id, ok: false, error: 'drop failed' },
+    );
+    const client = await createTreecrdtClient(clientOptions(runtime));
+
+    await expect(client.drop()).rejects.toThrow('drop failed');
+
+    expectCleaned(runtime, endpoint);
+  });
+}


### PR DESCRIPTION
## Problem

#210 prevents the reproduced automatic-extension failure, but any remaining OPFS initialization error still has to unwind every layer cleanly. A failed attempt can leave behind a database handle, VFS resources, wa-sqlite module callbacks/retry state, worker listeners, pending RPC calls, or an attached SharedWorker port.

In SharedWorker mode, that stale port can keep a failed session alive and make the next client using the same worker name fail as if a different database were already initialized.

## Change

- Close partially initialized database and VFS resources idempotently.
- Run optional memory fallback in a fresh wa-sqlite module. Closing the failed VFS does not unregister its callbacks or reset module retry state, so reusing that module is unsafe.
- Preserve both the OPFS error and the fallback error when both attempts fail.
- Remove listeners, reject pending RPC calls, close ports, and terminate dedicated workers when initialization, `close`, or `drop` fails.
- Cover recovery by forcing an OPFS open failure and then successfully reusing the same SharedWorker name.

This PR is the cleanup and recovery layer after #210; it does not claim to be the root fix for the initialization failure.

## Dependencies and merge order

Stacked directly on #210. Use a merge commit after #210, then retarget #163 to `main`.
