### PR TITLE
fix(sync): load RIBLT only during reconciliation

### DIFF
--- a/.changeset/tidy-riblt-startup.md
+++ b/.changeset/tidy-riblt-startup.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/sync-protocol': patch
+---
+
+Load RIBLT only when reconciliation needs it, so importing the sync protocol no longer suspends browser application startup.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,9 @@ jobs:
       - name: Build project
         run: pnpm run build
 
+      - name: Run sync protocol tests
+        run: pnpm -C packages/sync-protocol/protocol exec vitest run
+
       - name: Run browser tests
         run: pnpm run test:browser
 

--- a/packages/sync-protocol/protocol/src/sync.ts
+++ b/packages/sync-protocol/protocol/src/sync.ts
@@ -1,4 +1,4 @@
-import { RibltDecoder16, RibltEncoder16 } from '@treecrdt/riblt-wasm';
+import type { RibltDecoder16 } from '@treecrdt/riblt-wasm';
 
 import {
   AUTH_CAPABILITY_NAME,
@@ -700,6 +700,7 @@ export class SyncPeer<Op> {
         return;
       }
 
+      const { RibltEncoder16 } = await import('@treecrdt/riblt-wasm');
       const enc = new RibltEncoder16();
       for (const r of opRefs) enc.addSymbol(r);
 
@@ -1282,6 +1283,7 @@ export class SyncPeer<Op> {
         continue;
       }
 
+      const { RibltDecoder16 } = await import('@treecrdt/riblt-wasm');
       const decoder = new RibltDecoder16();
       for (const r of localOpRefs) decoder.addLocalSymbol(r);
       traceHello(this.backend.docId, traceStartedAt, 'after-decoder-setup', {


### PR DESCRIPTION
## What this fixes

`@treecrdt/sync-protocol` statically imported the RIBLT WASM package. In browsers, that package initializes WASM with top-level await, so importing sync also suspended the application's module graph. In em, the document could finish loading before the application resumed and attached `window.em`.

Context: https://github.com/cybersemics/em/pull/4325#discussion_r3548269233

## How it works

- Keep the RIBLT import type-only during normal sync module loading.
- Dynamically import the encoder or decoder only when RIBLT reconciliation is actually selected.
- Let the JavaScript module loader cache and single-flight that import.
- Browser import resolves after WASM initialization; Node import resolves after its normal synchronous initialization.

The direct-send fast paths do not load the RIBLT JavaScript chunk or WASM at all.

## Clean-slate/debloat

There is no new public initialization API, Node no-op, manual promise cache, compatibility shim, or package-level initialization test. The existing RIBLT API and initialization contract stay unchanged.

The PR is **3 files, +11/-1**, reduced from **7 files, +76/-4**.

## Validation

- sync protocol: 23/23
- TypeScript build
- Prettier
- changeset status
