### PR TITLE
fix: preserve empty SQLite payloads

### DIFF
--- a/.changeset/preserve-empty-sqlite-payloads.md
+++ b/.changeset/preserve-empty-sqlite-payloads.md
@@ -1,0 +1,6 @@
+---
+"@treecrdt/interface": patch
+"@treecrdt/wa-sqlite": patch
+---
+
+Preserve zero-length SQLite payloads distinctly from null across local writes, operation reads, replay, and reopen. Keep exact-state version-vector buffers alive until SQLite consumes them so a later local write cannot observe corrupted replay metadata.

--- a/.changeset/preserve-empty-sqlite-payloads.md
+++ b/.changeset/preserve-empty-sqlite-payloads.md
@@ -3,4 +3,4 @@
 "@treecrdt/wa-sqlite": patch
 ---
 
-Preserve zero-length SQLite payloads distinctly from null across local writes, operation reads, replay, and reopen. Keep exact-state version-vector buffers alive until SQLite consumes them so a later local write cannot observe corrupted replay metadata.
+Preserve zero-length SQLite payloads and order keys distinctly from null across local writes, remote appends, operation reads, replay, and reopen. Reject empty replica IDs without aborting or leaving SQLite statements open.

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -165,6 +165,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
       run: scenarioOutOfOrderOpsRebuild,
     },
     {
+      name: 'payload: empty bytes survive local writes and canonical replay',
+      run: scenarioEmptyPayloadCanonicalReplay,
+    },
+    {
       name: 'materialized tree: dump/children/meta + oprefs_children',
       run: scenarioMaterializedSmokeWithOpRefs,
     },
@@ -901,6 +905,88 @@ async function scenarioOutOfOrderOpsRebuild(ctx: TreecrdtEngineConformanceContex
   );
 }
 
+async function scenarioEmptyPayloadCanonicalReplay(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const withEmptyPayload = nodeIdFromInt(21);
+  const lateNode = nodeIdFromInt(22);
+  const localNode = nodeIdFromInt(23);
+  const empty = new Uint8Array();
+
+  // The late insert invalidates the materialization frontier and forces canonical replay.
+  await engine.ops.append(
+    makeInsertOp({
+      replica,
+      counter: 2,
+      lamport: 2,
+      parent: root,
+      node: withEmptyPayload,
+      orderKey: orderKeyFromPosition(1),
+      payload: empty,
+    }),
+  );
+  assertBytesEqual(
+    await engine.tree.getPayload(withEmptyPayload),
+    empty,
+    'empty insert payload before replay',
+  );
+
+  await engine.ops.append(
+    makeInsertOp({
+      replica,
+      counter: 1,
+      lamport: 1,
+      parent: root,
+      node: lateNode,
+      orderKey: orderKeyFromPosition(0),
+    }),
+  );
+
+  assertBytesEqual(
+    await engine.tree.getPayload(withEmptyPayload),
+    empty,
+    'empty insert payload after replay',
+  );
+  assertBytesEqual(
+    await engine.tree.getPayload(lateNode),
+    null,
+    'null remains distinct from empty',
+  );
+
+  const replayed = (await engine.ops.all()).find(
+    (op) => op.meta.id.counter === 2 && op.kind.type === 'insert',
+  );
+  assert(replayed?.kind.type === 'insert', 'replayed empty insert op');
+  assertBytesEqual(replayed.kind.payload ?? null, empty, 'op log preserves empty insert payload');
+
+  const localInsert = await engine.local.insert(replica, root, localNode, { type: 'last' }, empty);
+  assert(localInsert.kind.type === 'insert', 'local empty insert op');
+  assertBytesEqual(localInsert.kind.payload ?? null, empty, 'local insert returns empty payload');
+  assertBytesEqual(
+    await engine.tree.getPayload(localNode),
+    empty,
+    'local insert stores empty payload',
+  );
+
+  await engine.local.payload(replica, localNode, null);
+  assertBytesEqual(
+    await engine.tree.getPayload(localNode),
+    null,
+    'local payload clear stores null',
+  );
+  const localPayload = await engine.local.payload(replica, localNode, empty);
+  assert(localPayload.kind.type === 'payload', 'local empty payload op');
+  assertBytesEqual(localPayload.kind.payload, empty, 'local payload returns empty bytes');
+  assertBytesEqual(
+    await engine.tree.getPayload(localNode),
+    empty,
+    'local payload stores empty bytes',
+  );
+}
+
 async function scenarioMaterializedSmokeWithOpRefs(
   ctx: TreecrdtEngineConformanceContext,
 ): Promise<void> {
@@ -1405,29 +1491,32 @@ async function scenarioPersistencePayloadReopen(
   const replica = replicaFromLabel('r1');
   const root = nodeIdFromInt(0);
   const n1 = nodeIdFromInt(1);
+  const n2 = nodeIdFromInt(2);
+  const empty = new Uint8Array();
 
   const e1 = await ctx.createPersistentEngine({ docId: ctx.docId, name: 'db' });
   await e1.local.insert(replica, root, n1, { type: 'last' }, null);
-  await e1.local.payload(replica, n1, new TextEncoder().encode('hello'));
+  await e1.local.payload(replica, n1, empty);
+  await e1.local.insert(replica, root, n2, { type: 'last' }, null);
   await e1.close();
 
   const e2 = await ctx.createPersistentEngine({ docId: ctx.docId, name: 'db' });
-  assertArrayEqual(await e2.tree.children(root), [n1], 'children after reopen (payload)');
+  assertArrayEqual(await e2.tree.children(root), [n1, n2], 'children after reopen (payload)');
 
   const payload = await e2.tree.getPayload(n1);
   assert(payload !== null, 'tree.getPayload should return payload for node with payload');
-  assertEqual(
-    new TextDecoder().decode(payload),
-    'hello',
-    'tree.getPayload returns correct value after reopen',
-  );
+  assertBytesEqual(payload, empty, 'tree.getPayload returns empty payload after reopen');
+  assertBytesEqual(await e2.tree.getPayload(n2), null, 'null remains distinct after reopen');
 
   const refs = await e2.opRefs.children(root);
-  assertEqual(refs.length, 2, 'opRefs.children length after reopen (payload)');
+  assertEqual(refs.length, 3, 'opRefs.children length after reopen (payload)');
   const ops = await e2.ops.get(refs);
   const kinds = new Set(ops.map((op) => op.kind.type));
   assert(kinds.has('insert'), 'expected insert op after reopen');
   assert(kinds.has('payload'), 'expected payload op after reopen');
+  const payloadOp = ops.find((op) => op.kind.type === 'payload');
+  assert(payloadOp?.kind.type === 'payload', 'expected payload operation after reopen');
+  assertBytesEqual(payloadOp.kind.payload, empty, 'op log preserves empty payload after reopen');
 }
 
 function makeCapabilityTokenV1(opts: {

--- a/packages/treecrdt-engine-conformance/src/index.ts
+++ b/packages/treecrdt-engine-conformance/src/index.ts
@@ -1,6 +1,11 @@
 import type { MaterializationEvent, TreecrdtEngine } from '@treecrdt/interface/engine';
 import type { Operation, ReplicaId } from '@treecrdt/interface';
-import { bytesToHex, nodeIdToBytes16, replicaIdToBytes } from '@treecrdt/interface/ids';
+import {
+  bytesToHex,
+  nodeIdToBytes16,
+  replicaIdToBytes,
+  TRASH_NODE_ID_HEX,
+} from '@treecrdt/interface/ids';
 import type { SqliteRunner } from '@treecrdt/interface/sqlite';
 
 import type { Filter, OpRef, SyncBackend } from '@treecrdt/sync-protocol';
@@ -167,6 +172,10 @@ export function treecrdtEngineConformanceScenarios(): TreecrdtEngineConformanceS
     {
       name: 'payload: empty bytes survive local writes and canonical replay',
       run: scenarioEmptyPayloadCanonicalReplay,
+    },
+    {
+      name: 'operation bytes: empty order key survives append and read',
+      run: scenarioEmptyOrderKeyRoundTrip,
     },
     {
       name: 'materialized tree: dump/children/meta + oprefs_children',
@@ -962,6 +971,26 @@ async function scenarioEmptyPayloadCanonicalReplay(
   assert(replayed?.kind.type === 'insert', 'replayed empty insert op');
   assertBytesEqual(replayed.kind.payload ?? null, empty, 'op log preserves empty insert payload');
 
+  await engine.ops.append(
+    makePayloadOp({
+      replica,
+      counter: 3,
+      lamport: 3,
+      node: lateNode,
+      payload: empty,
+    }),
+  );
+  assertBytesEqual(
+    await engine.tree.getPayload(lateNode),
+    empty,
+    'remote empty payload op stores empty bytes',
+  );
+  const remotePayload = (await engine.ops.all()).find(
+    (op) => op.meta.id.counter === 3 && op.kind.type === 'payload',
+  );
+  assert(remotePayload?.kind.type === 'payload', 'remote empty payload op');
+  assertBytesEqual(remotePayload.kind.payload, empty, 'op log preserves remote empty payload op');
+
   const localInsert = await engine.local.insert(replica, root, localNode, { type: 'last' }, empty);
   assert(localInsert.kind.type === 'insert', 'local empty insert op');
   assertBytesEqual(localInsert.kind.payload ?? null, empty, 'local insert returns empty payload');
@@ -985,6 +1014,51 @@ async function scenarioEmptyPayloadCanonicalReplay(
     empty,
     'local payload stores empty bytes',
   );
+}
+
+async function scenarioEmptyOrderKeyRoundTrip(
+  ctx: TreecrdtEngineConformanceContext,
+): Promise<void> {
+  const engine = ctx.engine;
+  const replica = replicaFromLabel('r1');
+  const root = nodeIdFromInt(0);
+  const node = nodeIdFromInt(24);
+  const empty = new Uint8Array();
+
+  await engine.ops.append(
+    makeInsertOp({
+      replica,
+      counter: 1,
+      lamport: 1,
+      parent: root,
+      node,
+      orderKey: empty,
+    }),
+  );
+  assertArrayEqual(await engine.tree.children(root), [node], 'empty insert order key materializes');
+  const inserted = (await engine.ops.all()).find(
+    (op) => op.meta.id.counter === 1 && op.kind.type === 'insert',
+  );
+  assert(inserted?.kind.type === 'insert', 'empty insert order key op');
+  assertBytesEqual(inserted.kind.orderKey, empty, 'op log preserves empty insert order key');
+
+  await engine.ops.append(
+    makeMoveOp({
+      replica,
+      counter: 2,
+      lamport: 2,
+      node,
+      newParent: TRASH_NODE_ID_HEX,
+      orderKey: empty,
+    }),
+  );
+
+  assertArrayEqual(await engine.tree.children(root), [], 'empty order key move materializes');
+  const replayed = (await engine.ops.all()).find(
+    (op) => op.meta.id.counter === 2 && op.kind.type === 'move',
+  );
+  assert(replayed?.kind.type === 'move', 'empty order key move op');
+  assertBytesEqual(replayed.kind.orderKey, empty, 'op log preserves empty order key');
 }
 
 async function scenarioMaterializedSmokeWithOpRefs(

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
@@ -43,10 +43,10 @@ pub(super) unsafe extern "C" fn treecrdt_append_op(
 
     let replica_ptr = unsafe { sqlite_value_blob(args[0]) } as *const u8;
     let replica_len = unsafe { sqlite_value_bytes(args[0]) } as usize;
-    if replica_ptr.is_null() {
+    if replica_ptr.is_null() || replica_len == 0 {
         sqlite_result_error(
             ctx,
-            b"treecrdt_append_op: NULL replica\0".as_ptr() as *const c_char,
+            b"treecrdt_append_op: replica must be a non-empty BLOB\0".as_ptr() as *const c_char,
         );
         return;
     }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/append.rs
@@ -1,5 +1,5 @@
 use super::materialize::json_outcome_from_core;
-use super::util::sqlite_result_json;
+use super::util::{read_blob, sqlite_result_json};
 use super::*;
 
 /// Append an operation row to the `ops` table. Args:
@@ -71,23 +71,8 @@ pub(super) unsafe extern "C" fn treecrdt_append_op(
     };
     let kind = kind.to_string();
 
-    let read_opt_blob = |val: *mut sqlite3_value| -> Option<Vec<u8>> {
-        unsafe {
-            if sqlite_value_type(val) == SQLITE_NULL as c_int {
-                return None;
-            }
-            let ptr = sqlite_value_blob(val) as *const u8;
-            let len = sqlite_value_bytes(val) as usize;
-            if ptr.is_null() {
-                None
-            } else {
-                Some(slice::from_raw_parts(ptr, len).to_vec())
-            }
-        }
-    };
-
-    let parent = read_opt_blob(args[4]);
-    let node = match read_opt_blob(args[5]) {
+    let parent = read_blob(args[4]);
+    let node = match read_blob(args[5]) {
         Some(v) => v,
         None => {
             sqlite_result_error(
@@ -97,9 +82,9 @@ pub(super) unsafe extern "C" fn treecrdt_append_op(
             return;
         }
     };
-    let new_parent = read_opt_blob(args[6]);
-    let order_key = read_opt_blob(args[7]);
-    let known_state_or_payload = read_opt_blob(args[8]);
+    let new_parent = read_blob(args[6]);
+    let order_key = read_blob(args[7]);
+    let known_state_or_payload = read_blob(args[8]);
 
     let (known_state, payload) = match kind.as_str() {
         // Deletes must carry known_state (writer-side subtree version vector).

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/local_ops.rs
@@ -332,7 +332,8 @@ pub(super) unsafe extern "C" fn treecrdt_local_insert(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_insert: NULL replica\0".as_ptr() as *const c_char,
+                b"treecrdt_local_insert: replica must be a non-empty BLOB\0".as_ptr()
+                    as *const c_char,
             );
             return;
         }
@@ -436,7 +437,8 @@ pub(super) unsafe extern "C" fn treecrdt_local_move(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_move: NULL replica\0".as_ptr() as *const c_char,
+                b"treecrdt_local_move: replica must be a non-empty BLOB\0".as_ptr()
+                    as *const c_char,
             );
             return;
         }
@@ -537,7 +539,8 @@ pub(super) unsafe extern "C" fn treecrdt_local_delete(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_delete: NULL replica\0".as_ptr() as *const c_char,
+                b"treecrdt_local_delete: replica must be a non-empty BLOB\0".as_ptr()
+                    as *const c_char,
             );
             return;
         }
@@ -608,7 +611,8 @@ pub(super) unsafe extern "C" fn treecrdt_local_payload(
         Err(_) => {
             sqlite_result_error(
                 ctx,
-                b"treecrdt_local_payload: NULL replica\0".as_ptr() as *const c_char,
+                b"treecrdt_local_payload: replica must be a non-empty BLOB\0".as_ptr()
+                    as *const c_char,
             );
             return;
         }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
@@ -228,7 +228,9 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 } else {
                     let ptr = sqlite_column_blob(stmt, 1) as *const u8;
                     let len = sqlite_column_bytes(stmt, 1) as usize;
-                    if ptr.is_null() {
+                    if len == 0 {
+                        Some(Vec::new())
+                    } else if ptr.is_null() {
                         None
                     } else {
                         Some(slice::from_raw_parts(ptr, len).to_vec())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
@@ -77,7 +77,9 @@ fn read_operation_row(stmt: *mut sqlite3_stmt) -> treecrdt_core::Result<treecrdt
     } else {
         let ptr = unsafe { sqlite_column_blob(stmt, 9) } as *const u8;
         let len = unsafe { sqlite_column_bytes(stmt, 9) } as usize;
-        if ptr.is_null() {
+        if len == 0 {
+            Some(Vec::new())
+        } else if ptr.is_null() {
             None
         } else {
             Some(unsafe { slice::from_raw_parts(ptr, len) }.to_vec())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/op_storage.rs
@@ -23,10 +23,10 @@ fn sqlite_node_id_bytes(node: NodeId) -> [u8; 16] {
 fn read_operation_row(stmt: *mut sqlite3_stmt) -> treecrdt_core::Result<treecrdt_core::Operation> {
     let replica_ptr = unsafe { sqlite_column_blob(stmt, 0) } as *const u8;
     let replica_len = unsafe { sqlite_column_bytes(stmt, 0) } as usize;
-    if replica_ptr.is_null() {
+    if replica_ptr.is_null() || replica_len == 0 {
         return Err(sqlite_rc_error(
             SQLITE_ERROR as c_int,
-            "replica missing from op row",
+            "replica missing or empty in op row",
         ));
     }
     let replica = unsafe { slice::from_raw_parts(replica_ptr, replica_len) }.to_vec();
@@ -137,6 +137,18 @@ fn read_operation_row(stmt: *mut sqlite3_stmt) -> treecrdt_core::Result<treecrdt
     })
 }
 
+fn read_operation_row_or_finalize(
+    stmt: *mut sqlite3_stmt,
+) -> treecrdt_core::Result<treecrdt_core::Operation> {
+    match read_operation_row(stmt) {
+        Ok(op) => Ok(op),
+        Err(err) => {
+            unsafe { sqlite_finalize(stmt) };
+            Err(err)
+        }
+    }
+}
+
 pub(super) struct SqliteOpStorage {
     db: *mut sqlite3,
     doc_id: Option<Vec<u8>>,
@@ -163,6 +175,11 @@ impl SqliteOpStorage {
 
 impl treecrdt_core::Storage for SqliteOpStorage {
     fn apply(&mut self, op: treecrdt_core::Operation) -> treecrdt_core::Result<bool> {
+        if op.meta.id.replica.as_bytes().is_empty() {
+            return Err(treecrdt_core::Error::Storage(
+                "replica id must not be empty".into(),
+            ));
+        }
         let doc_id = self.ensure_doc_id()?;
 
         let (kind, parent, node, new_parent, order_key, known_state, payload) = match op.kind {
@@ -373,7 +390,7 @@ impl treecrdt_core::Storage for SqliteOpStorage {
         loop {
             let step_rc = unsafe { sqlite_step(stmt) };
             if step_rc == SQLITE_ROW as c_int {
-                out.push(read_operation_row(stmt)?);
+                out.push(read_operation_row_or_finalize(stmt)?);
             } else if step_rc == SQLITE_DONE as c_int {
                 break;
             } else {
@@ -415,7 +432,7 @@ impl treecrdt_core::Storage for SqliteOpStorage {
         loop {
             let step_rc = unsafe { sqlite_step(stmt) };
             if step_rc == SQLITE_ROW as c_int {
-                if let Err(err) = visit(read_operation_row(stmt)?) {
+                if let Err(err) = visit(read_operation_row_or_finalize(stmt)?) {
                     unsafe { sqlite_finalize(stmt) };
                     return Err(err);
                 }
@@ -533,7 +550,7 @@ impl treecrdt_core::FrontierRewindStorage for SqliteOpStorage {
         loop {
             let step_rc = unsafe { sqlite_step(stmt) };
             if step_rc == SQLITE_ROW as c_int {
-                if let Err(err) = visit(read_operation_row(stmt)?) {
+                if let Err(err) = visit(read_operation_row_or_finalize(stmt)?) {
                     unsafe { sqlite_finalize(stmt) };
                     return Err(err);
                 }
@@ -606,7 +623,7 @@ impl treecrdt_core::FrontierRewindStorage for SqliteOpStorage {
 
         let step_rc = unsafe { sqlite_step(stmt) };
         let op = if step_rc == SQLITE_ROW as c_int {
-            Some(read_operation_row(stmt)?)
+            Some(read_operation_row_or_finalize(stmt)?)
         } else if step_rc == SQLITE_DONE as c_int {
             None
         } else {
@@ -675,7 +692,7 @@ impl treecrdt_core::FrontierRewindStorage for SqliteOpStorage {
 
         let step_rc = unsafe { sqlite_step(stmt) };
         let op = if step_rc == SQLITE_ROW as c_int {
-            Some(read_operation_row(stmt)?)
+            Some(read_operation_row_or_finalize(stmt)?)
         } else if step_rc == SQLITE_DONE as c_int {
             None
         } else {

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
@@ -226,6 +226,9 @@ fn read_row(stmt: *mut sqlite3_stmt) -> Result<JsonOp, c_int> {
         let kind_ptr = sqlite_column_text(stmt, 3);
         let kind_len = sqlite_column_bytes(stmt, 3);
 
+        if replica_ptr.is_null() || replica_len == 0 || kind_ptr.is_null() || kind_len == 0 {
+            return Err(SQLITE_ERROR as c_int);
+        }
         let replica =
             std::slice::from_raw_parts(replica_ptr as *const u8, replica_len as usize).to_vec();
         let kind = std::str::from_utf8(std::slice::from_raw_parts(
@@ -246,7 +249,9 @@ fn read_row(stmt: *mut sqlite3_stmt) -> Result<JsonOp, c_int> {
         } else {
             let ptr = sqlite_column_blob(stmt, 7) as *const u8;
             let len = sqlite_column_bytes(stmt, 7) as usize;
-            if ptr.is_null() {
+            if len == 0 {
+                Some(Vec::new())
+            } else if ptr.is_null() {
                 None
             } else {
                 Some(slice::from_raw_parts(ptr, len).to_vec())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/ops.rs
@@ -268,7 +268,9 @@ fn read_row(stmt: *mut sqlite3_stmt) -> Result<JsonOp, c_int> {
         } else {
             let ptr = sqlite_column_blob(stmt, 9) as *const u8;
             let len = sqlite_column_bytes(stmt, 9) as usize;
-            if ptr.is_null() {
+            if len == 0 {
+                Some(Vec::new())
+            } else if ptr.is_null() {
                 None
             } else {
                 Some(slice::from_raw_parts(ptr, len).to_vec())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/payload_store.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/payload_store.rs
@@ -68,7 +68,9 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
                 } else {
                     let ptr = sqlite_column_blob(stmt, 0) as *const u8;
                     let len = sqlite_column_bytes(stmt, 0) as usize;
-                    if ptr.is_null() {
+                    if len == 0 {
+                        Some(Vec::new())
+                    } else if ptr.is_null() {
                         None
                     } else {
                         Some(slice::from_raw_parts(ptr, len).to_vec())

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/util.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/util.rs
@@ -43,6 +43,9 @@ pub(super) fn read_blob(val: *mut sqlite3_value) -> Option<Vec<u8>> {
         }
         let ptr = sqlite_value_blob(val) as *const u8;
         let len = sqlite_value_bytes(val) as usize;
+        if len == 0 {
+            return Some(Vec::new());
+        }
         if ptr.is_null() {
             return None;
         }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/util.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/util.rs
@@ -55,8 +55,8 @@ pub(super) fn read_blob(val: *mut sqlite3_value) -> Option<Vec<u8>> {
 
 pub(super) fn read_required_blob(val: *mut sqlite3_value) -> Result<Vec<u8>, ()> {
     match read_blob(val) {
-        Some(v) => Ok(v),
-        None => Err(()),
+        Some(v) if !v.is_empty() => Ok(v),
+        _ => Err(()),
     }
 }
 

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::ptr::null_mut;
 
 use rusqlite::Connection;
@@ -510,93 +510,45 @@ fn append_and_fetch_ops_via_extension() {
 }
 
 #[test]
-fn empty_payload_survives_canonical_catch_up_and_reopen() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let db_path = temp_dir.path().join("empty-payload.sqlite");
-    let replica = b"empty-payload".to_vec();
+fn empty_values_remain_non_null_blobs() {
+    let conn = setup_conn();
+    let replica = b"empty-values".to_vec();
     let root = node_bytes(0);
-    let with_empty_payload = node_bytes(1);
-    let late_node = node_bytes(2);
-    let local_node = node_bytes(3);
+    let node = node_bytes(1);
 
-    {
-        let conn = setup_conn_at(&db_path);
-        let _: String = conn
-            .query_row(
-                "SELECT treecrdt_append_op(?1, 2, 2, 'insert', ?2, ?3, NULL, ?4, zeroblob(0))",
-                rusqlite::params![
-                    replica.clone(),
-                    root.clone(),
-                    with_empty_payload.clone(),
-                    (2u16).to_be_bytes().to_vec(),
-                ],
-                |row| row.get(0),
-            )
-            .unwrap();
-
-        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
-
-        // A lower canonical key invalidates the frontier and rebuilds from the persisted op log.
-        let _: String = conn
-            .query_row(
-                "SELECT treecrdt_append_op(?1, 1, 1, 'insert', ?2, ?3, NULL, ?4, NULL)",
-                rusqlite::params![
-                    replica.clone(),
-                    root,
-                    late_node,
-                    (1u16).to_be_bytes().to_vec(),
-                ],
-                |row| row.get(0),
-            )
-            .unwrap();
-
-        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
-        let storage_shape: (String, i64, i64) = conn
-            .query_row(
-                "SELECT typeof(payload), length(payload), payload IS NULL \
-                 FROM tree_payload WHERE node = ?1",
-                rusqlite::params![with_empty_payload.clone()],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )
-            .unwrap();
-        assert_eq!(storage_shape, ("blob".to_string(), 0, 0));
-
-        let local_json: String = conn
-            .query_row(
-                "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, zeroblob(0))",
-                rusqlite::params![replica.clone(), node_bytes(0), local_node.clone()],
-                |row| row.get(0),
-            )
-            .unwrap();
-        let local_ops: Vec<JsonOp> = decode_ops_or_local_result(&local_json);
-        assert_eq!(local_ops[0].payload, Some(Vec::new()));
-        assert_eq!(payload_bytes(&conn, &local_node), Some(Vec::new()));
-    }
-
-    {
-        let conn = setup_conn_at(&db_path);
-        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
-
-        let ops_json: String =
-            conn.query_row("SELECT treecrdt_ops_since(0)", [], |row| row.get(0)).unwrap();
-        let ops: Vec<JsonOp> = decode_ops_or_local_result(&ops_json);
-        let empty_insert = ops.iter().find(|op| op.counter == 2).unwrap();
-        assert_eq!(empty_insert.payload, Some(Vec::new()));
-
-        conn.execute(
-            "UPDATE tree_meta \
-             SET replay_lamport = 0, replay_replica = X'', replay_counter = 0 \
-             WHERE id = 1",
-            [],
+    let _: String = conn
+        .query_row(
+            "SELECT treecrdt_append_op(?1, 1, 1, 'insert', ?2, ?3, NULL, zeroblob(0), zeroblob(0))",
+            rusqlite::params![replica, root, node.clone()],
+            |row| row.get(0),
         )
         .unwrap();
-        let _: String = conn
-            .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
-                row.get(0)
-            })
-            .unwrap();
-        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
-    }
+
+    let op_shape: (String, i64, String, i64) = conn
+        .query_row(
+            "SELECT typeof(order_key), length(order_key), typeof(payload), length(payload) \
+             FROM ops",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(op_shape, ("blob".to_string(), 0, "blob".to_string(), 0));
+
+    let materialized_shape: (String, i64) = conn
+        .query_row(
+            "SELECT typeof(payload), length(payload) FROM tree_payload WHERE node = ?1",
+            rusqlite::params![node],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(materialized_shape, ("blob".to_string(), 0));
+
+    let ops_json: String =
+        conn.query_row("SELECT treecrdt_ops_since(0)", [], |row| row.get(0)).unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&ops_json);
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].order_key, Some(Vec::new()));
+    assert_eq!(ops[0].payload, Some(Vec::new()));
 }
 
 #[test]
@@ -649,25 +601,77 @@ fn local_insert_returns_appended_insert_op() {
 }
 
 #[test]
-fn local_empty_payload_is_preserved() {
+fn empty_replica_is_rejected_by_direct_local_and_batch_writes() {
     let conn = setup_conn();
-
-    let replica = b"r1".to_vec();
-    let parent = node_bytes(0);
+    let root = node_bytes(0);
     let node = node_bytes(1);
 
-    let json: String = conn
-        .query_row(
-            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'first', NULL, zeroblob(0))",
-            rusqlite::params![replica, parent, node.clone()],
-            |row| row.get(0),
-        )
-        .unwrap();
+    let result = conn.query_row(
+        "SELECT treecrdt_append_op(zeroblob(0), 1, 1, 'insert', ?1, ?2, NULL, zeroblob(0), NULL)",
+        rusqlite::params![root.clone(), node.clone()],
+        |row| row.get::<_, String>(0),
+    );
+    assert!(result.is_err());
 
-    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
-    assert_eq!(ops.len(), 1);
-    assert_eq!(ops[0].payload, Some(Vec::new()));
-    assert_eq!(payload_bytes(&conn, &node), Some(Vec::new()));
+    let result = conn.query_row(
+        "SELECT treecrdt_local_insert(zeroblob(0), ?1, ?2, 'first', NULL, NULL)",
+        rusqlite::params![root.clone(), node.clone()],
+        |row| row.get::<_, String>(0),
+    );
+    assert!(result.is_err());
+
+    let batch = serde_json::to_string(&vec![JsonOp {
+        replica: Vec::new(),
+        counter: 1,
+        lamport: 1,
+        kind: "insert".to_string(),
+        parent: Some(<[u8; 16]>::try_from(root.as_slice()).unwrap()),
+        node: <[u8; 16]>::try_from(node.as_slice()).unwrap(),
+        new_parent: None,
+        order_key: Some(vec![0, 1]),
+        known_state: None,
+        payload: None,
+    }])
+    .unwrap();
+    let result = conn.query_row(
+        "SELECT treecrdt_append_ops(?1)",
+        rusqlite::params![batch],
+        |row| row.get::<_, String>(0),
+    );
+    assert!(result.is_err());
+
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM ops", [], |row| row.get(0)).unwrap();
+    assert_eq!(count, 0);
+}
+
+#[test]
+fn malformed_empty_replica_row_returns_an_error() {
+    let conn = setup_conn();
+    conn.execute(
+        "INSERT INTO ops(replica,counter,lamport,kind,parent,node,order_key,op_ref) \
+         VALUES(zeroblob(0),1,1,'insert',?1,?2,zeroblob(0),zeroblob(16))",
+        rusqlite::params![node_bytes(0), node_bytes(1)],
+    )
+    .unwrap();
+
+    let result = conn.query_row("SELECT treecrdt_ops_since(0)", [], |row| {
+        row.get::<_, String>(0)
+    });
+    assert!(result.is_err());
+
+    conn.execute(
+        "UPDATE tree_meta \
+         SET replay_lamport = 0, replay_replica = X'', replay_counter = 0 \
+         WHERE id = 1",
+        [],
+    )
+    .unwrap();
+    let result = conn.query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
+        row.get::<_, String>(0)
+    });
+    assert!(result.is_err());
+
+    conn.execute_batch("DROP TABLE ops").unwrap();
 }
 
 #[test]
@@ -1365,15 +1369,8 @@ fn local_payload_does_not_prepare_an_unused_delete_statement() {
 }
 
 fn setup_conn() -> Connection {
-    initialize_conn(Connection::open_in_memory().unwrap())
-}
-
-fn setup_conn_at(path: &Path) -> Connection {
-    initialize_conn(Connection::open(path).unwrap())
-}
-
-fn initialize_conn(conn: Connection) -> Connection {
     let ext_path = find_extension().expect("extension dylib path");
+    let conn = Connection::open_in_memory().unwrap();
     unsafe {
         conn.load_extension_enable().unwrap();
         conn.load_extension(ext_path, Some("sqlite3_treecrdt_init")).unwrap();

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -2,7 +2,7 @@
 use std::env;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::ptr::null_mut;
 
 use rusqlite::Connection;
@@ -510,6 +510,96 @@ fn append_and_fetch_ops_via_extension() {
 }
 
 #[test]
+fn empty_payload_survives_canonical_catch_up_and_reopen() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let db_path = temp_dir.path().join("empty-payload.sqlite");
+    let replica = b"empty-payload".to_vec();
+    let root = node_bytes(0);
+    let with_empty_payload = node_bytes(1);
+    let late_node = node_bytes(2);
+    let local_node = node_bytes(3);
+
+    {
+        let conn = setup_conn_at(&db_path);
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_append_op(?1, 2, 2, 'insert', ?2, ?3, NULL, ?4, zeroblob(0))",
+                rusqlite::params![
+                    replica.clone(),
+                    root.clone(),
+                    with_empty_payload.clone(),
+                    (2u16).to_be_bytes().to_vec(),
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
+
+        // A lower canonical key invalidates the frontier and rebuilds from the persisted op log.
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_append_op(?1, 1, 1, 'insert', ?2, ?3, NULL, ?4, NULL)",
+                rusqlite::params![
+                    replica.clone(),
+                    root,
+                    late_node,
+                    (1u16).to_be_bytes().to_vec(),
+                ],
+                |row| row.get(0),
+            )
+            .unwrap();
+
+        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
+        let storage_shape: (String, i64, i64) = conn
+            .query_row(
+                "SELECT typeof(payload), length(payload), payload IS NULL \
+                 FROM tree_payload WHERE node = ?1",
+                rusqlite::params![with_empty_payload.clone()],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(storage_shape, ("blob".to_string(), 0, 0));
+
+        let local_json: String = conn
+            .query_row(
+                "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, zeroblob(0))",
+                rusqlite::params![replica.clone(), node_bytes(0), local_node.clone()],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let local_ops: Vec<JsonOp> = decode_ops_or_local_result(&local_json);
+        assert_eq!(local_ops[0].payload, Some(Vec::new()));
+        assert_eq!(payload_bytes(&conn, &local_node), Some(Vec::new()));
+    }
+
+    {
+        let conn = setup_conn_at(&db_path);
+        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
+
+        let ops_json: String =
+            conn.query_row("SELECT treecrdt_ops_since(0)", [], |row| row.get(0)).unwrap();
+        let ops: Vec<JsonOp> = decode_ops_or_local_result(&ops_json);
+        let empty_insert = ops.iter().find(|op| op.counter == 2).unwrap();
+        assert_eq!(empty_insert.payload, Some(Vec::new()));
+
+        conn.execute(
+            "UPDATE tree_meta \
+             SET replay_lamport = 0, replay_replica = X'', replay_counter = 0 \
+             WHERE id = 1",
+            [],
+        )
+        .unwrap();
+        let _: String = conn
+            .query_row("SELECT treecrdt_ensure_materialized()", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(payload_bytes(&conn, &with_empty_payload), Some(Vec::new()));
+    }
+}
+
+#[test]
 fn local_insert_returns_appended_insert_op() {
     let conn = setup_conn();
 
@@ -556,6 +646,28 @@ fn local_insert_returns_appended_insert_op() {
     assert_eq!(head_replica, b"r1".to_vec());
     assert_eq!(head_counter, 1);
     assert_eq!(head_seq, 1);
+}
+
+#[test]
+fn local_empty_payload_is_preserved() {
+    let conn = setup_conn();
+
+    let replica = b"r1".to_vec();
+    let parent = node_bytes(0);
+    let node = node_bytes(1);
+
+    let json: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'first', NULL, zeroblob(0))",
+            rusqlite::params![replica, parent, node.clone()],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&json);
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].payload, Some(Vec::new()));
+    assert_eq!(payload_bytes(&conn, &node), Some(Vec::new()));
 }
 
 #[test]
@@ -1253,8 +1365,15 @@ fn local_payload_does_not_prepare_an_unused_delete_statement() {
 }
 
 fn setup_conn() -> Connection {
+    initialize_conn(Connection::open_in_memory().unwrap())
+}
+
+fn setup_conn_at(path: &Path) -> Connection {
+    initialize_conn(Connection::open(path).unwrap())
+}
+
+fn initialize_conn(conn: Connection) -> Connection {
     let ext_path = find_extension().expect("extension dylib path");
-    let conn = Connection::open_in_memory().unwrap();
     unsafe {
         conn.load_extension_enable().unwrap();
         conn.load_extension(ext_path, Some("sqlite3_treecrdt_init")).unwrap();

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -104,44 +104,57 @@ function buildAppendOp(
   )[];
 
   switch (kind.type) {
-    case 'insert':
+    case 'insert': {
+      const emptyOrderKey = kind.orderKey.byteLength === 0;
       if (kind.payload !== undefined) {
         const emptyPayload = kind.payload.byteLength === 0;
         return {
-          sql: emptyPayload
-            ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,zeroblob(0))'
-            : 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,?8)',
+          sql:
+            emptyOrderKey && emptyPayload
+              ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,zeroblob(0),zeroblob(0))'
+              : emptyOrderKey
+                ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,zeroblob(0),?7)'
+                : emptyPayload
+                  ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,zeroblob(0))'
+                  : 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,?8)',
           params: [
             ...base,
             'insert',
             opts.serializeNodeId(kind.parent),
             opts.serializeNodeId(kind.node),
-            kind.orderKey,
+            ...(!emptyOrderKey ? [kind.orderKey] : []),
             ...(!emptyPayload ? [kind.payload] : []),
           ],
         };
       }
       return {
-        sql: 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,NULL)',
+        sql: emptyOrderKey
+          ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,zeroblob(0),NULL)'
+          : 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,NULL)',
         params: [
           ...base,
           'insert',
           opts.serializeNodeId(kind.parent),
           opts.serializeNodeId(kind.node),
-          kind.orderKey,
+          ...(!emptyOrderKey ? [kind.orderKey] : []),
         ],
       };
-    case 'move':
+    }
+    case 'move': {
+      const emptyOrderKey = kind.orderKey.byteLength === 0;
       return {
-        sql: 'SELECT treecrdt_append_op(?1,?2,?3,?4,NULL,?5,?6,?7,NULL)',
+        sql: emptyOrderKey
+          ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,NULL,?5,?6,zeroblob(0),NULL)'
+          : 'SELECT treecrdt_append_op(?1,?2,?3,?4,NULL,?5,?6,?7,NULL)',
         params: [
           ...base,
           'move',
           opts.serializeNodeId(kind.node),
           opts.serializeNodeId(kind.newParent),
-          kind.orderKey,
+          ...(!emptyOrderKey ? [kind.orderKey] : []),
         ],
       };
+    }
     case 'delete':
       if (!opts.knownState || opts.knownState.length === 0) {
         throw new Error('treecrdt: delete operations require meta.knownState');

--- a/packages/treecrdt-ts/src/sqlite.ts
+++ b/packages/treecrdt-ts/src/sqlite.ts
@@ -106,15 +106,18 @@ function buildAppendOp(
   switch (kind.type) {
     case 'insert':
       if (kind.payload !== undefined) {
+        const emptyPayload = kind.payload.byteLength === 0;
         return {
-          sql: 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,?8)',
+          sql: emptyPayload
+            ? 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,zeroblob(0))'
+            : 'SELECT treecrdt_append_op(?1,?2,?3,?4,?5,?6,NULL,?7,?8)',
           params: [
             ...base,
             'insert',
             opts.serializeNodeId(kind.parent),
             opts.serializeNodeId(kind.node),
             kind.orderKey,
-            kind.payload,
+            ...(!emptyPayload ? [kind.payload] : []),
           ],
         };
       }
@@ -153,6 +156,12 @@ function buildAppendOp(
         params: [...base, 'tombstone', opts.serializeNodeId(kind.node), opts.knownState],
       };
     case 'payload':
+      if (kind.payload?.byteLength === 0) {
+        return {
+          sql: 'SELECT treecrdt_append_op(?1,?2,?3,?4,NULL,?5,NULL,NULL,zeroblob(0))',
+          params: [...base, 'payload', opts.serializeNodeId(kind.node)],
+        };
+      }
       return {
         sql: 'SELECT treecrdt_append_op(?1,?2,?3,?4,NULL,?5,NULL,NULL,?6)',
         params: [...base, 'payload', opts.serializeNodeId(kind.node), kind.payload],
@@ -549,12 +558,12 @@ async function treecrdtTreePayload(
   emitOutcome?: (outcome: MaterializationOutcome) => void,
 ): Promise<Uint8Array | null> {
   await treecrdtEnsureMaterialized(runner, emitOutcome);
-  const hex = await runner.getText(
-    'SELECT hex(payload) FROM tree_payload WHERE node = ?1 LIMIT 1',
+  const encoded = await runner.getText(
+    "SELECT CASE WHEN payload IS NULL THEN 'n' ELSE 'x' || hex(payload) END FROM tree_payload WHERE node = ?1 LIMIT 1",
     [node],
   );
-  if (hex === null || hex === undefined || hex === '') return null;
-  return hexToBytes(hex);
+  if (encoded === null || encoded === undefined || encoded === 'n') return null;
+  return hexToBytes(encoded.slice(1));
 }
 
 /**
@@ -660,16 +669,18 @@ export function createTreecrdtSqliteWriter(
   ) => {
     const afterNode = placement.type === 'after' ? nodeIdToBytes16(placement.after) : null;
     const payload = o.payload ?? null;
+    const params = [
+      replicaBytes,
+      nodeIdToBytes16(parent),
+      nodeIdToBytes16(node),
+      placement.type,
+      afterNode,
+    ];
     return getLocalOp(
-      'SELECT treecrdt_local_insert(?1,?2,?3,?4,?5,?6)',
-      [
-        replicaBytes,
-        nodeIdToBytes16(parent),
-        nodeIdToBytes16(node),
-        placement.type,
-        afterNode,
-        payload,
-      ],
+      payload !== null && payload.byteLength === 0
+        ? 'SELECT treecrdt_local_insert(?1,?2,?3,?4,?5,zeroblob(0))'
+        : 'SELECT treecrdt_local_insert(?1,?2,?3,?4,?5,?6)',
+      payload !== null && payload.byteLength === 0 ? params : [...params, payload],
       o,
     );
   };
@@ -697,9 +708,12 @@ export function createTreecrdtSqliteWriter(
   };
 
   const payload = async (node: string, next: Uint8Array | null, writeOpts?: LocalWriteOptions) => {
+    const params = [replicaBytes, nodeIdToBytes16(node)];
     return getLocalOp(
-      'SELECT treecrdt_local_payload(?1,?2,?3)',
-      [replicaBytes, nodeIdToBytes16(node), next],
+      next !== null && next.byteLength === 0
+        ? 'SELECT treecrdt_local_payload(?1,?2,zeroblob(0))'
+        : 'SELECT treecrdt_local_payload(?1,?2,?3)',
+      next !== null && next.byteLength === 0 ? params : [...params, next],
       writeOpts,
     );
   };


### PR DESCRIPTION
## Before

SQLite could expose a zero-length BLOB with a null data pointer. The extension treated that as SQL NULL, so empty payloads and order keys could become absent after write, replay, or reopen.

## After

- Preserve empty payloads and order keys distinctly from null.
- Bind empty values explicitly through the TypeScript adapter.
- Reject invalid empty replica IDs without leaving SQLite statements open.
- Cover local writes, operation reads, canonical replay, and reopen.

## Scope

#231 extracted and merged the separate replay-metadata lifetime fix. This PR now targets `main` and contains the remaining empty-value handling.