### PR TITLE
fix(wa-sqlite): make direct and dedicated teardown terminal

### DIFF
--- a/.changeset/terminal-single-client-teardown.md
+++ b/.changeset/terminal-single-client-teardown.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Make direct and dedicated-worker client handles terminal when close or drop fails.

--- a/.changeset/terminal-single-client-teardown.md
+++ b/.changeset/terminal-single-client-teardown.md
@@ -2,4 +2,5 @@
 '@treecrdt/wa-sqlite': patch
 ---
 
-Make direct and dedicated-worker client handles terminal when close or drop fails.
+Make direct and dedicated-worker client handles terminal when close or drop fails, and terminate dedicated workers when
+initialization rejects.

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -385,6 +385,7 @@ async function createWorkerClient(opts: {
     materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
   }
   const cleanup = () => {
+    if (closed) return;
     closed = true;
     materialized.close();
     for (const { reject } of pending.values()) reject(closedError);
@@ -410,9 +411,8 @@ async function createWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('close', [] as RpcParams<'close'>);
-      cleanup();
     } finally {
-      // noop: cleanup already handles terminal teardown, and repeated close is idempotent
+      cleanup();
     }
   };
 
@@ -420,9 +420,8 @@ async function createWorkerClient(opts: {
     if (closed) return;
     try {
       if (!terminalError) await call('drop', [] as RpcParams<'drop'>);
-      cleanup();
     } finally {
-      // noop: cleanup already handles terminal teardown, and repeated drop is idempotent
+      cleanup();
     }
   };
 
@@ -759,16 +758,16 @@ export async function buildDirectClient(
     materialized,
     close: async () => {
       if (closed) return;
-      if (db.close) await db.close();
       closed = true;
+      if (db.close) await db.close();
     },
     drop: async () => {
       if (closed) return;
+      closed = true;
       if (db.close) await db.close();
       if (finalStorage === 'opfs') {
         await clearOpfsStorage(filename);
       }
-      closed = true;
     },
   });
 }

--- a/packages/treecrdt-wa-sqlite/src/client.ts
+++ b/packages/treecrdt-wa-sqlite/src/client.ts
@@ -367,23 +367,6 @@ async function createWorkerClient(opts: {
     for (const { reject } of pending.values()) reject(err);
     pending.clear();
   };
-  worker.addEventListener('message', onMessage);
-  worker.addEventListener('error', onError);
-
-  // init
-  const initResult = (await call('init', [
-    opts.baseUrl ?? '/',
-    opts.filename,
-    opts.storage,
-    opts.docId,
-  ])) as { storage?: StorageMode; filename?: string; opfsError?: string } | undefined;
-  const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
-  const effectiveFilename =
-    initResult?.filename ??
-    (effectiveStorage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:');
-  if (effectiveStorage === 'opfs') {
-    materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
-  }
   const cleanup = () => {
     if (closed) return;
     closed = true;
@@ -394,6 +377,24 @@ async function createWorkerClient(opts: {
     worker.removeEventListener('message', onMessage);
     worker.terminate();
   };
+  worker.addEventListener('message', onMessage);
+  worker.addEventListener('error', onError);
+
+  // init
+  let initResult: RpcResult<'init'>;
+  try {
+    initResult = await call('init', [opts.baseUrl ?? '/', opts.filename, opts.storage, opts.docId]);
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
+  const effectiveStorage: StorageMode = initResult?.storage === 'opfs' ? 'opfs' : 'memory';
+  const effectiveFilename =
+    initResult?.filename ??
+    (effectiveStorage === 'opfs' ? (opts.filename ?? '/treecrdt.db') : ':memory:');
+  if (effectiveStorage === 'opfs') {
+    materialized.enableCrossTab({ docId: opts.docId, filename: effectiveFilename });
+  }
 
   if (opts.requireOpfs && effectiveStorage !== 'opfs') {
     const reason = initResult?.opfsError ? `: ${initResult.opfsError}` : '';

--- a/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
@@ -19,6 +19,7 @@ vi.mock('../src/opfs.js', async (importOriginal) => {
 const mockedClearOpfsStorage = vi.mocked(clearOpfsStorage);
 
 type TeardownMethod = 'close' | 'drop';
+type RejectedWorkerMethod = 'init' | TeardownMethod;
 
 type TestRpcResponse =
   | { id: number; ok: true; result?: unknown }
@@ -75,19 +76,20 @@ class TestDedicatedWorkerEndpoint {
   }
 }
 
-function installDedicatedWorkerThatRejects(teardown: TeardownMethod): TestDedicatedWorkerEndpoint {
+function installDedicatedWorkerThatRejects(
+  method: RejectedWorkerMethod,
+): TestDedicatedWorkerEndpoint {
   const endpoint = new TestDedicatedWorkerEndpoint((request) => {
-    // Initialization succeeds so the client reaches the teardown path under test.
-    // Only the selected teardown RPC fails.
+    if (request.method === method) {
+      return { id: request.id, ok: false, error: `${method} failed` };
+    }
+    // Initialization succeeds for close/drop tests so the client reaches teardown.
     if (request.method === 'init') {
       return {
         id: request.id,
         ok: true,
         result: { storage: 'memory', filename: ':memory:' },
       };
-    }
-    if (request.method === teardown) {
-      return { id: request.id, ok: false, error: `${teardown} failed` };
     }
     return { id: request.id, ok: true, result: 1 };
   });
@@ -174,6 +176,22 @@ test('direct drop failure leaves the handle terminal without retrying teardown',
   expect(closeDatabase).toHaveBeenCalledTimes(1);
   expect(readNodeCount).not.toHaveBeenCalled();
   expect(mockedClearOpfsStorage).toHaveBeenCalledTimes(1);
+});
+
+test('dedicated-worker init failure terminates the endpoint and removes its listeners', async () => {
+  const endpoint = installDedicatedWorkerThatRejects('init');
+
+  await expect(
+    createTreecrdtClient({
+      docId: 'dedicated-init-failure',
+      runtime: { type: 'dedicated-worker' },
+      storage: { type: 'memory' },
+    }),
+  ).rejects.toThrow('init failed');
+
+  expect(endpoint.terminated).toBe(true);
+  expect(endpoint.listenerCount).toBe(0);
+  expect(endpoint.teardownMethods).toEqual([]);
 });
 
 test('dedicated-worker close failure terminates the endpoint without retrying', async () => {

--- a/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../src/client.js';
 import { clearOpfsStorage } from '../src/opfs.js';
 import type { RpcRequest } from '../src/rpc.js';
-import type { Database } from '../src/types.js';
+import type { Database, TreecrdtClient } from '../src/types.js';
 
 vi.mock('../src/opfs.js', async (importOriginal) => {
   const original = await importOriginal<typeof import('../src/opfs.js')>();
@@ -18,30 +18,43 @@ vi.mock('../src/opfs.js', async (importOriginal) => {
 
 const mockedClearOpfsStorage = vi.mocked(clearOpfsStorage);
 
-type RpcResponse =
+type TeardownMethod = 'close' | 'drop';
+
+type TestRpcResponse =
   | { id: number; ok: true; result?: unknown }
   | { id: number; ok: false; error: string };
 
-class FakeWorker {
-  readonly listeners = new Map<string, Set<(event: any) => void>>();
-  readonly requests: RpcRequest[] = [];
+type TestWorkerEvent = { data: TestRpcResponse } | ErrorEvent;
+type TestWorkerListener = (event: TestWorkerEvent) => void;
+
+/**
+ * Minimal Worker endpoint for testing the dedicated-worker client's RPC boundary.
+ *
+ * It does not run SQLite or any worker code. It only reproduces the behavior the
+ * client depends on: asynchronous responses, event listeners, and termination.
+ */
+class TestDedicatedWorkerEndpoint {
+  private readonly listeners = new Map<string, Set<TestWorkerListener>>();
+  private readonly requests: RpcRequest[] = [];
   terminated = false;
 
-  constructor(private readonly respond: (request: RpcRequest) => RpcResponse) {}
+  constructor(private readonly respond: (request: RpcRequest) => TestRpcResponse) {}
 
-  addEventListener(type: string, listener: (event: any) => void): void {
+  addEventListener(type: string, listener: TestWorkerListener): void {
     const listeners = this.listeners.get(type) ?? new Set();
     listeners.add(listener);
     this.listeners.set(type, listeners);
   }
 
-  removeEventListener(type: string, listener: (event: any) => void): void {
+  removeEventListener(type: string, listener: TestWorkerListener): void {
     this.listeners.get(type)?.delete(listener);
   }
 
   postMessage(request: RpcRequest): void {
     this.requests.push(request);
     const response = this.respond(request);
+    // A real Worker responds asynchronously. Keep that boundary so the test also
+    // exercises the client's pending-request and cleanup ordering.
     queueMicrotask(() => {
       for (const listener of this.listeners.get('message') ?? []) listener({ data: response });
     });
@@ -50,10 +63,22 @@ class FakeWorker {
   terminate(): void {
     this.terminated = true;
   }
+
+  get listenerCount(): number {
+    return [...this.listeners.values()].reduce((total, listeners) => total + listeners.size, 0);
+  }
+
+  get teardownMethods(): RpcRequest['method'][] {
+    return this.requests
+      .filter((request) => request.method === 'close' || request.method === 'drop')
+      .map((request) => request.method);
+  }
 }
 
-function installDedicatedWorker(teardown: 'close' | 'drop'): FakeWorker {
-  const worker = new FakeWorker((request) => {
+function installDedicatedWorkerThatRejects(teardown: TeardownMethod): TestDedicatedWorkerEndpoint {
+  const endpoint = new TestDedicatedWorkerEndpoint((request) => {
+    // Initialization succeeds so the client reaches the teardown path under test.
+    // Only the selected teardown RPC fails.
     if (request.method === 'init') {
       return {
         id: request.id,
@@ -67,93 +92,122 @@ function installDedicatedWorker(teardown: 'close' | 'drop'): FakeWorker {
     return { id: request.id, ok: true, result: 1 };
   });
 
+  // createTreecrdtClient constructs the Worker internally, so replace the global
+  // constructor with one that returns our observable endpoint.
   vi.stubGlobal(
     'Worker',
     class {
       constructor() {
-        return worker;
+        return endpoint;
       }
     },
   );
 
-  return worker;
+  return endpoint;
 }
 
-async function createDirectClient(teardown: 'close' | 'drop') {
-  const close = vi.fn(async () => {
-    if (teardown === 'close') throw new Error('close failed');
+async function createDirectClientHarness(opts: { storage: 'memory' | 'opfs'; closeError?: Error }) {
+  const closeDatabase = vi.fn(async () => {
+    if (opts.closeError) throw opts.closeError;
   });
-  const treeNodeCount = vi.fn(async () => 1);
-  const storage = teardown === 'drop' ? 'opfs' : 'memory';
-  const filename = storage === 'opfs' ? '/drop-failure.db' : ':memory:';
+  const readNodeCount = vi.fn(async () => 1);
+  const filename = opts.storage === 'opfs' ? '/teardown-failure.db' : ':memory:';
+
+  // Inject a minimal database so these tests isolate client lifecycle behavior
+  // from the SQLite implementation itself.
   const openDb: OpenDbFn = async () => ({
-    api: { treeNodeCount } as unknown as TreecrdtAdapter,
-    db: { close } as unknown as Database,
+    api: { treeNodeCount: readNodeCount } as unknown as TreecrdtAdapter,
+    db: { close: closeDatabase } as unknown as Database,
     filename,
-    storage,
+    storage: opts.storage,
   });
   const client = await buildDirectClient(
-    { docId: `direct-${teardown}-failure`, filename, storage },
+    { docId: `direct-${opts.storage}-teardown`, filename, storage: opts.storage },
     openDb,
   );
-  return { client, close, treeNodeCount };
+  return { client, closeDatabase, readNodeCount };
+}
+
+async function expectClientToBeTerminal(client: TreecrdtClient): Promise<void> {
+  await expect(client.tree.nodeCount()).rejects.toThrow(CLIENT_CLOSED_ERROR);
 }
 
 beforeEach(() => {
   mockedClearOpfsStorage.mockReset();
-  mockedClearOpfsStorage.mockRejectedValue(new Error('drop failed'));
+  mockedClearOpfsStorage.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-test.each(['close', 'drop'] as const)(
-  'direct %s failure leaves the handle terminal without retrying teardown',
-  async (teardown) => {
-    const { client, close, treeNodeCount } = await createDirectClient(teardown);
+test('direct close failure leaves the handle terminal without retrying teardown', async () => {
+  const { client, closeDatabase, readNodeCount } = await createDirectClientHarness({
+    storage: 'memory',
+    closeError: new Error('close failed'),
+  });
 
-    if (teardown === 'close') {
-      await expect(client.close()).resolves.toBeUndefined();
-      await expect(client.drop()).resolves.toBeUndefined();
-    } else {
-      await expect(client.drop()).rejects.toThrow('drop failed');
-      await expect(client.drop()).rejects.toThrow('drop failed');
-      await expect(client.close()).resolves.toBeUndefined();
-    }
+  // close is best-effort at the public API, even when the database close fails.
+  await expect(client.close()).resolves.toBeUndefined();
+  await expect(client.close()).resolves.toBeUndefined();
+  await expect(client.drop()).resolves.toBeUndefined();
 
-    await expect(client.tree.nodeCount()).rejects.toThrow(CLIENT_CLOSED_ERROR);
-    expect(close).toHaveBeenCalledTimes(1);
-    expect(treeNodeCount).not.toHaveBeenCalled();
-    expect(mockedClearOpfsStorage).toHaveBeenCalledTimes(teardown === 'drop' ? 1 : 0);
-  },
-);
+  await expectClientToBeTerminal(client);
+  expect(closeDatabase).toHaveBeenCalledTimes(1);
+  expect(readNodeCount).not.toHaveBeenCalled();
+  expect(mockedClearOpfsStorage).not.toHaveBeenCalled();
+});
 
-test.each(['close', 'drop'] as const)(
-  'dedicated-worker %s failure terminates the endpoint without retrying teardown',
-  async (teardown) => {
-    const worker = installDedicatedWorker(teardown);
-    const client = await createTreecrdtClient({
-      docId: `dedicated-${teardown}-failure`,
-      runtime: { type: 'dedicated-worker' },
-      storage: { type: 'memory' },
-    });
+test('direct drop failure leaves the handle terminal without retrying teardown', async () => {
+  mockedClearOpfsStorage.mockRejectedValueOnce(new Error('drop failed'));
+  const { client, closeDatabase, readNodeCount } = await createDirectClientHarness({
+    storage: 'opfs',
+  });
 
-    if (teardown === 'close') {
-      await expect(client.close()).resolves.toBeUndefined();
-      await expect(client.drop()).resolves.toBeUndefined();
-    } else {
-      await expect(client.drop()).rejects.toThrow('drop failed');
-      await expect(client.drop()).rejects.toThrow('drop failed');
-      await expect(client.close()).resolves.toBeUndefined();
-    }
+  // The database closes successfully, then OPFS deletion fails. Repeating drop
+  // returns the original rejection instead of touching the released handle again.
+  await expect(client.drop()).rejects.toThrow('drop failed');
+  await expect(client.drop()).rejects.toThrow('drop failed');
+  await expect(client.close()).resolves.toBeUndefined();
 
-    await expect(client.tree.nodeCount()).rejects.toThrow(CLIENT_CLOSED_ERROR);
-    expect(worker.terminated).toBe(true);
-    expect([...worker.listeners.values()].every((listeners) => listeners.size === 0)).toBe(true);
-    expect(worker.requests.filter((request) => request.method === teardown)).toHaveLength(1);
-    expect(
-      worker.requests.filter((request) => request.method === 'close' || request.method === 'drop'),
-    ).toHaveLength(1);
-  },
-);
+  await expectClientToBeTerminal(client);
+  expect(closeDatabase).toHaveBeenCalledTimes(1);
+  expect(readNodeCount).not.toHaveBeenCalled();
+  expect(mockedClearOpfsStorage).toHaveBeenCalledTimes(1);
+});
+
+test('dedicated-worker close failure terminates the endpoint without retrying', async () => {
+  const endpoint = installDedicatedWorkerThatRejects('close');
+  const client = await createTreecrdtClient({
+    docId: 'dedicated-close-failure',
+    runtime: { type: 'dedicated-worker' },
+    storage: { type: 'memory' },
+  });
+
+  await expect(client.close()).resolves.toBeUndefined();
+  await expect(client.close()).resolves.toBeUndefined();
+  await expect(client.drop()).resolves.toBeUndefined();
+
+  await expectClientToBeTerminal(client);
+  expect(endpoint.terminated).toBe(true);
+  expect(endpoint.listenerCount).toBe(0);
+  expect(endpoint.teardownMethods).toEqual(['close']);
+});
+
+test('dedicated-worker drop failure terminates the endpoint without retrying', async () => {
+  const endpoint = installDedicatedWorkerThatRejects('drop');
+  const client = await createTreecrdtClient({
+    docId: 'dedicated-drop-failure',
+    runtime: { type: 'dedicated-worker' },
+    storage: { type: 'memory' },
+  });
+
+  await expect(client.drop()).rejects.toThrow('drop failed');
+  await expect(client.drop()).rejects.toThrow('drop failed');
+  await expect(client.close()).resolves.toBeUndefined();
+
+  await expectClientToBeTerminal(client);
+  expect(endpoint.terminated).toBe(true);
+  expect(endpoint.listenerCount).toBe(0);
+  expect(endpoint.teardownMethods).toEqual(['drop']);
+});

--- a/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/single-client-teardown.test.ts
@@ -1,0 +1,159 @@
+import type { TreecrdtAdapter } from '@treecrdt/interface';
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import {
+  buildDirectClient,
+  CLIENT_CLOSED_ERROR,
+  createTreecrdtClient,
+  type OpenDbFn,
+} from '../src/client.js';
+import { clearOpfsStorage } from '../src/opfs.js';
+import type { RpcRequest } from '../src/rpc.js';
+import type { Database } from '../src/types.js';
+
+vi.mock('../src/opfs.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/opfs.js')>();
+  return { ...original, clearOpfsStorage: vi.fn() };
+});
+
+const mockedClearOpfsStorage = vi.mocked(clearOpfsStorage);
+
+type RpcResponse =
+  | { id: number; ok: true; result?: unknown }
+  | { id: number; ok: false; error: string };
+
+class FakeWorker {
+  readonly listeners = new Map<string, Set<(event: any) => void>>();
+  readonly requests: RpcRequest[] = [];
+  terminated = false;
+
+  constructor(private readonly respond: (request: RpcRequest) => RpcResponse) {}
+
+  addEventListener(type: string, listener: (event: any) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: any) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  postMessage(request: RpcRequest): void {
+    this.requests.push(request);
+    const response = this.respond(request);
+    queueMicrotask(() => {
+      for (const listener of this.listeners.get('message') ?? []) listener({ data: response });
+    });
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+}
+
+function installDedicatedWorker(teardown: 'close' | 'drop'): FakeWorker {
+  const worker = new FakeWorker((request) => {
+    if (request.method === 'init') {
+      return {
+        id: request.id,
+        ok: true,
+        result: { storage: 'memory', filename: ':memory:' },
+      };
+    }
+    if (request.method === teardown) {
+      return { id: request.id, ok: false, error: `${teardown} failed` };
+    }
+    return { id: request.id, ok: true, result: 1 };
+  });
+
+  vi.stubGlobal(
+    'Worker',
+    class {
+      constructor() {
+        return worker;
+      }
+    },
+  );
+
+  return worker;
+}
+
+async function createDirectClient(teardown: 'close' | 'drop') {
+  const close = vi.fn(async () => {
+    if (teardown === 'close') throw new Error('close failed');
+  });
+  const treeNodeCount = vi.fn(async () => 1);
+  const storage = teardown === 'drop' ? 'opfs' : 'memory';
+  const filename = storage === 'opfs' ? '/drop-failure.db' : ':memory:';
+  const openDb: OpenDbFn = async () => ({
+    api: { treeNodeCount } as unknown as TreecrdtAdapter,
+    db: { close } as unknown as Database,
+    filename,
+    storage,
+  });
+  const client = await buildDirectClient(
+    { docId: `direct-${teardown}-failure`, filename, storage },
+    openDb,
+  );
+  return { client, close, treeNodeCount };
+}
+
+beforeEach(() => {
+  mockedClearOpfsStorage.mockReset();
+  mockedClearOpfsStorage.mockRejectedValue(new Error('drop failed'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test.each(['close', 'drop'] as const)(
+  'direct %s failure leaves the handle terminal without retrying teardown',
+  async (teardown) => {
+    const { client, close, treeNodeCount } = await createDirectClient(teardown);
+
+    if (teardown === 'close') {
+      await expect(client.close()).resolves.toBeUndefined();
+      await expect(client.drop()).resolves.toBeUndefined();
+    } else {
+      await expect(client.drop()).rejects.toThrow('drop failed');
+      await expect(client.drop()).rejects.toThrow('drop failed');
+      await expect(client.close()).resolves.toBeUndefined();
+    }
+
+    await expect(client.tree.nodeCount()).rejects.toThrow(CLIENT_CLOSED_ERROR);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(treeNodeCount).not.toHaveBeenCalled();
+    expect(mockedClearOpfsStorage).toHaveBeenCalledTimes(teardown === 'drop' ? 1 : 0);
+  },
+);
+
+test.each(['close', 'drop'] as const)(
+  'dedicated-worker %s failure terminates the endpoint without retrying teardown',
+  async (teardown) => {
+    const worker = installDedicatedWorker(teardown);
+    const client = await createTreecrdtClient({
+      docId: `dedicated-${teardown}-failure`,
+      runtime: { type: 'dedicated-worker' },
+      storage: { type: 'memory' },
+    });
+
+    if (teardown === 'close') {
+      await expect(client.close()).resolves.toBeUndefined();
+      await expect(client.drop()).resolves.toBeUndefined();
+    } else {
+      await expect(client.drop()).rejects.toThrow('drop failed');
+      await expect(client.drop()).rejects.toThrow('drop failed');
+      await expect(client.close()).resolves.toBeUndefined();
+    }
+
+    await expect(client.tree.nodeCount()).rejects.toThrow(CLIENT_CLOSED_ERROR);
+    expect(worker.terminated).toBe(true);
+    expect([...worker.listeners.values()].every((listeners) => listeners.size === 0)).toBe(true);
+    expect(worker.requests.filter((request) => request.method === teardown)).toHaveLength(1);
+    expect(
+      worker.requests.filter((request) => request.method === 'close' || request.method === 'drop'),
+    ).toHaveLength(1);
+  },
+);


### PR DESCRIPTION
## Summary

- Mark direct clients closed before database cleanup can fail.
- Always terminate a dedicated worker and remove its listeners when the `init`, `close`, or `drop` RPC rejects.
- Preserve existing error behavior: `close()` is best-effort, `drop()` reports the first teardown error, and repeated teardown does not retry the backend.
- Add focused regressions for failed direct close/drop and dedicated-worker init/close/drop.

## Why

cybersemics/em#4325 uses persistent OPFS with `dedicated-worker`, plus `direct` for unit tests and some Puppeteer profiles. Its integration currently falls back from a rejected `drop()` to `close()` because wa-sqlite can leave the lower handle live after teardown fails.

em also treats initialization as retryable. If a dedicated worker rejects its `init` RPC, `createTreecrdtClient()` returns no client handle, so em cannot clean up the worker itself. Terminating that failed endpoint must therefore be guaranteed by wa-sqlite.

This extracts only the relevant single-client lifecycle slice from #208. It intentionally does **not** include #209 SharedWorker peer invalidation, protocol/server changes, cross-tab behavior, OPFS memory fallback, or a generic lifecycle-hook abstraction.

With this behavior, em can discard the terminal client after `drop()` settles, remove its `drop()` → `close()` fallback, and safely retry after a dedicated-worker initialization rejection. em still owns WebSocket shutdown, materialization unsubscribe, provider reset, and lifecycle serialization.

## Validation

- focused single-client teardown suite — 5/5
- wa-sqlite TypeScript build
- Prettier and `git diff --check`
- full CI build and test matrix