### PR TITLE
fix(bench): honor explicit iteration counts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:ext:native": "cargo rustc -p treecrdt-sqlite-ext --release --no-default-features --features \"ext-sqlite rusqlite-storage\" -- --crate-type=cdylib",
     "build": "pnpm -r --if-present run build",
     "test:browser": "pnpm -C packages/treecrdt-wa-sqlite/e2e test:e2e",
-    "test:native-node": "pnpm -C packages/sync-protocol/material/sqlite run test && pnpm -C packages/treecrdt-sqlite-node run test && pnpm -C packages/treecrdt-wa-sqlite run test",
+    "test:native-node": "pnpm -C packages/sync-protocol/material/sqlite run test && pnpm -C packages/treecrdt-sqlite-node run test && pnpm -C packages/treecrdt-wa-sqlite run test && pnpm -C packages/treecrdt-benchmark run test",
     "benchmark": "rm -rf benchmarks && mkdir -p benchmarks && pnpm run benchmark:web && pnpm run benchmark:sqlite-node:ops && pnpm run benchmark:sqlite-node:note-paths && pnpm run benchmark:sync:direct && pnpm run benchmark:wasm && pnpm run benchmark:postgres && pnpm run benchmark:core && pnpm run benchmark:aggregate",
     "benchmark:sqlite-node": "pnpm run benchmark:sqlite-node:ops && pnpm run benchmark:sqlite-node:note-paths && pnpm run benchmark:sqlite-node:sync",
     "benchmark:core": "cargo bench -p treecrdt-core --bench core --features bench",

--- a/packages/treecrdt-benchmark/package.json
+++ b/packages/treecrdt-benchmark/package.json
@@ -20,7 +20,8 @@
     "src"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "test": "pnpm -C ../treecrdt-ts run build && pnpm run build && node --test tests/*.test.mjs"
   },
   "dependencies": {
     "@treecrdt/interface": "workspace:*",

--- a/packages/treecrdt-benchmark/src/index.ts
+++ b/packages/treecrdt-benchmark/src/index.ts
@@ -54,9 +54,9 @@ export async function runBenchmark(
 
   const envIterations = envInt('BENCH_ITERATIONS');
   const envWarmup = envInt('BENCH_WARMUP');
-  const rawIterations = Math.max(1, workload.iterations ?? envIterations ?? 1);
   const minIterationsForTiny = totalOps >= 1 && totalOps <= 100 ? 10 : totalOps <= 1000 ? 7 : 1;
-  const iterations = Math.max(minIterationsForTiny, rawIterations);
+  const requestedIterations = workload.iterations ?? envIterations;
+  const iterations = Math.max(1, requestedIterations ?? minIterationsForTiny);
   const warmupIterations = Math.max(
     0,
     workload.warmupIterations ?? envWarmup ?? (iterations > 1 ? 1 : 0),

--- a/packages/treecrdt-benchmark/tests/iterations.test.mjs
+++ b/packages/treecrdt-benchmark/tests/iterations.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runBenchmark } from '../dist/index.js';
+
+async function countRuns(workload, envIterations) {
+  const previous = process.env.BENCH_ITERATIONS;
+  if (envIterations === undefined) delete process.env.BENCH_ITERATIONS;
+  else process.env.BENCH_ITERATIONS = envIterations;
+
+  let runs = 0;
+  try {
+    await runBenchmark(() => ({}), {
+      name: 'tiny',
+      totalOps: 1,
+      warmupIterations: 0,
+      run: async () => {
+        runs += 1;
+      },
+      ...workload,
+    });
+    return runs;
+  } finally {
+    if (previous === undefined) delete process.env.BENCH_ITERATIONS;
+    else process.env.BENCH_ITERATIONS = previous;
+  }
+}
+
+test('an explicit workload iteration count overrides the tiny-workload heuristic', async () => {
+  assert.equal(await countRuns({ iterations: 1 }, '4'), 1);
+});
+
+test('an environment iteration count overrides the tiny-workload heuristic', async () => {
+  assert.equal(await countRuns({}, '3'), 3);
+});
+
+test('tiny workloads still receive extra samples when no iteration count is requested', async () => {
+  assert.equal(await countRuns({}, undefined), 10);
+});


### PR DESCRIPTION
## Why

The shared benchmark runner's small-workload sampling floor currently overrides an explicit iteration count.

That silently multiplies callers which already perform their own outer sampling. In the SQLite note-path suite, the intended 2–3 samples become 20–30 seeded database runs per result: 200 database seedings per revision while the artifact still reports only 2–3 samples. The 100-operation SQLite benchmark is multiplied similarly.

In the successful `/bench` run for #167, note paths consumed about 5m12s per revision. Most of that work was unreported nested sampling.

## What changed

- Treat workload and environment iteration counts as explicit requests.
- Apply the automatic 7–10-sample floor only when neither supplies a count.
- Add dependency-free regression tests for workload, environment, and fallback precedence.
- Include the benchmark package test in the native Node test command so CI runs it.

## Expected impact

The note-path matrix now performs its intended 20 seeded runs per revision instead of 200. Based on run 29234317596, that should save roughly nine minutes across a full base/head comparison while making the reported sample counts truthful.

Unconfigured tiny workloads retain the existing adaptive sampling behavior.

## Validation

- `pnpm -C packages/treecrdt-benchmark test`
- Prettier check on all changed files
- `git diff --check`
