### PR TITLE
fix(core): enforce canonical structural order keys

### DIFF
--- a/packages/treecrdt-core/src/ops.rs
+++ b/packages/treecrdt-core/src/ops.rs
@@ -64,12 +64,14 @@ pub struct Operation {
 }
 
 impl Operation {
-    /// Validate identity fields required by causal tracking and portable persistent adapters.
+    /// Validate fields required by causal tracking and portable persistent adapters.
     ///
     /// Zero is reserved as the initial clock/counter and as the exclusive `scan_since(0)`
     /// sentinel. Persisting a zero-valued operation would make it disappear during canonical
     /// replay. Persistent SQLite/PostgreSQL schemas use signed 64-bit integers, so values above
-    /// `i64::MAX` are rejected consistently before any adapter can truncate them.
+    /// `i64::MAX` are rejected consistently before any adapter can truncate them. Structural
+    /// insert/move keys are complete big-endian `u16` digits with a non-zero final digit; the
+    /// empty key is reserved for attachment to Trash.
     pub fn validate(&self) -> Result<()> {
         if self.meta.lamport == 0 {
             return Err(Error::InvalidOperation(
@@ -90,6 +92,27 @@ impl Operation {
             return Err(Error::InvalidOperation(
                 "operation counter exceeds the supported signed 64-bit range".into(),
             ));
+        }
+        match &self.kind {
+            OperationKind::Insert {
+                parent, order_key, ..
+            }
+            | OperationKind::Move {
+                new_parent: parent,
+                order_key,
+                ..
+            } => {
+                if *parent == NodeId::TRASH {
+                    if !order_key.is_empty() {
+                        return Err(Error::InvalidOperation(
+                            "order_key must be empty when the parent is Trash".into(),
+                        ));
+                    }
+                } else {
+                    crate::order_key::validate_order_key(order_key)?;
+                }
+            }
+            _ => {}
         }
         Ok(())
     }

--- a/packages/treecrdt-core/src/order_key.rs
+++ b/packages/treecrdt-core/src/order_key.rs
@@ -6,6 +6,26 @@ const DEFAULT_BOUNDARY: u16 = 10;
 const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 
+/// Validate the canonical encoding used by structural insert and move operations.
+pub(crate) fn validate_order_key(key: &[u8]) -> Result<()> {
+    if key.is_empty() {
+        return Err(Error::InvalidOperation(
+            "structural order_key must be non-empty".into(),
+        ));
+    }
+    if !key.len().is_multiple_of(DIGIT_BYTES) {
+        return Err(Error::InvalidOperation(
+            "structural order_key must contain complete big-endian u16 digits".into(),
+        ));
+    }
+    if key[key.len() - DIGIT_BYTES..] == [0, 0] {
+        return Err(Error::InvalidOperation(
+            "structural order_key must end in a non-zero u16 digit".into(),
+        ));
+    }
+    Ok(())
+}
+
 fn decode_digits(bytes: &[u8]) -> Result<Vec<u16>> {
     if !bytes.len().is_multiple_of(DIGIT_BYTES) {
         return Err(Error::InvalidOperation(

--- a/packages/treecrdt-core/src/tree.rs
+++ b/packages/treecrdt-core/src/tree.rs
@@ -776,6 +776,7 @@ where
         let mut seq: u64 = 0;
         let mut head: Option<Operation> = None;
         storage.scan_since(0, &mut |op| {
+            op.validate()?;
             clock.observe(op.meta.lamport);
             version_vector.observe(&op.meta.id.replica, op.meta.id.counter);
             let _ = Self::apply_forward(nodes, payloads, &op)?;

--- a/packages/treecrdt-core/tests/conflict_resolution.rs
+++ b/packages/treecrdt-core/tests/conflict_resolution.rs
@@ -40,7 +40,7 @@ fn higher_lamport_wins_on_conflict() {
         move_left.meta.lamport + 1,
         x,
         right,
-        Vec::new(),
+        vec![0, 1],
     );
     crdt_b.apply_remote(move_right.clone()).unwrap();
 
@@ -66,12 +66,12 @@ fn moves_reordered_by_lamport_and_id() {
     let x = NodeId(3);
 
     let ops = [
-        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, Vec::new()),
-        Operation::insert(&ReplicaId::new(b"a"), 2, 2, root, b, Vec::new()),
-        Operation::insert(&ReplicaId::new(b"a"), 3, 3, root, x, Vec::new()),
+        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, vec![0, 1]),
+        Operation::insert(&ReplicaId::new(b"a"), 2, 2, root, b, vec![0, 2]),
+        Operation::insert(&ReplicaId::new(b"a"), 3, 3, root, x, vec![0, 3]),
         // higher lamport move -> should win
-        Operation::move_node(&ReplicaId::new(b"a"), 4, 5, x, a, Vec::new()),
-        Operation::move_node(&ReplicaId::new(b"a"), 5, 4, x, b, Vec::new()),
+        Operation::move_node(&ReplicaId::new(b"a"), 4, 5, x, a, vec![0, 1]),
+        Operation::move_node(&ReplicaId::new(b"a"), 5, 4, x, b, vec![0, 1]),
     ];
 
     // apply out of order
@@ -99,16 +99,16 @@ fn same_lamport_orders_by_op_id() {
     let x = NodeId(3);
 
     let inserts = [
-        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, Vec::new()),
-        Operation::insert(&ReplicaId::new(b"a"), 2, 2, root, b, Vec::new()),
-        Operation::insert(&ReplicaId::new(b"a"), 3, 3, root, x, Vec::new()),
+        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, vec![0, 1]),
+        Operation::insert(&ReplicaId::new(b"a"), 2, 2, root, b, vec![0, 2]),
+        Operation::insert(&ReplicaId::new(b"a"), 3, 3, root, x, vec![0, 3]),
     ];
     for op in inserts {
         crdt.apply_remote(op).unwrap();
     }
 
-    let move_a = Operation::move_node(&ReplicaId::new(b"a"), 10, 5, x, a, Vec::new());
-    let move_b = Operation::move_node(&ReplicaId::new(b"b"), 10, 5, x, b, Vec::new());
+    let move_a = Operation::move_node(&ReplicaId::new(b"a"), 10, 5, x, a, vec![0, 1]);
+    let move_b = Operation::move_node(&ReplicaId::new(b"b"), 10, 5, x, b, vec![0, 1]);
 
     crdt.apply_remote(move_b.clone()).unwrap();
     crdt.apply_remote(move_a.clone()).unwrap();

--- a/packages/treecrdt-core/tests/convergence.rs
+++ b/packages/treecrdt-core/tests/convergence.rs
@@ -9,7 +9,7 @@ fn permutations_converge() {
             1,
             NodeId::ROOT,
             NodeId(1),
-            Vec::new(),
+            vec![0, 1],
         ),
         Operation::insert(
             &ReplicaId::new(b"a"),
@@ -17,7 +17,7 @@ fn permutations_converge() {
             2,
             NodeId::ROOT,
             NodeId(2),
-            Vec::new(),
+            vec![0, 2],
         ),
         Operation::insert(
             &ReplicaId::new(b"a"),
@@ -25,7 +25,7 @@ fn permutations_converge() {
             3,
             NodeId::ROOT,
             NodeId(3),
-            Vec::new(),
+            vec![0, 3],
         ),
         Operation::move_node(
             &ReplicaId::new(b"a"),
@@ -33,7 +33,7 @@ fn permutations_converge() {
             4,
             NodeId(3),
             NodeId(1),
-            Vec::new(),
+            vec![0, 1],
         ),
         Operation::move_node(
             &ReplicaId::new(b"a"),
@@ -41,7 +41,7 @@ fn permutations_converge() {
             5,
             NodeId(3),
             NodeId(2),
-            Vec::new(),
+            vec![0, 1],
         ),
     ];
 

--- a/packages/treecrdt-core/tests/materialization_helpers.rs
+++ b/packages/treecrdt-core/tests/materialization_helpers.rs
@@ -183,8 +183,8 @@ fn apply_incremental_ops_with_delta_sorts_and_returns_head() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
 
-    let first = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
-    let second = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
+    let first = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
+    let second = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0, 0x20]);
 
     let next =
         apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![second, first])
@@ -211,7 +211,7 @@ fn apply_incremental_ops_with_delta_keeps_head_for_duplicate_ops() {
     .unwrap();
     let mut index = RecordingIndex::default();
     let replica = ReplicaId::new(b"remote");
-    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
 
     let first_result = apply_incremental_ops_with_delta(
         &mut crdt,
@@ -264,7 +264,7 @@ fn apply_incremental_ops_with_delta_rejects_before_materialized_head() {
         4,
         NodeId::ROOT,
         NodeId(9),
-        vec![0x10],
+        vec![0, 0x10],
     );
 
     let res = apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![op]);
@@ -295,7 +295,7 @@ fn apply_incremental_ops_with_delta_rejects_pending_replay_frontier() {
         6,
         NodeId::ROOT,
         NodeId(9),
-        vec![0x10],
+        vec![0, 0x10],
     );
 
     let res = apply_incremental_ops_with_delta(&mut crdt, &mut index, &cursor, vec![op]);
@@ -316,8 +316,8 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
 
     let parent = NodeId(10);
     let child = NodeId(11);
-    let parent_insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, parent, vec![0x10]);
-    let child_insert = Operation::insert(&replica, 2, 2, parent, child, vec![0x20]);
+    let parent_insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, parent, vec![0, 0x10]);
+    let child_insert = Operation::insert(&replica, 2, 2, parent, child, vec![0, 0x20]);
 
     let res = apply_incremental_ops_with_delta(
         &mut crdt,
@@ -339,7 +339,7 @@ fn apply_incremental_ops_with_delta_returns_affected_union() {
 fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let op2 = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
+    let op2 = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0, 0x20]);
     let op3 = Operation::set_payload(&replica, 3, 3, NodeId(2), vec![9]);
 
     let mut seen_counters = Vec::new();
@@ -397,7 +397,7 @@ fn apply_persisted_remote_ops_materializes_only_inserted_entries() {
 fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
     let mut runs = 0u64;
     let mut scheduled_replay = 0u64;
 
@@ -430,7 +430,7 @@ fn apply_persisted_remote_ops_schedules_replay_from_start_when_head_is_missing()
 fn apply_persisted_remote_ops_propagates_update_head_failure() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
     let mut scheduled_replay = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
@@ -478,7 +478,7 @@ fn apply_persisted_remote_ops_propagates_update_head_failure() {
 fn apply_persisted_remote_ops_schedules_repair_after_materialization_failure() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
+    let op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
     let mut scheduled_replay = 0u64;
 
     let result = apply_persisted_remote_ops_with_delta(
@@ -508,8 +508,8 @@ fn apply_persisted_remote_ops_schedules_replay_frontier_for_out_of_order_ops() {
         ..Cursor::default()
     };
     let replica = ReplicaId::new(b"r");
-    let out_of_order = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
-    let later = Operation::insert(&replica, 6, 6, NodeId::ROOT, NodeId(6), vec![0x60]);
+    let out_of_order = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0, 0x20]);
+    let later = Operation::insert(&replica, 6, 6, NodeId::ROOT, NodeId(6), vec![0, 0x60]);
     let mut materialize_runs = 0u64;
     let mut replay_frontier = None;
 
@@ -557,7 +557,7 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
         replay_counter: Some(2),
     };
     let replica = ReplicaId::new(b"r");
-    let later = Operation::insert(&replica, 4, 4, NodeId::ROOT, NodeId(4), vec![0x40]);
+    let later = Operation::insert(&replica, 4, 4, NodeId::ROOT, NodeId(4), vec![0, 0x40]);
     let mut replay_frontier = None;
 
     let result = apply_persisted_remote_ops_with_delta(
@@ -589,8 +589,8 @@ fn apply_persisted_remote_ops_keeps_earliest_existing_replay_frontier() {
 fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
     let cursor = Cursor::default();
     let replica = ReplicaId::new(b"remote");
-    let parent = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(10), vec![0x10]);
-    let child = Operation::insert(&replica, 2, 2, NodeId(10), NodeId(11), vec![0x20]);
+    let parent = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(10), vec![0, 0x10]);
+    let child = Operation::insert(&replica, 2, 2, NodeId(10), NodeId(11), vec![0, 0x20]);
 
     let mut prepared = 0u64;
     let mut flushed_nodes = 0u64;
@@ -635,8 +635,8 @@ fn materialize_persisted_remote_ops_with_delta_runs_prepare_and_flush_hooks() {
 #[test]
 fn catch_up_materialized_state_scans_storage_once() {
     let replica = ReplicaId::new(b"scan-once");
-    let first = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0x10]);
-    let second = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0x20]);
+    let first = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 0x10]);
+    let second = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![0, 0x20]);
 
     let mut inner = MemoryStorage::default();
     inner.apply(first.clone()).unwrap();
@@ -681,8 +681,8 @@ fn catch_up_materialized_state_reports_only_net_visible_changes() {
     let replica = ReplicaId::new(b"suffix-only");
     let prefix = NodeId(1);
     let suffix = NodeId(2);
-    let prefix_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, prefix, vec![0x10]);
-    let suffix_op = Operation::insert(&replica, 2, 2, NodeId::ROOT, suffix, vec![0x20]);
+    let prefix_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, prefix, vec![0, 0x10]);
+    let suffix_op = Operation::insert(&replica, 2, 2, NodeId::ROOT, suffix, vec![0, 0x20]);
 
     let mut storage = MemoryStorage::default();
     storage.apply(prefix_op.clone()).unwrap();
@@ -692,7 +692,7 @@ fn catch_up_materialized_state_reports_only_net_visible_changes() {
     // so conservative catch-up should not re-emit them as materialization changes.
     let mut nodes = MemoryNodeStore::default();
     nodes.ensure_node(prefix).unwrap();
-    nodes.attach(prefix, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(prefix, NodeId::ROOT, vec![0, 0x10]).unwrap();
     let mut index = RecordingIndex::default();
     index.record(NodeId::ROOT, &prefix_op.meta.id, 1).unwrap();
 
@@ -747,19 +747,19 @@ fn catch_up_reports_net_delete() {
     let deleter = ReplicaId::new(b"net-delete-writer");
     let node = NodeId(7);
     let unrelated = NodeId(8);
-    let insert = Operation::insert(&creator, 1, 1, NodeId::ROOT, node, vec![0x10]);
+    let insert = Operation::insert(&creator, 1, 1, NodeId::ROOT, node, vec![0, 0x10]);
     let mut known_state = VersionVector::new();
     known_state.observe(&creator, 1);
     let delete = Operation::delete(&deleter, 1, 2, node, Some(known_state));
-    let head_op = Operation::insert(&creator, 2, 3, NodeId::ROOT, unrelated, vec![0x20]);
+    let head_op = Operation::insert(&creator, 2, 3, NodeId::ROOT, unrelated, vec![0, 0x20]);
 
     let mut storage = MemoryStorage::default();
     for op in [&insert, &delete, &head_op] {
         storage.apply(op.clone()).unwrap();
     }
     let mut nodes = MemoryNodeStore::default();
-    nodes.attach(node, NodeId::ROOT, vec![0x10]).unwrap();
-    nodes.attach(unrelated, NodeId::ROOT, vec![0x20]).unwrap();
+    nodes.attach(node, NodeId::ROOT, vec![0, 0x10]).unwrap();
+    nodes.attach(unrelated, NodeId::ROOT, vec![0, 0x20]).unwrap();
     let meta = Cursor {
         head_lamport: head_op.meta.lamport,
         head_replica: head_op.meta.id.replica.as_bytes().to_vec(),
@@ -790,7 +790,7 @@ fn catch_up_reports_payload_changes_for_root_and_tombstoned_nodes() {
     let unrelated = NodeId(6);
     let root_payload = Operation::set_payload(&creator, 1, 1, NodeId::ROOT, vec![1]);
     let insert =
-        Operation::insert_with_payload(&creator, 2, 2, NodeId::ROOT, node, vec![0x10], vec![1]);
+        Operation::insert_with_payload(&creator, 2, 2, NodeId::ROOT, node, vec![0, 0x10], vec![1]);
     let late_root_payload = Operation::clear_payload(&creator, 3, 3, NodeId::ROOT);
     let late_node_payload = Operation::set_payload(&creator, 4, 4, node, vec![2]);
     let mut known_state = VersionVector::new();
@@ -798,7 +798,7 @@ fn catch_up_reports_payload_changes_for_root_and_tombstoned_nodes() {
         known_state.observe(&creator, counter);
     }
     let delete = Operation::delete(&deleter, 1, 5, node, Some(known_state.clone()));
-    let head_op = Operation::insert(&creator, 5, 6, NodeId::ROOT, unrelated, vec![0x20]);
+    let head_op = Operation::insert(&creator, 5, 6, NodeId::ROOT, unrelated, vec![0, 0x20]);
 
     let mut storage = MemoryStorage::default();
     for op in [
@@ -813,8 +813,8 @@ fn catch_up_reports_payload_changes_for_root_and_tombstoned_nodes() {
     }
 
     let mut nodes = MemoryNodeStore::default();
-    nodes.attach(node, NodeId::ROOT, vec![0x10]).unwrap();
-    nodes.attach(unrelated, NodeId::ROOT, vec![0x20]).unwrap();
+    nodes.attach(node, NodeId::ROOT, vec![0, 0x10]).unwrap();
+    nodes.attach(unrelated, NodeId::ROOT, vec![0, 0x20]).unwrap();
     let mut deleted_at = known_state;
     deleted_at.observe(&deleter, 1);
     nodes.merge_deleted_at(node, &deleted_at).unwrap();
@@ -870,8 +870,8 @@ fn catch_up_materialized_state_reports_net_restore_from_rebuilt_state() {
     let parent = NodeId(10);
     let child = NodeId(11);
 
-    let parent_op = Operation::insert(&author, 1, 1, NodeId::ROOT, parent, vec![0x10]);
-    let child_op = Operation::insert(&author, 2, 2, parent, child, vec![0x20]);
+    let parent_op = Operation::insert(&author, 1, 1, NodeId::ROOT, parent, vec![0, 0x10]);
+    let child_op = Operation::insert(&author, 2, 2, parent, child, vec![0, 0x20]);
     let mut known_state = VersionVector::new();
     known_state.observe(&author, 1);
     let delete_op = Operation::delete(&deleter, 1, 3, parent, Some(known_state.clone()));
@@ -888,7 +888,7 @@ fn catch_up_materialized_state_reports_net_restore_from_rebuilt_state() {
     // delete were materialized, but the out-of-order child insert has not been replayed yet.
     let mut nodes = MemoryNodeStore::default();
     nodes.ensure_node(parent).unwrap();
-    nodes.attach(parent, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(parent, NodeId::ROOT, vec![0, 0x10]).unwrap();
     nodes.merge_deleted_at(parent, &deleted_at).unwrap();
     nodes.set_tombstone(parent, true).unwrap();
 
@@ -940,13 +940,13 @@ fn catch_up_reports_real_restore_once() {
     let child = NodeId(21);
     let unrelated = NodeId(22);
 
-    let parent_op = Operation::insert(&author, 1, 1, NodeId::ROOT, parent, vec![0x10]);
+    let parent_op = Operation::insert(&author, 1, 1, NodeId::ROOT, parent, vec![0, 0x10]);
     let mut known_state = VersionVector::new();
     known_state.observe(&author, 1);
     let delete_op = Operation::delete(&author, 2, 2, parent, Some(known_state.clone()));
     // This arrives late, but canonically follows the delete and therefore restores the parent.
-    let child_op = Operation::insert(&child_author, 1, 3, parent, child, vec![0x20]);
-    let unrelated_op = Operation::insert(&author, 3, 4, NodeId::ROOT, unrelated, vec![0x30]);
+    let child_op = Operation::insert(&child_author, 1, 3, parent, child, vec![0, 0x20]);
+    let unrelated_op = Operation::insert(&author, 3, 4, NodeId::ROOT, unrelated, vec![0, 0x30]);
 
     let mut storage = MemoryStorage::default();
     for op in [&parent_op, &delete_op, &child_op, &unrelated_op] {
@@ -956,13 +956,13 @@ fn catch_up_reports_real_restore_once() {
     // State before the late child arrives: parent/delete/unrelated are already materialized.
     let mut nodes = MemoryNodeStore::default();
     nodes.ensure_node(parent).unwrap();
-    nodes.attach(parent, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(parent, NodeId::ROOT, vec![0, 0x10]).unwrap();
     let mut deleted_at = known_state;
     deleted_at.observe(&author, 2);
     nodes.merge_deleted_at(parent, &deleted_at).unwrap();
     nodes.set_tombstone(parent, true).unwrap();
     nodes.ensure_node(unrelated).unwrap();
-    nodes.attach(unrelated, NodeId::ROOT, vec![0x30]).unwrap();
+    nodes.attach(unrelated, NodeId::ROOT, vec![0, 0x30]).unwrap();
 
     let meta = Cursor {
         head_lamport: unrelated_op.meta.lamport,
@@ -1008,16 +1008,16 @@ fn catch_up_removes_orphan_derived_rows() {
     let replica = ReplicaId::new(b"orphan-repair");
     let canonical = NodeId(30);
     let orphan = NodeId(31);
-    let canonical_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, canonical, vec![0x10]);
+    let canonical_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, canonical, vec![0, 0x10]);
 
     let mut storage = MemoryStorage::default();
     storage.apply(canonical_op.clone()).unwrap();
 
     let mut nodes = MemoryNodeStore::default();
     nodes.ensure_node(canonical).unwrap();
-    nodes.attach(canonical, NodeId::ROOT, vec![0x10]).unwrap();
+    nodes.attach(canonical, NodeId::ROOT, vec![0, 0x10]).unwrap();
     nodes.ensure_node(orphan).unwrap();
-    nodes.attach(orphan, NodeId::ROOT, vec![0x20]).unwrap();
+    nodes.attach(orphan, NodeId::ROOT, vec![0, 0x20]).unwrap();
 
     let mut index = RecordingIndex::default();
     index.record(NodeId::ROOT, &canonical_op.meta.id, 1).unwrap();
@@ -1066,7 +1066,7 @@ fn catch_up_removes_orphan_derived_rows() {
 #[test]
 fn catch_up_rejects_an_incomplete_scan_before_rewriting_stores() {
     let replica = ReplicaId::new(b"incomplete-scan");
-    let only_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(50), vec![0x10]);
+    let only_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(50), vec![0, 0x10]);
     let mut storage = MemoryStorage::default();
     storage.apply(only_op).unwrap();
 
@@ -1110,7 +1110,7 @@ fn catch_up_rejects_an_incomplete_scan_before_rewriting_stores() {
 #[test]
 fn catch_up_rejects_a_frontier_beyond_the_operation_log() {
     let replica = ReplicaId::new(b"frontier-ahead");
-    let only_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(51), vec![0x10]);
+    let only_op = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(51), vec![0, 0x10]);
     let mut storage = MemoryStorage::default();
     storage.apply(only_op).unwrap();
 

--- a/packages/treecrdt-core/tests/operations.rs
+++ b/packages/treecrdt-core/tests/operations.rs
@@ -59,7 +59,14 @@ fn persisted_operations_require_portable_key_range() {
         (1, overflow, NodeId(92)),
         (overflow, 1, NodeId(93)),
     ] {
-        let op = Operation::insert(&replica, counter, lamport, NodeId::ROOT, node, vec![0x10]);
+        let op = Operation::insert(
+            &replica,
+            counter,
+            lamport,
+            NodeId::ROOT,
+            node,
+            vec![0, 0x10],
+        );
         assert!(crdt.apply_remote(op).is_err());
     }
     assert!(crdt.children(NodeId::ROOT).unwrap().is_empty());
@@ -135,7 +142,7 @@ fn prevents_cycle_on_move() {
         3,
         a,
         b,
-        Vec::new(),
+        vec![0, 1],
     ))
     .unwrap();
     assert_eq!(crdt.parent(a).unwrap(), Some(root));
@@ -160,7 +167,7 @@ fn rejected_cycle_move_emits_no_visible_change() {
     let mut index = NoopParentOpIndex;
     let delta = crdt
         .apply_remote_with_materialization_seq(
-            Operation::move_node(&ReplicaId::new(b"remote"), 1, 3, parent, child, Vec::new()),
+            Operation::move_node(&ReplicaId::new(b"remote"), 1, 3, parent, child, vec![0, 1]),
             &mut index,
             &mut seq,
         )
@@ -173,7 +180,7 @@ fn rejected_cycle_move_emits_no_visible_change() {
 
     let rejected_insert = crdt
         .apply_remote_with_materialization_seq(
-            Operation::insert(&ReplicaId::new(b"remote"), 2, 4, child, parent, Vec::new()),
+            Operation::insert(&ReplicaId::new(b"remote"), 2, 4, child, parent, vec![0, 1]),
             &mut index,
             &mut seq,
         )
@@ -190,7 +197,7 @@ fn rejected_cycle_move_emits_no_visible_change() {
                 5,
                 child,
                 child,
-                Vec::new(),
+                vec![0, 1],
                 vec![9],
             ),
             &mut index,
@@ -224,7 +231,7 @@ fn rejected_cycle_move_emits_no_visible_change() {
             7,
             NodeId::TRASH,
             root,
-            Vec::new(),
+            vec![0, 1],
         ),
     ] {
         let delta = crdt
@@ -274,9 +281,9 @@ fn malformed_parent_cycle_rejects_move_without_looping() {
     nodes.ensure_node(cycle_a).unwrap();
     nodes.ensure_node(cycle_b).unwrap();
     nodes.ensure_node(node).unwrap();
-    nodes.attach(cycle_a, cycle_b, vec![1]).unwrap();
-    nodes.attach(cycle_b, cycle_a, vec![1]).unwrap();
-    nodes.attach(node, root, vec![1]).unwrap();
+    nodes.attach(cycle_a, cycle_b, vec![0, 1]).unwrap();
+    nodes.attach(cycle_b, cycle_a, vec![0, 1]).unwrap();
+    nodes.attach(node, root, vec![0, 1]).unwrap();
 
     let mut crdt = TreeCrdt::with_stores(
         ReplicaId::new(b"local"),
@@ -290,7 +297,7 @@ fn malformed_parent_cycle_rejects_move_without_looping() {
     let mut index = NoopParentOpIndex;
     let delta = crdt
         .apply_remote_with_materialization_seq(
-            Operation::move_node(&ReplicaId::new(b"remote"), 1, 1, node, cycle_a, Vec::new()),
+            Operation::move_node(&ReplicaId::new(b"remote"), 1, 1, node, cycle_a, vec![0, 1]),
             &mut index,
             &mut seq,
         )
@@ -314,14 +321,14 @@ fn cycles_are_blocked() {
     let b = NodeId(2);
 
     let inserts = [
-        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, Vec::new()),
-        Operation::insert(&ReplicaId::new(b"a"), 2, 2, a, b, Vec::new()),
+        Operation::insert(&ReplicaId::new(b"a"), 1, 1, root, a, vec![0, 1]),
+        Operation::insert(&ReplicaId::new(b"a"), 2, 2, a, b, vec![0, 1]),
     ];
     for op in inserts {
         crdt.apply_remote(op).unwrap();
     }
 
-    let bad_move = Operation::move_node(&ReplicaId::new(b"a"), 3, 3, a, b, Vec::new());
+    let bad_move = Operation::move_node(&ReplicaId::new(b"a"), 3, 3, a, b, vec![0, 1]);
     crdt.apply_remote(bad_move).unwrap();
     assert_eq!(crdt.parent(a).unwrap(), Some(root));
     assert_eq!(crdt.parent(b).unwrap(), Some(a));
@@ -344,7 +351,7 @@ fn materialization_seq_advances_only_for_new_ops() {
         1,
         NodeId::ROOT,
         NodeId(1),
-        Vec::new(),
+        vec![0, 1],
     );
 
     let first = crdt
@@ -370,7 +377,7 @@ fn apply_remote_with_materialization_reports_changes() {
     let mut index = NoopParentOpIndex;
     let replica = ReplicaId::new(b"remote");
 
-    let insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), Vec::new());
+    let insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 1]);
     let insert_delta = crdt
         .apply_remote_with_materialization_seq(insert, &mut index, &mut seq)
         .unwrap()

--- a/packages/treecrdt-core/tests/order_key_validation.rs
+++ b/packages/treecrdt-core/tests/order_key_validation.rs
@@ -1,0 +1,90 @@
+use treecrdt_core::{
+    Lamport, LamportClock, LocalPlacement, MemoryStorage, NodeId, Operation, OperationKind,
+    ReplicaId, Result, Storage, TreeCrdt,
+};
+
+#[test]
+fn structural_operation_validation_is_state_independent() {
+    let replica = ReplicaId::new(b"remote");
+    let invalid = [
+        Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![]),
+        Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(2), vec![1]),
+        Operation::insert(&replica, 3, 3, NodeId::ROOT, NodeId(3), vec![0, 1, 0, 0]),
+        Operation::insert(&replica, 4, 4, NodeId::TRASH, NodeId(4), vec![0, 1]),
+        Operation::move_node(&replica, 5, 5, NodeId(5), NodeId::ROOT, vec![]),
+        Operation::move_node(&replica, 6, 6, NodeId(6), NodeId::TRASH, vec![0, 1]),
+    ];
+    for op in invalid {
+        assert!(
+            op.validate().is_err(),
+            "operation should be rejected: {op:?}"
+        );
+    }
+
+    for op in [
+        Operation::insert(&replica, 7, 7, NodeId::ROOT, NodeId(7), vec![0, 1]),
+        Operation::move_node(&replica, 8, 8, NodeId(8), NodeId::ROOT, vec![0xff, 0xff]),
+        Operation::insert(&replica, 9, 9, NodeId::TRASH, NodeId(9), vec![]),
+        Operation::move_node(&replica, 10, 10, NodeId(10), NodeId::TRASH, vec![]),
+    ] {
+        op.validate().unwrap();
+    }
+}
+
+#[derive(Clone)]
+struct UncheckedStorage(Vec<Operation>);
+
+impl Storage for UncheckedStorage {
+    fn apply(&mut self, op: Operation) -> Result<bool> {
+        self.0.push(op);
+        Ok(true)
+    }
+
+    fn load_since(&self, lamport: Lamport) -> Result<Vec<Operation>> {
+        Ok(self.0.iter().filter(|op| op.meta.lamport > lamport).cloned().collect())
+    }
+
+    fn latest_lamport(&self) -> Lamport {
+        self.0.iter().map(|op| op.meta.lamport).max().unwrap_or(0)
+    }
+}
+
+#[test]
+fn replay_revalidates_persisted_operations() {
+    let invalid = Operation::insert(
+        &ReplicaId::new(b"remote"),
+        1,
+        1,
+        NodeId::ROOT,
+        NodeId(10),
+        vec![],
+    );
+    let mut tree = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        UncheckedStorage(vec![invalid]),
+        LamportClock::default(),
+    )
+    .unwrap();
+
+    let error = tree.replay_from_storage().unwrap_err();
+    assert!(error.to_string().contains("non-empty"));
+    assert!(tree.children(NodeId::ROOT).unwrap().is_empty());
+}
+
+#[test]
+fn local_move_to_trash_uses_the_empty_sentinel_key() {
+    let mut tree = TreeCrdt::new(
+        ReplicaId::new(b"local"),
+        MemoryStorage::default(),
+        LamportClock::default(),
+    )
+    .unwrap();
+    let node = NodeId(10);
+    tree.local_insert(NodeId::ROOT, node, LocalPlacement::First, None).unwrap();
+
+    let (operation, _) = tree.local_move(node, NodeId::TRASH, LocalPlacement::First).unwrap();
+    let OperationKind::Move { order_key, .. } = operation.kind else {
+        unreachable!();
+    };
+    assert!(order_key.is_empty());
+}

--- a/packages/treecrdt-core/tests/out_of_order.rs
+++ b/packages/treecrdt-core/tests/out_of_order.rs
@@ -13,10 +13,10 @@ fn applies_insert_after_parent_arrives_out_of_order() {
     let child = NodeId(2);
     let replica = ReplicaId::new(b"r1");
 
-    let child_first = Operation::insert(&replica, 1, 1, parent, child, Vec::new());
+    let child_first = Operation::insert(&replica, 1, 1, parent, child, vec![0, 1]);
     crdt.apply_remote(child_first).unwrap();
 
-    let parent_op = Operation::insert(&replica, 2, 2, NodeId::ROOT, parent, Vec::new());
+    let parent_op = Operation::insert(&replica, 2, 2, NodeId::ROOT, parent, vec![0, 1]);
     crdt.apply_remote(parent_op).unwrap();
 
     assert_eq!(crdt.parent(child).unwrap(), Some(parent));
@@ -37,12 +37,12 @@ fn move_applied_after_insert_when_delivered_out_of_order() {
     let replica = ReplicaId::new(b"r1");
 
     // Move arrives first (references node + parent that do not yet exist)
-    let move_op = Operation::move_node(&replica, 3, 3, node, parent, Vec::new());
+    let move_op = Operation::move_node(&replica, 3, 3, node, parent, vec![0, 1]);
     crdt.apply_remote(move_op).unwrap();
 
     // Later, parent and node inserts arrive
-    let parent_insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, parent, Vec::new());
-    let node_insert = Operation::insert(&replica, 2, 2, NodeId::ROOT, node, Vec::new());
+    let parent_insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, parent, vec![0, 1]);
+    let node_insert = Operation::insert(&replica, 2, 2, NodeId::ROOT, node, vec![0, 2]);
     crdt.apply_remote(parent_insert).unwrap();
     crdt.apply_remote(node_insert).unwrap();
 
@@ -58,9 +58,9 @@ fn replay_from_storage_catches_up_state_and_advanced_clock() {
     let node = NodeId(20);
 
     // out-of-order arrival persisted to storage
-    let move_first = Operation::move_node(&replica, 3, 4, node, parent, Vec::new());
-    let node_insert = Operation::insert(&replica, 1, 2, NodeId::ROOT, node, Vec::new());
-    let parent_insert = Operation::insert(&replica, 2, 5, NodeId::ROOT, parent, Vec::new());
+    let move_first = Operation::move_node(&replica, 3, 4, node, parent, vec![0, 1]);
+    let node_insert = Operation::insert(&replica, 1, 2, NodeId::ROOT, node, vec![0, 1]);
+    let parent_insert = Operation::insert(&replica, 2, 5, NodeId::ROOT, parent, vec![0, 2]);
     storage.apply(move_first.clone()).unwrap();
     storage.apply(node_insert.clone()).unwrap();
     storage.apply(parent_insert.clone()).unwrap();
@@ -87,8 +87,8 @@ fn apply_remote_with_delta_returns_none_when_replay_is_required() {
     .unwrap();
     let replica = ReplicaId::new(b"r1");
 
-    let high = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(20), Vec::new());
-    let low = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(10), Vec::new());
+    let high = Operation::insert(&replica, 2, 2, NodeId::ROOT, NodeId(20), vec![0, 2]);
+    let low = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(10), vec![0, 1]);
 
     let first = crdt.apply_remote_with_delta(high).unwrap();
     assert!(first.is_some());

--- a/packages/treecrdt-core/tests/payload_ops.rs
+++ b/packages/treecrdt-core/tests/payload_ops.rs
@@ -16,7 +16,7 @@ fn payload_lww_tie_breaker_converges() {
     .unwrap();
 
     let node = NodeId(1);
-    let insert = Operation::insert(&ReplicaId::new(b"s"), 1, 1, NodeId::ROOT, node, Vec::new());
+    let insert = Operation::insert(&ReplicaId::new(b"s"), 1, 1, NodeId::ROOT, node, vec![0, 1]);
     a.apply_remote(insert.clone()).unwrap();
     b.apply_remote(insert).unwrap();
 
@@ -50,7 +50,7 @@ fn payload_clear_is_last_writer_wins() {
     .unwrap();
 
     let node = NodeId(1);
-    let insert = Operation::insert(&ReplicaId::new(b"s"), 1, 1, NodeId::ROOT, node, Vec::new());
+    let insert = Operation::insert(&ReplicaId::new(b"s"), 1, 1, NodeId::ROOT, node, vec![0, 1]);
     a.apply_remote(insert.clone()).unwrap();
     b.apply_remote(insert).unwrap();
 
@@ -77,7 +77,7 @@ fn payload_can_arrive_before_insert() {
     .unwrap();
 
     let node = NodeId(1);
-    let insert = Operation::insert(&ReplicaId::new(b"a"), 1, 1, NodeId::ROOT, node, Vec::new());
+    let insert = Operation::insert(&ReplicaId::new(b"a"), 1, 1, NodeId::ROOT, node, vec![0, 1]);
     let payload = Operation::set_payload(&ReplicaId::new(b"a"), 2, 2, node, b"hello");
 
     // Receive payload first, then receive the earlier insert (out of order by lamport).
@@ -105,7 +105,7 @@ fn insert_with_payload_sets_value() {
         1,
         NodeId::ROOT,
         node,
-        Vec::new(),
+        vec![0, 1],
         b"hello",
     );
 
@@ -132,7 +132,7 @@ fn insert_payload_does_not_override_newer_payload() {
         1,
         NodeId::ROOT,
         node,
-        Vec::new(),
+        vec![0, 1],
         b"old",
     );
     let payload = Operation::set_payload(&ReplicaId::new(b"a"), 2, 2, node, b"new");

--- a/packages/treecrdt-core/tests/property_tests.rs
+++ b/packages/treecrdt-core/tests/property_tests.rs
@@ -14,8 +14,8 @@ proptest! {
                 let node = nodes[(i + 1) % nodes.len()];
                 let parent = nodes[i % nodes.len()];
                 match i % 3 {
-                    0 => Operation::insert(&replica, (i + 1) as u64, lamport, parent, node, Vec::new()),
-                    1 => Operation::move_node(&replica, (i + 1) as u64, lamport, node, parent, Vec::new()),
+                    0 => Operation::insert(&replica, (i + 1) as u64, lamport, parent, node, vec![0, (i + 1) as u8]),
+                    1 => Operation::move_node(&replica, (i + 1) as u64, lamport, node, parent, vec![0, (i + 1) as u8]),
                     _ => Operation::delete(&replica, (i + 1) as u64, lamport, node, None),
                 }
             }),

--- a/packages/treecrdt-core/tests/subtree_version_vector.rs
+++ b/packages/treecrdt-core/tests/subtree_version_vector.rs
@@ -17,8 +17,8 @@ fn subtree_walk_terminates_on_cycle_and_merges_each_node() {
     let node_b = NodeId(2);
     let mut nodes = MemoryNodeStore::default();
 
-    nodes.attach(node_a, node_b, vec![0x10]).unwrap();
-    nodes.attach(node_b, node_a, vec![0x20]).unwrap();
+    nodes.attach(node_a, node_b, vec![0, 0x10]).unwrap();
+    nodes.attach(node_b, node_a, vec![0, 0x20]).unwrap();
     nodes.merge_last_change(node_a, &version(&replica_a, 1)).unwrap();
     nodes.merge_last_change(node_b, &version(&replica_b, 2)).unwrap();
 
@@ -46,7 +46,7 @@ fn subtree_walk_handles_a_deep_chain_without_recursion() {
 
     for counter in 1..=DEPTH {
         let child = NodeId(counter as u128);
-        nodes.attach(child, parent, vec![0x10]).unwrap();
+        nodes.attach(child, parent, vec![0, 0x10]).unwrap();
         nodes.merge_last_change(child, &version(&replica, counter)).unwrap();
         parent = child;
     }

--- a/packages/treecrdt-sqlite-ext/src/storage.rs
+++ b/packages/treecrdt-sqlite-ext/src/storage.rs
@@ -252,8 +252,8 @@ mod tests {
     fn apply_and_load_round_trip() {
         let mut storage = SqliteStorage::new_in_memory().unwrap();
         let replica = ReplicaId::new(b"r1");
-        let insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), Vec::new());
-        let mov = Operation::move_node(&replica, 2, 2, NodeId(1), NodeId::ROOT, Vec::new());
+        let insert = Operation::insert(&replica, 1, 1, NodeId::ROOT, NodeId(1), vec![0, 1]);
+        let mov = Operation::move_node(&replica, 2, 2, NodeId(1), NodeId::ROOT, vec![0, 1]);
         let del = Operation::delete(&replica, 3, 3, NodeId(1), None);
 
         storage.apply(insert.clone()).unwrap();
@@ -283,7 +283,7 @@ mod tests {
                 3,
                 child,
                 parent,
-                Vec::new(),
+                vec![0, 1],
             ))
             .unwrap();
         storage
@@ -293,7 +293,7 @@ mod tests {
                 1,
                 NodeId::ROOT,
                 parent,
-                Vec::new(),
+                vec![0, 1],
             ))
             .unwrap();
         storage
@@ -303,7 +303,7 @@ mod tests {
                 2,
                 NodeId::ROOT,
                 child,
-                Vec::new(),
+                vec![0, 2],
             ))
             .unwrap();
 

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -868,7 +868,7 @@ fn concurrent_remote_appends_load_meta_after_write_serialization() {
 }
 
 #[test]
-fn remote_append_validates_operation_key_range_atomically() {
+fn remote_append_validates_operations_atomically() {
     let conn = setup_conn();
     let replica = ReplicaId::new(b"invalid-key");
     let append = |ops: &[Operation]| -> rusqlite::Result<String> {
@@ -902,6 +902,29 @@ fn remote_append_validates_operation_key_range_atomically() {
     assert_eq!(op_count, 0);
     assert_eq!(read_tree_meta(&conn).3, 0);
     assert_eq!(read_replay_frontier(&conn), (None, None, None));
+
+    let valid_prefix = Operation::insert(
+        &replica,
+        3,
+        3,
+        NodeId::ROOT,
+        materialization_conformance::node(42),
+        materialization_conformance::order_key_from_position(2),
+    );
+    let invalid_order_key = Operation::insert(
+        &replica,
+        4,
+        4,
+        NodeId::ROOT,
+        materialization_conformance::node(43),
+        vec![1],
+    );
+    assert!(append(&[valid_prefix, invalid_order_key]).is_err());
+    assert_eq!(
+        conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get::<_, i64>(0))
+            .unwrap(),
+        0
+    );
 
     let max = i64::MAX as u64;
     let boundary = Operation::insert(

--- a/packages/treecrdt-test-support/src/lib.rs
+++ b/packages/treecrdt-test-support/src/lib.rs
@@ -63,8 +63,10 @@ fn visible_payload_source(
 }
 
 pub fn order_key_from_position(position: u16) -> Vec<u8> {
-    let n = position.wrapping_add(1);
-    n.to_be_bytes().to_vec()
+    match position.checked_add(1) {
+        Some(next) => next.to_be_bytes().to_vec(),
+        None => vec![0xff, 0xff, 0, 1],
+    }
 }
 
 pub fn node(n: u128) -> NodeId {
@@ -843,4 +845,19 @@ pub fn catch_up_omits_replay_only_restore<H: MaterializationConformanceHarness>(
     assert_eq!(harness.visible_children(NodeId::ROOT), vec![parent]);
     assert_eq!(harness.visible_children(parent), vec![child]);
     assert_replay_cleared(harness);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::order_key_from_position;
+
+    #[test]
+    fn maximum_position_stays_canonical_and_ordered() {
+        let penultimate = order_key_from_position(u16::MAX - 1);
+        let maximum = order_key_from_position(u16::MAX);
+
+        assert_eq!(penultimate, vec![0xff, 0xff]);
+        assert_eq!(maximum, vec![0xff, 0xff, 0, 1]);
+        assert!(maximum > penultimate);
+    }
 }


### PR DESCRIPTION
## Problem

TreeCRDT accepted structurally malformed sibling order keys at some ingestion boundaries. Odd-width, empty, or zero-terminated keys can make bytewise ordering ambiguous and leave the allocator with bounds that have no canonical key between them.

Because there are no deployed consumers to migrate, this PR defines one format and rejects everything else.

## Canonical contract

For ordinary insert and move operations, `orderKey` must:

- be non-empty
- contain complete big-endian `u16` digits
- end in a non-zero `u16` digit

Moves into `Trash` use exactly the empty key. Equal canonical keys remain valid; siblings are deterministically ordered by `(orderKey, nodeId)`.

## What changes

- Enforce the contract in `Operation::validate`.
- Validate operations again when rebuilding from stored canonical history.
- Normalize repository fixtures to the canonical encoding.
- Keep the maximum test position canonical instead of wrapping to zero.
- Add focused core and SQLite boundary tests.

This is a hard validation boundary, not a legacy decoder or migration.

## Fast paths

- Validation checks only emptiness, byte parity, and the final two bytes; it does not parse or allocate.
- Trash keeps its dedicated empty-key sentinel.
- Normal materialization and sibling comparisons are unchanged.

## Verification

- `cargo test --workspace`
- full core and test-support tests
- SQLite extension-feature tests
- strict workspace Clippy
- Rust formatting and diff checks

## Stack

Stacked on #185. #186 is rebased onto this PR and now contains only allocator behavior.