### PR TITLE
test(wa-sqlite): cover SharedWorker OPFS lifecycle

### DIFF
--- a/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/src/lifecycle.ts
@@ -2,7 +2,7 @@ import { createTreecrdtClient, detectOpfsSupport, type TreecrdtClient } from '@t
 import { nodeIdFromInt } from '@treecrdt/benchmark';
 import { replicaFromLabel } from './op-helpers.js';
 
-export type LifecycleRuntime = 'direct' | 'dedicated-worker';
+export type LifecycleRuntime = 'direct' | 'dedicated-worker' | 'shared-worker';
 
 const rootId = '0'.repeat(32);
 const parentId = nodeIdFromInt(901);

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test';
 
 type LifecycleHarness = NonNullable<Window['__treecrdtLifecycle']>;
-type LifecycleRuntime = 'direct' | 'dedicated-worker';
+type LifecycleRuntime = 'direct' | 'dedicated-worker' | 'shared-worker';
 
 const scenarios: Array<{
   runtime: LifecycleRuntime;
@@ -9,6 +9,7 @@ const scenarios: Array<{
 }> = [
   { runtime: 'direct', expectedMode: 'direct' },
   { runtime: 'dedicated-worker', expectedMode: 'worker' },
+  { runtime: 'shared-worker', expectedMode: 'worker' },
 ];
 
 const reloadCases: Array<{
@@ -120,7 +121,11 @@ test.describe('browser OPFS lifecycle', () => {
         if (!opfsSupport.available) test.skip(true, `OPFS unavailable: ${opfsSupport.reason}`);
 
         try {
-          await drop(page, opts);
+          // Start the shared-worker lifecycle without a pre-existing worker port.
+          await drop(page, {
+            ...opts,
+            runtime: scenario.runtime === 'shared-worker' ? 'direct' : scenario.runtime,
+          });
           const initialState = await write(page, {
             ...opts,
             closeBeforeReload: reloadCase.closeBeforeReload,

--- a/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/lifecycle.spec.ts
@@ -121,11 +121,6 @@ test.describe('browser OPFS lifecycle', () => {
         if (!opfsSupport.available) test.skip(true, `OPFS unavailable: ${opfsSupport.reason}`);
 
         try {
-          // Start the shared-worker lifecycle without a pre-existing worker port.
-          await drop(page, {
-            ...opts,
-            runtime: scenario.runtime === 'shared-worker' ? 'direct' : scenario.runtime,
-          });
           const initialState = await write(page, {
             ...opts,
             closeBeforeReload: reloadCase.closeBeforeReload,


### PR DESCRIPTION
## Summary

- add SharedWorker to the browser OPFS lifecycle matrix
- exercise long filenames across write, reload, persisted read, and drop
- cover both explicit close and abrupt reload
- start each lifecycle from its unique document ID and filename without a pre-clean client

Each case uses a fresh randomized OPFS path, so the first client created is the runtime under test. The final `drop` still verifies cleanup and removes the test store.

## Verification

- `pnpm -C packages/treecrdt-wa-sqlite/e2e exec playwright test tests/lifecycle.spec.ts --project=chromium-dev` (6 passed)
- focused Prettier check
- `git diff --check`