### PR TITLE
fix(wa-sqlite): clean up Vite WASM assets

### DIFF
--- a/packages/treecrdt-wa-sqlite/package.json
+++ b/packages/treecrdt-wa-sqlite/package.json
@@ -48,7 +48,8 @@
     "build:ts": "pnpm run prep:opfs:sources && tsc -p tsconfig.json",
     "build": "pnpm run build:ts && pnpm run prep:wa-sqlite-assets",
     "benchmark": "pnpm run build && tsx ./scripts/bench.ts",
-    "test": "pnpm --filter @treecrdt/wa-sqlite^... run build && pnpm run build && vitest run"
+    "test:native-import": "node ./tests/native-node-import.mjs",
+    "test": "pnpm --filter @treecrdt/wa-sqlite^... run build && pnpm run build && pnpm run test:native-import && vitest run"
   },
   "dependencies": {
     "@treecrdt/interface": "workspace:*"

--- a/packages/treecrdt-wa-sqlite/src/vite-plugin.ts
+++ b/packages/treecrdt-wa-sqlite/src/vite-plugin.ts
@@ -17,14 +17,9 @@ export type WaSqlitePluginOptions = {
   outDirs?: string[];
 };
 
-const defaultFiles = [
-  'wa-sqlite.mjs',
-  'wa-sqlite-async.mjs',
-  'sqlite-api.js',
-  'sqlite-constants.js',
-];
+const defaultFiles = ['wa-sqlite-async.mjs', 'sqlite-api.js', 'sqlite-constants.js'];
 
-const obsoletePublicFiles = ['wa-sqlite.wasm', 'wa-sqlite-async.wasm'];
+const stalePublicAssets = ['wa-sqlite.mjs', 'wa-sqlite.wasm', 'wa-sqlite-async.wasm'];
 
 /**
  * Copies wa-sqlite JS artifacts into the app's public folder.
@@ -47,7 +42,7 @@ export function treecrdt(opts: WaSqlitePluginOptions = {}): Plugin {
       await Promise.all(outDirs.map((dir) => fs.mkdir(dir, { recursive: true })));
       await Promise.all(
         outDirs.flatMap((dir) =>
-          obsoletePublicFiles.map((file) => fs.rm(path.join(dir, file), { force: true })),
+          stalePublicAssets.map((file) => fs.rm(path.join(dir, file), { force: true })),
         ),
       );
       for (const file of defaultFiles) {

--- a/packages/treecrdt-wa-sqlite/tests/native-node-import.mjs
+++ b/packages/treecrdt-wa-sqlite/tests/native-node-import.mjs
@@ -1,0 +1,1 @@
+import '@treecrdt/wa-sqlite';


### PR DESCRIPTION
## Summary

- Stop copying `wa-sqlite.mjs` after #233 removes its companion public WASM.
- Remove stale synchronous and unhashed WASM assets from public output.
- Run a package self-import through native Node before the Vitest suite.

## Why

Vitest loads local modules through Vite, so it can transform `?url` imports and miss a failure in the published Node entry. The direct Node import covers that package boundary while the existing conformance suite continues to cover client behavior.

Stacked on #233.