### PR TITLE
fix(wa-sqlite): allow long OPFS database paths

### DIFF
--- a/.changeset/wa-sqlite-opfs-path-capacity.md
+++ b/.changeset/wa-sqlite-opfs-path-capacity.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Allow OPFS database paths longer than wa-sqlite's 64-byte VFS default.

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -107,9 +107,11 @@ test.describe('browser OPFS lifecycle', () => {
         page.on('console', (msg) => console.log(`[page][${msg.type()}] ${msg.text()}`));
 
         const suffix = `${Date.now().toString(36)}-${Math.random().toString(16).slice(2, 8)}`;
+        const filename = `/lifecycle-${'p'.repeat(48)}-${scenario.runtime}-${suffix}.db`;
+        expect(new TextEncoder().encode(`${filename}-journal`).byteLength).toBeGreaterThan(64);
         const opts = {
           docId: `lifecycle-${scenario.runtime}-${suffix}`,
-          filename: `/lifecycle-${scenario.runtime}-${suffix}.db`,
+          filename,
           runtime: scenario.runtime,
         };
 

--- a/packages/treecrdt-wa-sqlite/src/opfs.ts
+++ b/packages/treecrdt-wa-sqlite/src/opfs.ts
@@ -124,6 +124,14 @@ export type OpfsVfsOptions = {
   kind?: OpfsVfsKind;
 };
 
+const OPFS_MAX_PATHNAME = 512;
+
+function withOpfsPathCapacity(vfs: any): any {
+  // SQLite appends sidecar suffixes such as "-journal" after checking this capacity.
+  vfs.mxPathname = Math.max(vfs.mxPathname ?? 0, OPFS_MAX_PATHNAME);
+  return vfs;
+}
+
 /**
  * Create an OPFS VFS bound to the provided wa-sqlite Module.
  * Uses local copies of wa-sqlite's example VFS implementations to avoid reaching into vendor paths.
@@ -133,12 +141,14 @@ export async function createOpfsVfs(module: any, opts: OpfsVfsOptions = {}): Pro
   if (opts.kind === 'any-context') {
     // @ts-ignore vendored module lacks type declarations
     const { OPFSAnyContextVFS } = await import('./vendor/OPFSAnyContextVFS.js');
-    return OPFSAnyContextVFS.create(name, module, { lockPolicy: 'exclusive' });
+    return withOpfsPathCapacity(
+      await OPFSAnyContextVFS.create(name, module, { lockPolicy: 'exclusive' }),
+    );
   }
 
   // @ts-ignore vendored module lacks type declarations
   const { OPFSCoopSyncVFS } = await import('./vendor/OPFSCoopSyncVFS.js');
-  return OPFSCoopSyncVFS.create(name, module);
+  return withOpfsPathCapacity(await OPFSCoopSyncVFS.create(name, module));
 }
 
 export type OpenOptions = {


### PR DESCRIPTION
## What

Allow valid OPFS database paths longer than wa-sqlite's 64-byte VFS default.

TreeCRDT now advertises a 512-byte pathname capacity before registering either OPFS VFS:

- CoopSync in dedicated workers.
- AnyContext in direct/main-thread mode.

## Why

SQLite appends sidecar names such as `-journal` and `-wal` after checking the VFS pathname capacity. A 58-byte database path therefore becomes a 66-byte journal path and fails with the generic `SQLITE_CANTOPEN` / `sqlite3_open_v2` error when the VFS reports 64 bytes.

This was reproduced exactly in Chromium:

- 54-byte database path, 62 with `-journal`: opens.
- 58-byte database path, 66 with `-journal`: fails with the old limit.
- The same 58-byte path opens when the VFS advertises 512 bytes.

The failure looked like an OPFS drop/reopen race in #164 only because its normal-priority filename was four characters shorter than its background-priority filename.

## Scope / fast paths

- 3 files, **+20/-3**.
- One VFS wrapper change; no vendored/generated files.
- No database format, journal mode, locking, worker lifecycle, or sync behavior changes.
- Runtime and storage fast paths are unchanged; this only enlarges SQLite's pathname buffer.
- Independent of #208, #209, and the scheduler stack.

## Regression coverage

The existing browser lifecycle matrix now deliberately uses a database path whose `-journal` form exceeds 64 bytes. It covers both direct/AnyContext and dedicated-worker/CoopSync clients, explicit close and reload teardown, persistence, and drop cleanup.

## Verification

- wa-sqlite TypeScript build passes.
- Prettier and `git diff --check` pass.
- Playwright covers all four long-path lifecycle scenarios.
- Full GitHub build, browser, native-node, playground, and Postgres CI is green.
