### PR TITLE
test(wa-sqlite): allow installed Chrome e2e runs

### DIFF
--- a/packages/treecrdt-wa-sqlite/e2e/README.md
+++ b/packages/treecrdt-wa-sqlite/e2e/README.md
@@ -3,6 +3,20 @@
 This package hosts the React demo and Playwright e2e tests for the TreeCRDT wa-sqlite build. The library code lives in `@treecrdt/wa-sqlite`; this package depends on it and exercises it in the browser.
 
 ## Scripts
+
 - `pnpm run dev` – start Vite dev server on port 4166.
 - `pnpm run build` – rebuild wa-sqlite artifacts and Vite build the demo.
 - `pnpm run test:e2e` – rebuild wa-sqlite artifacts and run Playwright tests.
+
+## Browser selection
+
+The default `chromium-dev` project uses Playwright's bundled Chromium. Set
+`TREECRDT_BROWSER_CHANNEL=chrome` to run the same integration tests against the installed
+Google Chrome release instead:
+
+```sh
+TREECRDT_BROWSER_CHANNEL=chrome pnpm run test:e2e -- \
+  tests/lifecycle.spec.ts \
+  --project=chromium-dev \
+  --grep shared-worker
+```

--- a/packages/treecrdt-wa-sqlite/e2e/playwright.config.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const browserChannel = process.env.TREECRDT_BROWSER_CHANNEL;
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: false,
@@ -11,7 +13,11 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium-dev',
-      use: { ...devices['Desktop Chrome'], baseURL: 'http://localhost:4166' },
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:4166',
+        ...(browserChannel ? { channel: browserChannel } : {}),
+      },
     },
     {
       name: 'chromium-basepath-preview',


### PR DESCRIPTION
## Why

The `Desktop Chrome` device profile still launches Playwright's bundled Chromium. That hides browser-version regressions from TreeCRDT's existing SharedWorker + OPFS lifecycle coverage.

The current lifecycle tests pass in bundled Chromium 143 and reproduce `sqlite3_open_v2` in installed Chrome 150 under the existing COOP/COEP server headers.

## Change

- Allow `TREECRDT_BROWSER_CHANNEL=chrome` to run the `chromium-dev` project against installed Google Chrome.
- Document the focused lifecycle-test command.

The default CI browser remains unchanged.