### PR TITLE
refactor(core): remove legacy VersionVector serde fallback

### DIFF
--- a/packages/treecrdt-core/src/version_vector.rs
+++ b/packages/treecrdt-core/src/version_vector.rs
@@ -198,7 +198,7 @@ pub struct VersionVector {
 mod serde_impl {
     use super::{ReplicaVersion, VersionVector};
     use crate::ids::ReplicaId;
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+    use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
     use std::collections::HashMap;
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -211,15 +211,6 @@ mod serde_impl {
     #[derive(Clone, Debug, Serialize, Deserialize)]
     struct VersionVectorRepr {
         entries: Vec<VersionVectorEntry>,
-    }
-
-    #[derive(Deserialize)]
-    #[serde(untagged)]
-    enum VersionVectorWire {
-        Repr(VersionVectorRepr),
-        Legacy {
-            entries: HashMap<ReplicaId, ReplicaVersion>,
-        },
     }
 
     impl Serialize for VersionVector {
@@ -246,27 +237,26 @@ mod serde_impl {
         where
             D: Deserializer<'de>,
         {
-            let wire = VersionVectorWire::deserialize(deserializer)?;
-            match wire {
-                VersionVectorWire::Repr(repr) => {
-                    let mut entries: HashMap<ReplicaId, ReplicaVersion> = HashMap::new();
-                    for entry in repr.entries {
-                        let replica = ReplicaId(entry.replica);
-                        let incoming = ReplicaVersion {
+            let repr = VersionVectorRepr::deserialize(deserializer)?;
+            if repr.entries.windows(2).any(|pair| pair[0].replica >= pair[1].replica) {
+                return Err(D::Error::custom(
+                    "version vector replicas must be unique and strictly sorted",
+                ));
+            }
+            let entries = repr
+                .entries
+                .into_iter()
+                .map(|entry| {
+                    (
+                        ReplicaId(entry.replica),
+                        ReplicaVersion {
                             frontier: entry.frontier,
                             ranges: entry.ranges,
-                        };
-
-                        if let Some(existing) = entries.get_mut(&replica) {
-                            existing.union(&incoming);
-                        } else {
-                            entries.insert(replica, incoming);
-                        }
-                    }
-                    Ok(VersionVector { entries })
-                }
-                VersionVectorWire::Legacy { entries } => Ok(VersionVector { entries }),
-            }
+                        },
+                    )
+                })
+                .collect::<HashMap<_, _>>();
+            Ok(VersionVector { entries })
         }
     }
 }

--- a/packages/treecrdt-core/tests/serde_version_vector.rs
+++ b/packages/treecrdt-core/tests/serde_version_vector.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "serde")]
 #[test]
-fn version_vector_json_roundtrips_and_is_nonempty() {
+fn version_vector_json_uses_sorted_entry_list_and_roundtrips() {
     use treecrdt_core::{ReplicaId, VersionVector};
 
     let mut vv = VersionVector::new();
@@ -11,13 +11,33 @@ fn version_vector_json_roundtrips_and_is_nonempty() {
     let bytes = serde_json::to_vec(&vv).expect("serialize VersionVector");
     let json = std::str::from_utf8(&bytes).expect("VersionVector JSON must be UTF-8");
 
-    // If this ever regresses, the sqlite extension will silently store NULL/empty vectors.
-    assert!(
-        json.contains("\"entries\"") && json.contains('['),
-        "expected VersionVector to serialize as an entries list, got: {json}"
+    assert_eq!(
+        json,
+        r#"{"entries":[{"replica":[114,65],"frontier":1,"ranges":[]},{"replica":[114,66],"frontier":2,"ranges":[]}]}"#
     );
 
     let roundtrip: VersionVector =
         serde_json::from_slice(&bytes).expect("deserialize VersionVector");
     assert_eq!(roundtrip, vv);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn version_vector_json_rejects_map_shaped_entries() {
+    use treecrdt_core::VersionVector;
+
+    let legacy = r#"{"entries":{"rA":{"frontier":1,"ranges":[]}}}"#;
+    assert!(serde_json::from_str::<VersionVector>(legacy).is_err());
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn version_vector_json_rejects_duplicate_or_unsorted_replicas() {
+    use treecrdt_core::VersionVector;
+
+    let duplicate = r#"{"entries":[{"replica":[114,65],"frontier":1,"ranges":[]},{"replica":[114,65],"frontier":2,"ranges":[]}]}"#;
+    assert!(serde_json::from_str::<VersionVector>(duplicate).is_err());
+
+    let unsorted = r#"{"entries":[{"replica":[114,66],"frontier":2,"ranges":[]},{"replica":[114,65],"frontier":1,"ranges":[]}]}"#;
+    assert!(serde_json::from_str::<VersionVector>(unsorted).is_err());
 }


### PR DESCRIPTION
## Why

There are no deployed consumers that require the original map-shaped VersionVector representation. Keeping both formats adds parsing complexity without useful compatibility.

## What changed

- Deserialize VersionVector only from the deterministic entry-list representation.
- Remove the untagged legacy map fallback.
- Require replica entries to be unique and strictly sorted, matching the serializer's canonical output.
- Lock the sorted JSON representation with an exact-format test.
- Reject map-shaped, duplicate, and out-of-order entries.

## Testing

- `cargo fmt --all`
- `cargo test -p treecrdt-core --features serde`

This is a clean wire reset: one canonical representation, with no migration, dual decoder, or permissive alternate ordering.
