### PR TITLE
fix: allocate between adjacent order-key prefixes

### DIFF
--- a/.changeset/warm-dragons-order.md
+++ b/.changeset/warm-dragons-order.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Allocate local insert and move order keys correctly when adjacent prefix digits have independently ordered suffixes.

--- a/packages/treecrdt-core/src/order_key.rs
+++ b/packages/treecrdt-core/src/order_key.rs
@@ -84,7 +84,7 @@ pub fn allocate_between(left: Option<&[u8]>, right: Option<&[u8]>, seed: &[u8]) 
             ));
         }
 
-        if rd > ld + 1 {
+        if u32::from(rd) > u32::from(ld) + 1 {
             let gap = rd - ld - 1;
             let boundary = DEFAULT_BOUNDARY.min(gap);
             let choose_left = choose_side(seed, depth);
@@ -100,6 +100,14 @@ pub fn allocate_between(left: Option<&[u8]>, right: Option<&[u8]>, seed: &[u8]) 
             };
 
             out.push(choose_in_range(seed, depth, lo, hi));
+            break;
+        }
+
+        // Once a concrete left digit is immediately below the upper digit, its remaining suffix
+        // can be extended without comparing it against the right key's suffix.
+        if rd > ld && depth < left_digits.len() {
+            out.extend_from_slice(&left_digits[depth..]);
+            out.push(choose_in_range(seed, left_digits.len(), 1, u16::MAX));
             break;
         }
 

--- a/packages/treecrdt-core/tests/order_key_adjacent_prefix.rs
+++ b/packages/treecrdt-core/tests/order_key_adjacent_prefix.rs
@@ -1,0 +1,23 @@
+use treecrdt_core::order_key::allocate_between;
+
+#[test]
+fn allocates_between_adjacent_prefixes_with_opposite_suffix_order() {
+    // Once fffd < fffe, later digits must not be compared across the bounds, even when the right
+    // suffix is smaller.
+    let left = [0xff, 0xfd, 0xff, 0xfe];
+    let right = [0xff, 0xfe, 0xff, 0xfc];
+
+    let allocated = allocate_between(Some(&left), Some(&right), b"em-undo-redo").unwrap();
+
+    assert!(allocated.as_slice() > left.as_slice());
+    assert!(allocated.as_slice() < right.as_slice());
+}
+
+#[test]
+fn allocates_after_maximum_digit_without_overflow() {
+    let left = [0xff, 0xff];
+
+    let allocated = allocate_between(Some(&left), None, b"append-after-ffff").unwrap();
+
+    assert!(allocated.as_slice() > left.as_slice());
+}


### PR DESCRIPTION
em undo/redo can request an order key between `fffd fffe` and `fffe fffc`. Those bounds are correctly ordered, but the current allocator keeps comparing their suffixes after the first differing digit and rejects the move with `right < left`, which surfaces through wa-sqlite as a `treecrdt_local_move` SQL logic error.

Stop consulting the right suffix once adjacent concrete digits differ and extend the left key instead. The same comparison now also avoids overflowing at `ffff`.

This extracts the immediate regression fix from #186 so it can land without waiting for the full core stack. #186 remains the broader allocator and canonical-key hardening and should be rebased after this merges.