### PR TITLE
perf(sqlite): prepare local helper statements lazily

### DIFF
--- a/.changeset/lazy-sqlite-local-statements.md
+++ b/.changeset/lazy-sqlite-local-statements.md
@@ -1,0 +1,5 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Reduce local insert, move, delete, and payload overhead by preparing SQLite helper statements only when each operation needs them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Run Rust tests
         run: cargo test --workspace --all-targets
 
+      - name: Run SQLite extension roundtrip tests
+        run: cargo test -p treecrdt-sqlite-ext --test extension_roundtrip --features ext-sqlite
+
       - name: Detect Playwright version
         id: pw-version
         shell: bash

--- a/packages/treecrdt-sqlite-ext/src/extension/functions.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions.rs
@@ -17,6 +17,7 @@ mod ops;
 mod payload_store;
 mod schema;
 mod sqlite_api;
+mod statement;
 mod util;
 
 use append::{treecrdt_append_op, treecrdt_append_ops};

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/node_store.rs
@@ -1,3 +1,4 @@
+use super::statement::LazyStatement;
 use super::*;
 use std::slice;
 use treecrdt_core::NodeStore;
@@ -24,119 +25,65 @@ fn vv_from_bytes(bytes: &[u8]) -> treecrdt_core::Result<VersionVector> {
 
 pub(super) struct SqliteNodeStore {
     db: *mut sqlite3,
-    ensure_node: *mut sqlite3_stmt,
-    exists: *mut sqlite3_stmt,
-    select_node: *mut sqlite3_stmt,
-    select_tombstone: *mut sqlite3_stmt,
-    select_children: *mut sqlite3_stmt,
-    all_nodes: *mut sqlite3_stmt,
-    clear_parent_order_key: *mut sqlite3_stmt,
-    set_parent_order_key: *mut sqlite3_stmt,
-    update_tombstone: *mut sqlite3_stmt,
-    update_last_change: *mut sqlite3_stmt,
-    update_deleted_at: *mut sqlite3_stmt,
+    ensure_node: LazyStatement,
+    exists: LazyStatement,
+    select_node: LazyStatement,
+    select_tombstone: LazyStatement,
+    select_children: LazyStatement,
+    all_nodes: LazyStatement,
+    clear_parent_order_key: LazyStatement,
+    set_parent_order_key: LazyStatement,
+    update_tombstone: LazyStatement,
+    update_last_change: LazyStatement,
+    update_deleted_at: LazyStatement,
 }
 
 impl SqliteNodeStore {
     pub(super) fn prepare(db: *mut sqlite3) -> treecrdt_core::Result<Self> {
-        let ensure_node_sql = CString::new(
-            "INSERT OR IGNORE INTO tree_nodes(node,parent,order_key,tombstone) VALUES (?1,NULL,NULL,0)",
-        )
-        .expect("ensure node sql");
-        let exists_sql =
-            CString::new("SELECT 1 FROM tree_nodes WHERE node = ?1 LIMIT 1").expect("exists sql");
-        let select_node_sql = CString::new(
-            "SELECT parent,order_key,last_change,deleted_at FROM tree_nodes WHERE node = ?1 LIMIT 1",
-        )
-        .expect("select node sql");
-        let select_tombstone_sql =
-            CString::new("SELECT tombstone FROM tree_nodes WHERE node = ?1 LIMIT 1")
-                .expect("select tombstone sql");
-        let select_children_sql =
-            CString::new("SELECT node FROM tree_nodes WHERE parent = ?1 ORDER BY order_key, node")
-                .expect("select children sql");
-        let all_nodes_sql =
-            CString::new("SELECT node FROM tree_nodes").expect("select all nodes sql");
-        let clear_parent_order_key_sql =
-            CString::new("UPDATE tree_nodes SET parent = NULL, order_key = NULL WHERE node = ?1")
-                .expect("clear parent order_key sql");
-        let set_parent_order_key_sql =
-            CString::new("UPDATE tree_nodes SET parent = ?2, order_key = ?3 WHERE node = ?1")
-                .expect("set parent order_key sql");
-        let update_tombstone_sql =
-            CString::new("UPDATE tree_nodes SET tombstone = ?2 WHERE node = ?1")
-                .expect("update tombstone sql");
-        let update_last_change_sql =
-            CString::new("UPDATE tree_nodes SET last_change = ?2 WHERE node = ?1")
-                .expect("update last_change sql");
-        let update_deleted_at_sql =
-            CString::new("UPDATE tree_nodes SET deleted_at = ?2 WHERE node = ?1")
-                .expect("update deleted_at sql");
-
-        let mut ensure_node: *mut sqlite3_stmt = null_mut();
-        let mut exists: *mut sqlite3_stmt = null_mut();
-        let mut select_node: *mut sqlite3_stmt = null_mut();
-        let mut select_tombstone: *mut sqlite3_stmt = null_mut();
-        let mut select_children: *mut sqlite3_stmt = null_mut();
-        let mut all_nodes: *mut sqlite3_stmt = null_mut();
-        let mut clear_parent_order_key: *mut sqlite3_stmt = null_mut();
-        let mut set_parent_order_key: *mut sqlite3_stmt = null_mut();
-        let mut update_tombstone: *mut sqlite3_stmt = null_mut();
-        let mut update_last_change: *mut sqlite3_stmt = null_mut();
-        let mut update_deleted_at: *mut sqlite3_stmt = null_mut();
-
-        let prep = |sql: &CString, stmt: &mut *mut sqlite3_stmt| -> treecrdt_core::Result<()> {
-            let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, stmt, null_mut());
-            if rc != SQLITE_OK as c_int {
-                return Err(sqlite_rc_error(rc, "sqlite_prepare_v2 failed"));
-            }
-            Ok(())
-        };
-
-        prep(&ensure_node_sql, &mut ensure_node)?;
-        prep(&exists_sql, &mut exists)?;
-        prep(&select_node_sql, &mut select_node)?;
-        prep(&select_tombstone_sql, &mut select_tombstone)?;
-        prep(&select_children_sql, &mut select_children)?;
-        prep(&all_nodes_sql, &mut all_nodes)?;
-        prep(&clear_parent_order_key_sql, &mut clear_parent_order_key)?;
-        prep(&set_parent_order_key_sql, &mut set_parent_order_key)?;
-        prep(&update_tombstone_sql, &mut update_tombstone)?;
-        prep(&update_last_change_sql, &mut update_last_change)?;
-        prep(&update_deleted_at_sql, &mut update_deleted_at)?;
-
         Ok(Self {
             db,
-            ensure_node,
-            exists,
-            select_node,
-            select_tombstone,
-            select_children,
-            all_nodes,
-            clear_parent_order_key,
-            set_parent_order_key,
-            update_tombstone,
-            update_last_change,
-            update_deleted_at,
+            ensure_node: LazyStatement::new(
+                db,
+                c"INSERT OR IGNORE INTO tree_nodes(node,parent,order_key,tombstone) VALUES (?1,NULL,NULL,0)",
+            ),
+            exists: LazyStatement::new(
+                db,
+                c"SELECT 1 FROM tree_nodes WHERE node = ?1 LIMIT 1",
+            ),
+            select_node: LazyStatement::new(
+                db,
+                c"SELECT parent,order_key,last_change,deleted_at FROM tree_nodes WHERE node = ?1 LIMIT 1",
+            ),
+            select_tombstone: LazyStatement::new(
+                db,
+                c"SELECT tombstone FROM tree_nodes WHERE node = ?1 LIMIT 1",
+            ),
+            select_children: LazyStatement::new(
+                db,
+                c"SELECT node FROM tree_nodes WHERE parent = ?1 ORDER BY order_key, node",
+            ),
+            all_nodes: LazyStatement::new(db, c"SELECT node FROM tree_nodes"),
+            clear_parent_order_key: LazyStatement::new(
+                db,
+                c"UPDATE tree_nodes SET parent = NULL, order_key = NULL WHERE node = ?1",
+            ),
+            set_parent_order_key: LazyStatement::new(
+                db,
+                c"UPDATE tree_nodes SET parent = ?2, order_key = ?3 WHERE node = ?1",
+            ),
+            update_tombstone: LazyStatement::new(
+                db,
+                c"UPDATE tree_nodes SET tombstone = ?2 WHERE node = ?1",
+            ),
+            update_last_change: LazyStatement::new(
+                db,
+                c"UPDATE tree_nodes SET last_change = ?2 WHERE node = ?1",
+            ),
+            update_deleted_at: LazyStatement::new(
+                db,
+                c"UPDATE tree_nodes SET deleted_at = ?2 WHERE node = ?1",
+            ),
         })
-    }
-}
-
-impl Drop for SqliteNodeStore {
-    fn drop(&mut self) {
-        unsafe {
-            sqlite_finalize(self.ensure_node);
-            sqlite_finalize(self.exists);
-            sqlite_finalize(self.select_node);
-            sqlite_finalize(self.select_tombstone);
-            sqlite_finalize(self.select_children);
-            sqlite_finalize(self.all_nodes);
-            sqlite_finalize(self.clear_parent_order_key);
-            sqlite_finalize(self.set_parent_order_key);
-            sqlite_finalize(self.update_tombstone);
-            sqlite_finalize(self.update_last_change);
-            sqlite_finalize(self.update_deleted_at);
-        }
     }
 }
 
@@ -150,27 +97,22 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
         let root = sqlite_node_id_bytes(NodeId::ROOT);
         self.ensure_node(NodeId::ROOT)?;
+        let stmt = self.set_parent_order_key.get()?;
         unsafe {
-            sqlite_clear_bindings(self.set_parent_order_key);
-            sqlite_reset(self.set_parent_order_key);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.set_parent_order_key,
+                stmt,
                 1,
                 root.as_ptr() as *const c_void,
                 root.len() as c_int,
                 None,
             );
-            sqlite_bind_null(self.set_parent_order_key, 2);
+            sqlite_bind_null(stmt, 2);
             let empty: [u8; 0] = [];
-            sqlite_bind_blob(
-                self.set_parent_order_key,
-                3,
-                empty.as_ptr() as *const c_void,
-                0,
-                None,
-            );
-            let step_rc = sqlite_step(self.set_parent_order_key);
-            sqlite_reset(self.set_parent_order_key);
+            sqlite_bind_blob(stmt, 3, empty.as_ptr() as *const c_void, 0, None);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "reset root row failed"));
             }
@@ -180,11 +122,12 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn ensure_node(&mut self, node: NodeId) -> treecrdt_core::Result<()> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.ensure_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.ensure_node);
-            sqlite_reset(self.ensure_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.ensure_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
@@ -193,8 +136,8 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             if bind_rc != SQLITE_OK as c_int {
                 return Err(sqlite_rc_error(bind_rc, "bind ensure_node failed"));
             }
-            let step_rc = sqlite_step(self.ensure_node);
-            sqlite_reset(self.ensure_node);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "ensure_node step failed"));
             }
@@ -204,11 +147,12 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn exists(&self, node: NodeId) -> treecrdt_core::Result<bool> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.exists.get()?;
         unsafe {
-            sqlite_clear_bindings(self.exists);
-            sqlite_reset(self.exists);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.exists,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
@@ -217,8 +161,8 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             if bind_rc != SQLITE_OK as c_int {
                 return Err(sqlite_rc_error(bind_rc, "bind exists failed"));
             }
-            let step_rc = sqlite_step(self.exists);
-            sqlite_reset(self.exists);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             match step_rc {
                 rc if rc == SQLITE_ROW as c_int => Ok(true),
                 rc if rc == SQLITE_DONE as c_int => Ok(false),
@@ -229,11 +173,12 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn parent(&self, node: NodeId) -> treecrdt_core::Result<Option<NodeId>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
@@ -242,9 +187,9 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             if bind_rc != SQLITE_OK as c_int {
                 return Err(sqlite_rc_error(bind_rc, "bind select_node failed"));
             }
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             let parent = if step_rc == SQLITE_ROW as c_int {
-                match column_blob16(self.select_node, 0) {
+                match column_blob16(stmt, 0) {
                     Ok(Some(p)) => Some(sqlite_bytes_to_node_id(p)),
                     Ok(None) => None,
                     Err(rc) => return Err(sqlite_rc_error(rc, "read parent failed")),
@@ -254,18 +199,19 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
             } else {
                 return Err(sqlite_rc_error(step_rc, "select_node step failed"));
             };
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(parent)
         }
     }
 
     fn order_key(&self, node: NodeId) -> treecrdt_core::Result<Option<Vec<u8>>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
@@ -275,13 +221,13 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 return Err(sqlite_rc_error(bind_rc, "bind select_node failed"));
             }
 
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             let out = if step_rc == SQLITE_ROW as c_int {
-                if sqlite_column_type(self.select_node, 1) == SQLITE_NULL as c_int {
+                if sqlite_column_type(stmt, 1) == SQLITE_NULL as c_int {
                     None
                 } else {
-                    let ptr = sqlite_column_blob(self.select_node, 1) as *const u8;
-                    let len = sqlite_column_bytes(self.select_node, 1) as usize;
+                    let ptr = sqlite_column_blob(stmt, 1) as *const u8;
+                    let len = sqlite_column_bytes(stmt, 1) as usize;
                     if ptr.is_null() {
                         None
                     } else {
@@ -294,7 +240,7 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 return Err(sqlite_rc_error(step_rc, "select_node step failed"));
             };
 
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(out)
         }
     }
@@ -305,11 +251,12 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         }
         let parent_bytes = sqlite_node_id_bytes(parent);
         let mut out = Vec::new();
+        let stmt = self.select_children.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_children);
-            sqlite_reset(self.select_children);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_children,
+                stmt,
                 1,
                 parent_bytes.as_ptr() as *const c_void,
                 parent_bytes.len() as c_int,
@@ -319,9 +266,9 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 return Err(sqlite_rc_error(bind_rc, "bind select_children failed"));
             }
             loop {
-                let step_rc = sqlite_step(self.select_children);
+                let step_rc = sqlite_step(stmt);
                 if step_rc == SQLITE_ROW as c_int {
-                    match column_blob16(self.select_children, 0) {
+                    match column_blob16(stmt, 0) {
                         Ok(Some(id)) => out.push(sqlite_bytes_to_node_id(id)),
                         Ok(None) => {}
                         Err(rc) => return Err(sqlite_rc_error(rc, "read child id failed")),
@@ -332,7 +279,7 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                     return Err(sqlite_rc_error(step_rc, "select_children step failed"));
                 }
             }
-            sqlite_reset(self.select_children);
+            sqlite_reset(stmt);
         }
         Ok(out)
     }
@@ -343,12 +290,13 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         }
         self.ensure_node(node)?;
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.clear_parent_order_key.get()?;
 
         unsafe {
-            sqlite_clear_bindings(self.clear_parent_order_key);
-            sqlite_reset(self.clear_parent_order_key);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.clear_parent_order_key,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
@@ -360,8 +308,8 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                     "bind clear_parent_order_key failed",
                 ));
             }
-            let step_rc = sqlite_step(self.clear_parent_order_key);
-            sqlite_reset(self.clear_parent_order_key);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(
                     step_rc,
@@ -387,28 +335,29 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
         let node_bytes = sqlite_node_id_bytes(node);
         let parent_bytes = sqlite_node_id_bytes(parent);
+        let stmt = self.set_parent_order_key.get()?;
 
         if parent == NodeId::TRASH {
             unsafe {
-                sqlite_clear_bindings(self.set_parent_order_key);
-                sqlite_reset(self.set_parent_order_key);
+                sqlite_clear_bindings(stmt);
+                sqlite_reset(stmt);
                 sqlite_bind_blob(
-                    self.set_parent_order_key,
+                    stmt,
                     1,
                     node_bytes.as_ptr() as *const c_void,
                     node_bytes.len() as c_int,
                     None,
                 );
                 sqlite_bind_blob(
-                    self.set_parent_order_key,
+                    stmt,
                     2,
                     parent_bytes.as_ptr() as *const c_void,
                     parent_bytes.len() as c_int,
                     None,
                 );
-                sqlite_bind_null(self.set_parent_order_key, 3);
-                let step_rc = sqlite_step(self.set_parent_order_key);
-                sqlite_reset(self.set_parent_order_key);
+                sqlite_bind_null(stmt, 3);
+                let step_rc = sqlite_step(stmt);
+                sqlite_reset(stmt);
                 if step_rc != SQLITE_DONE as c_int {
                     return Err(sqlite_rc_error(step_rc, "attach to trash failed"));
                 }
@@ -417,10 +366,10 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         }
 
         unsafe {
-            sqlite_clear_bindings(self.set_parent_order_key);
-            sqlite_reset(self.set_parent_order_key);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_node = sqlite_bind_blob(
-                self.set_parent_order_key,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
@@ -433,7 +382,7 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 ));
             }
             let bind_parent = sqlite_bind_blob(
-                self.set_parent_order_key,
+                stmt,
                 2,
                 parent_bytes.as_ptr() as *const c_void,
                 parent_bytes.len() as c_int,
@@ -446,7 +395,7 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                 ));
             }
             let bind_pos = sqlite_bind_blob(
-                self.set_parent_order_key,
+                stmt,
                 3,
                 order_key.as_ptr() as *const c_void,
                 order_key.len() as c_int,
@@ -458,8 +407,8 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                     "bind set_parent_order_key order_key failed",
                 ));
             }
-            let step_rc = sqlite_step(self.set_parent_order_key);
-            sqlite_reset(self.set_parent_order_key);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "set_parent_order_key step failed"));
             }
@@ -470,31 +419,32 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn tombstone(&self, node: NodeId) -> treecrdt_core::Result<bool> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_tombstone.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_tombstone);
-            sqlite_reset(self.select_tombstone);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_tombstone,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.select_tombstone);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(bind_rc, "bind select_tombstone failed"));
             }
 
-            let step_rc = sqlite_step(self.select_tombstone);
+            let step_rc = sqlite_step(stmt);
             let out = if step_rc == SQLITE_ROW as c_int {
-                sqlite_column_int64(self.select_tombstone, 0) != 0
+                sqlite_column_int64(stmt, 0) != 0
             } else if step_rc == SQLITE_DONE as c_int {
                 false
             } else {
-                sqlite_reset(self.select_tombstone);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(step_rc, "select_tombstone step failed"));
             };
-            sqlite_reset(self.select_tombstone);
+            sqlite_reset(stmt);
             Ok(out)
         }
     }
@@ -502,28 +452,29 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
     fn set_tombstone(&mut self, node: NodeId, tombstone: bool) -> treecrdt_core::Result<()> {
         self.ensure_node(node)?;
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.update_tombstone.get()?;
         unsafe {
-            sqlite_clear_bindings(self.update_tombstone);
-            sqlite_reset(self.update_tombstone);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let mut bind_err = false;
             bind_err |= sqlite_bind_blob(
-                self.update_tombstone,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             ) != SQLITE_OK as c_int;
-            bind_err |= sqlite_bind_int64(self.update_tombstone, 2, if tombstone { 1 } else { 0 })
-                != SQLITE_OK as c_int;
+            bind_err |=
+                sqlite_bind_int64(stmt, 2, if tombstone { 1 } else { 0 }) != SQLITE_OK as c_int;
             if bind_err {
-                sqlite_reset(self.update_tombstone);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(
                     SQLITE_ERROR as c_int,
                     "bind update_tombstone failed",
                 ));
             }
-            let step_rc = sqlite_step(self.update_tombstone);
-            sqlite_reset(self.update_tombstone);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "update_tombstone step failed"));
             }
@@ -533,32 +484,33 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn has_deleted_at(&self, node: NodeId) -> treecrdt_core::Result<bool> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(bind_rc, "bind select_node failed"));
             }
 
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             let has = if step_rc == SQLITE_ROW as c_int {
-                sqlite_column_type(self.select_node, 3) != SQLITE_NULL as c_int
-                    && sqlite_column_bytes(self.select_node, 3) > 0
+                sqlite_column_type(stmt, 3) != SQLITE_NULL as c_int
+                    && sqlite_column_bytes(stmt, 3) > 0
             } else if step_rc == SQLITE_DONE as c_int {
                 false
             } else {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(step_rc, "select_node step failed"));
             };
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(has)
         }
     }
@@ -568,75 +520,76 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         node: NodeId,
     ) -> treecrdt_core::Result<Option<(Option<NodeId>, bool)>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(bind_rc, "bind select_node failed"));
             }
 
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             let out = if step_rc == SQLITE_ROW as c_int {
-                let parent = match column_blob16(self.select_node, 0) {
+                let parent = match column_blob16(stmt, 0) {
                     Ok(Some(p)) => Some(sqlite_bytes_to_node_id(p)),
                     Ok(None) => None,
                     Err(rc) => {
-                        sqlite_reset(self.select_node);
+                        sqlite_reset(stmt);
                         return Err(sqlite_rc_error(rc, "read parent failed"));
                     }
                 };
-                let has_deleted_at = sqlite_column_type(self.select_node, 3)
-                    != SQLITE_NULL as c_int
-                    && sqlite_column_bytes(self.select_node, 3) > 0;
+                let has_deleted_at = sqlite_column_type(stmt, 3) != SQLITE_NULL as c_int
+                    && sqlite_column_bytes(stmt, 3) > 0;
                 Some((parent, has_deleted_at))
             } else if step_rc == SQLITE_DONE as c_int {
                 None
             } else {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(step_rc, "select_node step failed"));
             };
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(out)
         }
     }
 
     fn last_change(&self, node: NodeId) -> treecrdt_core::Result<VersionVector> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             if step_rc != SQLITE_ROW as c_int {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(step_rc, "select_node last_change failed"));
             }
-            let vv = if sqlite_column_type(self.select_node, 2) == SQLITE_NULL as c_int {
+            let vv = if sqlite_column_type(stmt, 2) == SQLITE_NULL as c_int {
                 VersionVector::new()
             } else {
-                let ptr = sqlite_column_blob(self.select_node, 2) as *const u8;
-                let len = sqlite_column_bytes(self.select_node, 2) as usize;
+                let ptr = sqlite_column_blob(stmt, 2) as *const u8;
+                let len = sqlite_column_bytes(stmt, 2) as usize;
                 if ptr.is_null() || len == 0 {
                     VersionVector::new()
                 } else {
                     vv_from_bytes(slice::from_raw_parts(ptr, len))?
                 }
             };
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(vv)
         }
     }
@@ -652,25 +605,26 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         let bytes = vv_to_bytes(&vv)?;
 
         let node_bytes = sqlite_node_id_bytes(node);
+        let stmt = self.update_last_change.get()?;
         unsafe {
-            sqlite_clear_bindings(self.update_last_change);
-            sqlite_reset(self.update_last_change);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.update_last_change,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
                 None,
             );
             sqlite_bind_blob(
-                self.update_last_change,
+                stmt,
                 2,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
-            let step_rc = sqlite_step(self.update_last_change);
-            sqlite_reset(self.update_last_change);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "update_last_change failed"));
             }
@@ -681,33 +635,34 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn deleted_at(&self, node: NodeId) -> treecrdt_core::Result<Option<VersionVector>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select_node.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select_node);
-            sqlite_reset(self.select_node);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.select_node,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
-            let step_rc = sqlite_step(self.select_node);
+            let step_rc = sqlite_step(stmt);
             if step_rc != SQLITE_ROW as c_int {
-                sqlite_reset(self.select_node);
+                sqlite_reset(stmt);
                 return Ok(None);
             }
-            let vv = if sqlite_column_type(self.select_node, 3) == SQLITE_NULL as c_int {
+            let vv = if sqlite_column_type(stmt, 3) == SQLITE_NULL as c_int {
                 None
             } else {
-                let ptr = sqlite_column_blob(self.select_node, 3) as *const u8;
-                let len = sqlite_column_bytes(self.select_node, 3) as usize;
+                let ptr = sqlite_column_blob(stmt, 3) as *const u8;
+                let len = sqlite_column_bytes(stmt, 3) as usize;
                 if ptr.is_null() || len == 0 {
                     None
                 } else {
                     Some(vv_from_bytes(slice::from_raw_parts(ptr, len))?)
                 }
             };
-            sqlite_reset(self.select_node);
+            sqlite_reset(stmt);
             Ok(vv)
         }
     }
@@ -723,25 +678,26 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
         let bytes = vv_to_bytes(&vv)?;
 
         let node_bytes = sqlite_node_id_bytes(node);
+        let stmt = self.update_deleted_at.get()?;
         unsafe {
-            sqlite_clear_bindings(self.update_deleted_at);
-            sqlite_reset(self.update_deleted_at);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.update_deleted_at,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
                 None,
             );
             sqlite_bind_blob(
-                self.update_deleted_at,
+                stmt,
                 2,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
-            let step_rc = sqlite_step(self.update_deleted_at);
-            sqlite_reset(self.update_deleted_at);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "update_deleted_at failed"));
             }
@@ -752,13 +708,14 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
 
     fn all_nodes(&self) -> treecrdt_core::Result<Vec<NodeId>> {
         let mut out = Vec::new();
+        let stmt = self.all_nodes.get()?;
         unsafe {
-            sqlite_clear_bindings(self.all_nodes);
-            sqlite_reset(self.all_nodes);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             loop {
-                let step_rc = sqlite_step(self.all_nodes);
+                let step_rc = sqlite_step(stmt);
                 if step_rc == SQLITE_ROW as c_int {
-                    match column_blob16(self.all_nodes, 0) {
+                    match column_blob16(stmt, 0) {
                         Ok(Some(id)) => out.push(sqlite_bytes_to_node_id(id)),
                         Ok(None) => {}
                         Err(rc) => return Err(sqlite_rc_error(rc, "read node id failed")),
@@ -769,7 +726,7 @@ impl treecrdt_core::NodeStore for SqliteNodeStore {
                     return Err(sqlite_rc_error(step_rc, "all_nodes step failed"));
                 }
             }
-            sqlite_reset(self.all_nodes);
+            sqlite_reset(stmt);
         }
         Ok(out)
     }
@@ -784,11 +741,12 @@ impl treecrdt_core::ExactNodeStore for SqliteNodeStore {
         self.ensure_node(node)?;
         let node_bytes = sqlite_node_id_bytes(node);
         let vv_bytes = (!vv.is_empty()).then(|| vv_to_bytes(vv)).transpose()?;
+        let stmt = self.update_last_change.get()?;
         unsafe {
-            sqlite_clear_bindings(self.update_last_change);
-            sqlite_reset(self.update_last_change);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.update_last_change,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
@@ -796,20 +754,20 @@ impl treecrdt_core::ExactNodeStore for SqliteNodeStore {
             );
             if let Some(bytes) = vv_bytes.as_ref() {
                 sqlite_bind_blob(
-                    self.update_last_change,
+                    stmt,
                     2,
                     bytes.as_ptr() as *const c_void,
                     bytes.len() as c_int,
                     None,
                 );
             } else {
-                sqlite_bind_null(self.update_last_change, 2);
+                sqlite_bind_null(stmt, 2);
             }
-            let step_rc = sqlite_step(self.update_last_change);
-            let reset_rc = sqlite_reset(self.update_last_change);
+            let step_rc = sqlite_step(stmt);
+            let reset_rc = sqlite_reset(stmt);
             // sqlite_reset preserves SQLITE_STATIC bindings, so clear them before node_bytes and
             // vv_bytes are dropped.
-            let clear_rc = sqlite_clear_bindings(self.update_last_change);
+            let clear_rc = sqlite_clear_bindings(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "set exact last_change failed"));
             }
@@ -834,11 +792,12 @@ impl treecrdt_core::ExactNodeStore for SqliteNodeStore {
         self.ensure_node(node)?;
         let node_bytes = sqlite_node_id_bytes(node);
         let vv_bytes = vv.filter(|vv| !vv.is_empty()).map(vv_to_bytes).transpose()?;
+        let stmt = self.update_deleted_at.get()?;
         unsafe {
-            sqlite_clear_bindings(self.update_deleted_at);
-            sqlite_reset(self.update_deleted_at);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             sqlite_bind_blob(
-                self.update_deleted_at,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
@@ -846,20 +805,20 @@ impl treecrdt_core::ExactNodeStore for SqliteNodeStore {
             );
             if let Some(bytes) = vv_bytes.as_ref() {
                 sqlite_bind_blob(
-                    self.update_deleted_at,
+                    stmt,
                     2,
                     bytes.as_ptr() as *const c_void,
                     bytes.len() as c_int,
                     None,
                 );
             } else {
-                sqlite_bind_null(self.update_deleted_at, 2);
+                sqlite_bind_null(stmt, 2);
             }
-            let step_rc = sqlite_step(self.update_deleted_at);
-            let reset_rc = sqlite_reset(self.update_deleted_at);
+            let step_rc = sqlite_step(stmt);
+            let reset_rc = sqlite_reset(stmt);
             // sqlite_reset preserves SQLITE_STATIC bindings, so clear them before node_bytes and
             // vv_bytes are dropped.
-            let clear_rc = sqlite_clear_bindings(self.update_deleted_at);
+            let clear_rc = sqlite_clear_bindings(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "set exact deleted_at failed"));
             }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/op_index.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/op_index.rs
@@ -1,3 +1,4 @@
+use super::statement::LazyStatement;
 use super::*;
 
 fn sqlite_rc_error(rc: c_int, context: &str) -> treecrdt_core::Error {
@@ -7,30 +8,19 @@ fn sqlite_rc_error(rc: c_int, context: &str) -> treecrdt_core::Error {
 pub(super) struct SqliteParentOpIndex {
     db: *mut sqlite3,
     doc_id: Vec<u8>,
-    insert: *mut sqlite3_stmt,
+    insert: LazyStatement,
 }
 
 impl SqliteParentOpIndex {
     pub(super) fn prepare(db: *mut sqlite3, doc_id: Vec<u8>) -> treecrdt_core::Result<Self> {
-        let insert_sql = CString::new(
-            "INSERT OR IGNORE INTO oprefs_children(parent, op_ref, seq) VALUES (?1, ?2, ?3)",
-        )
-        .expect("oprefs_children insert sql");
-        let mut insert: *mut sqlite3_stmt = null_mut();
-        let rc = sqlite_prepare_v2(db, insert_sql.as_ptr(), -1, &mut insert, null_mut());
-        if rc != SQLITE_OK as c_int {
-            return Err(sqlite_rc_error(
-                rc,
-                "sqlite_prepare_v2 oprefs_children insert failed",
-            ));
-        }
-        Ok(Self { db, doc_id, insert })
-    }
-}
-
-impl Drop for SqliteParentOpIndex {
-    fn drop(&mut self) {
-        unsafe { sqlite_finalize(self.insert) };
+        Ok(Self {
+            db,
+            doc_id,
+            insert: LazyStatement::new(
+                db,
+                c"INSERT OR IGNORE INTO oprefs_children(parent, op_ref, seq) VALUES (?1, ?2, ?3)",
+            ),
+        })
     }
 }
 
@@ -59,40 +49,41 @@ impl treecrdt_core::ParentOpIndex for SqliteParentOpIndex {
 
         let parent_bytes = parent.0.to_be_bytes();
         let op_ref = derive_op_ref_v0(&self.doc_id, op_id.replica.as_bytes(), op_id.counter);
+        let stmt = self.insert.get()?;
 
         unsafe {
-            sqlite_clear_bindings(self.insert);
-            sqlite_reset(self.insert);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
         }
         let mut bind_err = false;
         unsafe {
             bind_err |= sqlite_bind_blob(
-                self.insert,
+                stmt,
                 1,
                 parent_bytes.as_ptr() as *const c_void,
                 parent_bytes.len() as c_int,
                 None,
             ) != SQLITE_OK as c_int;
             bind_err |= sqlite_bind_blob(
-                self.insert,
+                stmt,
                 2,
                 op_ref.as_ptr() as *const c_void,
                 op_ref.len() as c_int,
                 None,
             ) != SQLITE_OK as c_int;
-            bind_err |= sqlite_bind_int64(self.insert, 3, seq.min(i64::MAX as u64) as i64)
-                != SQLITE_OK as c_int;
+            bind_err |=
+                sqlite_bind_int64(stmt, 3, seq.min(i64::MAX as u64) as i64) != SQLITE_OK as c_int;
         }
         if bind_err {
-            unsafe { sqlite_reset(self.insert) };
+            unsafe { sqlite_reset(stmt) };
             return Err(sqlite_rc_error(
                 SQLITE_ERROR as c_int,
                 "bind oprefs_children insert failed",
             ));
         }
 
-        let step_rc = unsafe { sqlite_step(self.insert) };
-        unsafe { sqlite_reset(self.insert) };
+        let step_rc = unsafe { sqlite_step(stmt) };
+        unsafe { sqlite_reset(stmt) };
         if step_rc != SQLITE_DONE as c_int {
             return Err(sqlite_rc_error(
                 step_rc,

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/payload_store.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/payload_store.rs
@@ -1,3 +1,4 @@
+use super::statement::LazyStatement;
 use super::*;
 
 fn sqlite_node_id_bytes(node: NodeId) -> [u8; 16] {
@@ -10,62 +11,25 @@ fn sqlite_rc_error(rc: c_int, context: &str) -> treecrdt_core::Error {
 
 pub(super) struct SqlitePayloadStore {
     db: *mut sqlite3,
-    select: *mut sqlite3_stmt,
-    upsert: *mut sqlite3_stmt,
-    delete: *mut sqlite3_stmt,
+    select: LazyStatement,
+    upsert: LazyStatement,
+    delete: LazyStatement,
 }
 
 impl SqlitePayloadStore {
     pub(super) fn prepare(db: *mut sqlite3) -> treecrdt_core::Result<Self> {
-        let select_sql = CString::new(
-            "SELECT payload, last_lamport, last_replica, last_counter \
-             FROM tree_payload WHERE node = ?1 LIMIT 1",
-        )
-        .expect("select payload sql");
-        let upsert_sql = CString::new(
-            "INSERT INTO tree_payload(node,payload,last_lamport,last_replica,last_counter) \
-             VALUES (?1,?2,?3,?4,?5) \
-             ON CONFLICT(node) DO UPDATE SET \
-               payload = excluded.payload, \
-               last_lamport = excluded.last_lamport, \
-               last_replica = excluded.last_replica, \
-               last_counter = excluded.last_counter",
-        )
-        .expect("upsert payload sql");
-        let delete_sql =
-            CString::new("DELETE FROM tree_payload WHERE node = ?1").expect("delete payload sql");
-
-        let mut select: *mut sqlite3_stmt = null_mut();
-        let mut upsert: *mut sqlite3_stmt = null_mut();
-        let mut delete: *mut sqlite3_stmt = null_mut();
-
-        let prep = |sql: &CString, stmt: &mut *mut sqlite3_stmt| -> treecrdt_core::Result<()> {
-            let rc = sqlite_prepare_v2(db, sql.as_ptr(), -1, stmt, null_mut());
-            if rc != SQLITE_OK as c_int {
-                return Err(sqlite_rc_error(rc, "sqlite_prepare_v2 failed"));
-            }
-            Ok(())
-        };
-        prep(&select_sql, &mut select)?;
-        prep(&upsert_sql, &mut upsert)?;
-        prep(&delete_sql, &mut delete)?;
-
         Ok(Self {
             db,
-            select,
-            upsert,
-            delete,
+            select: LazyStatement::new(
+                db,
+                c"SELECT payload, last_lamport, last_replica, last_counter FROM tree_payload WHERE node = ?1 LIMIT 1",
+            ),
+            upsert: LazyStatement::new(
+                db,
+                c"INSERT INTO tree_payload(node,payload,last_lamport,last_replica,last_counter) VALUES (?1,?2,?3,?4,?5) ON CONFLICT(node) DO UPDATE SET payload = excluded.payload, last_lamport = excluded.last_lamport, last_replica = excluded.last_replica, last_counter = excluded.last_counter",
+            ),
+            delete: LazyStatement::new(db, c"DELETE FROM tree_payload WHERE node = ?1"),
         })
-    }
-}
-
-impl Drop for SqlitePayloadStore {
-    fn drop(&mut self) {
-        unsafe {
-            sqlite_finalize(self.select);
-            sqlite_finalize(self.upsert);
-            sqlite_finalize(self.delete);
-        }
     }
 }
 
@@ -81,28 +45,29 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
 
     fn payload(&self, node: NodeId) -> treecrdt_core::Result<Option<Vec<u8>>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select);
-            sqlite_reset(self.select);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.select);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(bind_rc, "bind select payload failed"));
             }
 
-            let step_rc = sqlite_step(self.select);
+            let step_rc = sqlite_step(stmt);
             let payload = if step_rc == SQLITE_ROW as c_int {
-                if sqlite_column_type(self.select, 0) == SQLITE_NULL as c_int {
+                if sqlite_column_type(stmt, 0) == SQLITE_NULL as c_int {
                     None
                 } else {
-                    let ptr = sqlite_column_blob(self.select, 0) as *const u8;
-                    let len = sqlite_column_bytes(self.select, 0) as usize;
+                    let ptr = sqlite_column_blob(stmt, 0) as *const u8;
+                    let len = sqlite_column_bytes(stmt, 0) as usize;
                     if ptr.is_null() {
                         None
                     } else {
@@ -112,10 +77,10 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
             } else if step_rc == SQLITE_DONE as c_int {
                 None
             } else {
-                sqlite_reset(self.select);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(step_rc, "select payload step failed"));
             };
-            sqlite_reset(self.select);
+            sqlite_reset(stmt);
             Ok(payload)
         }
     }
@@ -125,35 +90,36 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
         node: NodeId,
     ) -> treecrdt_core::Result<Option<(Lamport, treecrdt_core::OperationId)>> {
         let bytes = sqlite_node_id_bytes(node);
+        let stmt = self.select.get()?;
         unsafe {
-            sqlite_clear_bindings(self.select);
-            sqlite_reset(self.select);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.select,
+                stmt,
                 1,
                 bytes.as_ptr() as *const c_void,
                 bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.select);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(
                     bind_rc,
                     "bind select payload writer failed",
                 ));
             }
 
-            let step_rc = sqlite_step(self.select);
+            let step_rc = sqlite_step(stmt);
             let writer = if step_rc == SQLITE_ROW as c_int {
-                let lamport = sqlite_column_int64(self.select, 1).max(0) as Lamport;
-                let rep_ptr = sqlite_column_blob(self.select, 2) as *const u8;
-                let rep_len = sqlite_column_bytes(self.select, 2) as usize;
+                let lamport = sqlite_column_int64(stmt, 1).max(0) as Lamport;
+                let rep_ptr = sqlite_column_blob(stmt, 2) as *const u8;
+                let rep_len = sqlite_column_bytes(stmt, 2) as usize;
                 let replica = if rep_ptr.is_null() || rep_len == 0 {
                     Vec::new()
                 } else {
                     slice::from_raw_parts(rep_ptr, rep_len).to_vec()
                 };
-                let counter = sqlite_column_int64(self.select, 3).max(0) as u64;
+                let counter = sqlite_column_int64(stmt, 3).max(0) as u64;
                 Some((
                     lamport,
                     treecrdt_core::OperationId {
@@ -164,13 +130,13 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
             } else if step_rc == SQLITE_DONE as c_int {
                 None
             } else {
-                sqlite_reset(self.select);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(
                     step_rc,
                     "select payload writer step failed",
                 ));
             };
-            sqlite_reset(self.select);
+            sqlite_reset(stmt);
             Ok(writer)
         }
     }
@@ -183,14 +149,15 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
     ) -> treecrdt_core::Result<()> {
         let node_bytes = sqlite_node_id_bytes(node);
         let (lamport, id) = writer;
+        let stmt = self.upsert.get()?;
         unsafe {
-            sqlite_clear_bindings(self.upsert);
-            sqlite_reset(self.upsert);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
         }
         let mut bind_err = false;
         unsafe {
             bind_err |= sqlite_bind_blob(
-                self.upsert,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
@@ -199,35 +166,35 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
 
             if let Some(ref bytes) = payload {
                 bind_err |= sqlite_bind_blob(
-                    self.upsert,
+                    stmt,
                     2,
                     bytes.as_ptr() as *const c_void,
                     bytes.len() as c_int,
                     None,
                 ) != SQLITE_OK as c_int;
             } else {
-                bind_err |= sqlite_bind_null(self.upsert, 2) != SQLITE_OK as c_int;
+                bind_err |= sqlite_bind_null(stmt, 2) != SQLITE_OK as c_int;
             }
 
-            bind_err |= sqlite_bind_int64(self.upsert, 3, lamport as i64) != SQLITE_OK as c_int;
+            bind_err |= sqlite_bind_int64(stmt, 3, lamport as i64) != SQLITE_OK as c_int;
             bind_err |= sqlite_bind_blob(
-                self.upsert,
+                stmt,
                 4,
                 id.replica.as_bytes().as_ptr() as *const c_void,
                 id.replica.as_bytes().len() as c_int,
                 None,
             ) != SQLITE_OK as c_int;
-            bind_err |= sqlite_bind_int64(self.upsert, 5, id.counter as i64) != SQLITE_OK as c_int;
+            bind_err |= sqlite_bind_int64(stmt, 5, id.counter as i64) != SQLITE_OK as c_int;
         }
         if bind_err {
-            unsafe { sqlite_reset(self.upsert) };
+            unsafe { sqlite_reset(stmt) };
             return Err(sqlite_rc_error(
                 SQLITE_ERROR as c_int,
                 "bind upsert payload failed",
             ));
         }
-        let step_rc = unsafe { sqlite_step(self.upsert) };
-        unsafe { sqlite_reset(self.upsert) };
+        let step_rc = unsafe { sqlite_step(stmt) };
+        unsafe { sqlite_reset(stmt) };
         if step_rc != SQLITE_DONE as c_int {
             return Err(sqlite_rc_error(step_rc, "upsert payload step failed"));
         }
@@ -238,22 +205,23 @@ impl treecrdt_core::PayloadStore for SqlitePayloadStore {
 impl treecrdt_core::ExactPayloadStore for SqlitePayloadStore {
     fn clear_payload(&mut self, node: NodeId) -> treecrdt_core::Result<()> {
         let node_bytes = sqlite_node_id_bytes(node);
+        let stmt = self.delete.get()?;
         unsafe {
-            sqlite_clear_bindings(self.delete);
-            sqlite_reset(self.delete);
+            sqlite_clear_bindings(stmt);
+            sqlite_reset(stmt);
             let bind_rc = sqlite_bind_blob(
-                self.delete,
+                stmt,
                 1,
                 node_bytes.as_ptr() as *const c_void,
                 node_bytes.len() as c_int,
                 None,
             );
             if bind_rc != SQLITE_OK as c_int {
-                sqlite_reset(self.delete);
+                sqlite_reset(stmt);
                 return Err(sqlite_rc_error(bind_rc, "bind delete payload failed"));
             }
-            let step_rc = sqlite_step(self.delete);
-            sqlite_reset(self.delete);
+            let step_rc = sqlite_step(stmt);
+            sqlite_reset(stmt);
             if step_rc != SQLITE_DONE as c_int {
                 return Err(sqlite_rc_error(step_rc, "delete payload step failed"));
             }

--- a/packages/treecrdt-sqlite-ext/src/extension/functions/statement.rs
+++ b/packages/treecrdt-sqlite-ext/src/extension/functions/statement.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+use std::{cell::Cell, ffi::CStr};
+
+/// Lazily prepares a SQLite statement and finalizes it with its owning operation-scoped store.
+///
+/// Statements intentionally do not outlive the store: keeping them across local UDF calls would
+/// leave the SQLite connection busy when its owner tries to close it.
+pub(super) struct LazyStatement {
+    db: *mut sqlite3,
+    sql: &'static CStr,
+    stmt: Cell<*mut sqlite3_stmt>,
+}
+
+impl LazyStatement {
+    pub(super) fn new(db: *mut sqlite3, sql: &'static CStr) -> Self {
+        Self {
+            db,
+            sql,
+            stmt: Cell::new(null_mut()),
+        }
+    }
+
+    pub(super) fn get(&self) -> treecrdt_core::Result<*mut sqlite3_stmt> {
+        let cached = self.stmt.get();
+        if !cached.is_null() {
+            return Ok(cached);
+        }
+
+        let mut stmt = null_mut();
+        let rc = sqlite_prepare_v2(self.db, self.sql.as_ptr(), -1, &mut stmt, null_mut());
+        if rc != SQLITE_OK as c_int || stmt.is_null() {
+            if !stmt.is_null() {
+                unsafe { sqlite_finalize(stmt) };
+            }
+            return Err(treecrdt_core::Error::Storage(format!(
+                "sqlite_prepare_v2 failed (rc={rc})"
+            )));
+        }
+        self.stmt.set(stmt);
+        Ok(stmt)
+    }
+}
+
+impl Drop for LazyStatement {
+    fn drop(&mut self) {
+        let stmt = self.stmt.get();
+        if !stmt.is_null() {
+            unsafe { sqlite_finalize(stmt) };
+        }
+    }
+}

--- a/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
+++ b/packages/treecrdt-sqlite-ext/tests/extension_roundtrip.rs
@@ -1,6 +1,9 @@
 #![cfg(all(feature = "rusqlite-storage", feature = "ext-sqlite"))]
 use std::env;
+use std::ffi::CStr;
+use std::os::raw::{c_char, c_int, c_void};
 use std::path::PathBuf;
+use std::ptr::null_mut;
 
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
@@ -1091,6 +1094,162 @@ fn oprefs_children_include_payload_after_move() {
         .unwrap();
     let refs: Vec<Vec<u8>> = serde_json::from_str(&refs_json).unwrap();
     assert_eq!(refs.len(), 2);
+}
+
+#[test]
+fn repeated_local_ops_release_statements_before_connection_close() {
+    let conn = setup_conn();
+
+    let replica = b"lifecycle".to_vec();
+    let root = node_bytes(0);
+    let parent_a = node_bytes(1);
+    let parent_b = node_bytes(2);
+
+    for parent in [&parent_a, &parent_b] {
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, NULL)",
+                rusqlite::params![replica, root, parent],
+                |row| row.get(0),
+            )
+            .unwrap();
+    }
+
+    for id in 3..35u128 {
+        let node = node_bytes(id);
+        let payload = id.to_be_bytes().to_vec();
+
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_local_insert(?1, ?2, ?3, 'last', NULL, ?4)",
+                rusqlite::params![replica, parent_a, node, payload],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_local_payload(?1, ?2, ?3)",
+                rusqlite::params![replica, node, vec![id as u8; 32]],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_local_move(?1, ?2, ?3, 'last', NULL)",
+                rusqlite::params![replica, node, parent_b],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let _: String = conn
+            .query_row(
+                "SELECT treecrdt_local_delete(?1, ?2)",
+                rusqlite::params![replica, node],
+                |row| row.get(0),
+            )
+            .unwrap();
+    }
+
+    conn.close()
+        .expect("local helper statements should be finalized before connection close");
+}
+
+#[test]
+fn failed_local_op_releases_statements_before_the_next_write() {
+    let conn = setup_conn();
+
+    let replica = b"failure-recovery".to_vec();
+    let root = node_bytes(0);
+    let node = node_bytes(1);
+    let _: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'first', NULL, ?4)",
+            rusqlite::params![replica, root, node, vec![1u8]],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    conn.execute_batch(
+        "CREATE TRIGGER fail_tree_payload_upsert \
+         BEFORE INSERT ON tree_payload \
+         BEGIN \
+           SELECT RAISE(ABORT, 'forced local write failure'); \
+         END;",
+    )
+    .unwrap();
+    let failed: rusqlite::Result<String> = conn.query_row(
+        "SELECT treecrdt_local_payload(?1, ?2, ?3)",
+        rusqlite::params![replica, node, vec![2u8]],
+        |row| row.get(0),
+    );
+    assert!(failed.is_err());
+
+    conn.execute_batch("DROP TRIGGER fail_tree_payload_upsert").unwrap();
+    let recovered: String = conn
+        .query_row(
+            "SELECT treecrdt_local_payload(?1, ?2, ?3)",
+            rusqlite::params![replica, node, vec![3u8]],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let ops: Vec<JsonOp> = decode_ops_or_local_result(&recovered);
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].payload, Some(vec![3u8]));
+
+    conn.close()
+        .expect("failed local helper statements should not leak into connection close");
+}
+
+unsafe extern "C" fn deny_tree_payload_delete(
+    _context: *mut c_void,
+    action: c_int,
+    table: *const c_char,
+    _column: *const c_char,
+    _database: *const c_char,
+    _trigger: *const c_char,
+) -> c_int {
+    let is_tree_payload =
+        !table.is_null() && unsafe { CStr::from_ptr(table) }.to_bytes() == b"tree_payload";
+    if action == rusqlite::ffi::SQLITE_DELETE && is_tree_payload {
+        rusqlite::ffi::SQLITE_DENY
+    } else {
+        rusqlite::ffi::SQLITE_OK
+    }
+}
+
+#[test]
+fn local_payload_does_not_prepare_an_unused_delete_statement() {
+    let conn = setup_conn();
+
+    let replica = b"lazy-prepare".to_vec();
+    let root = node_bytes(0);
+    let node = node_bytes(1);
+    let _: String = conn
+        .query_row(
+            "SELECT treecrdt_local_insert(?1, ?2, ?3, 'first', NULL, ?4)",
+            rusqlite::params![replica, root, node, vec![1u8]],
+            |row| row.get(0),
+        )
+        .unwrap();
+
+    let set_authorizer_rc = unsafe {
+        rusqlite::ffi::sqlite3_set_authorizer(
+            conn.handle(),
+            Some(deny_tree_payload_delete),
+            null_mut(),
+        )
+    };
+    assert_eq!(set_authorizer_rc, rusqlite::ffi::SQLITE_OK);
+
+    let result: rusqlite::Result<String> = conn.query_row(
+        "SELECT treecrdt_local_payload(?1, ?2, ?3)",
+        rusqlite::params![replica, node, vec![2u8]],
+        |row| row.get(0),
+    );
+
+    let clear_authorizer_rc =
+        unsafe { rusqlite::ffi::sqlite3_set_authorizer(conn.handle(), None, null_mut()) };
+    assert_eq!(clear_authorizer_rc, rusqlite::ffi::SQLITE_OK);
+    result.expect("payload writes should not prepare the unused payload-delete statement");
 }
 
 fn setup_conn() -> Connection {


### PR DESCRIPTION
Refs #70

Local writes prepared all 15 SQLite helper statements even when most were unused. This patch prepares node, payload, and parent-index statements on first use, then finalizes them before the local UDF returns.

This stays operation-scoped, so #70 remains open for safe reuse across operations.

## Benchmarks

Median batch-time reduction (patch vs base):

| Local operation | Native, memory | Native, file-backed | wa-sqlite WASM, memory | wa-sqlite WASM, OPFS |
|---|---:|---:|---:|---:|
| Insert | 16.6% | 1.8% | 6.7% | 0.5% |
| Payload | 32.2% | 5.5% | 22.9% | 0.6% |
| Move | 24.9% | 4.0% | 15.1% | -0.9% |
| Delete | 18.7% | 3.4% | 14.0% | 1.5% |

Positive values mean lower median duration. Native and direct-WASM results used 11 samples; Chromium OPFS used seven alternating pairs. The OPFS differences are within normal run-to-run noise, so there was no measurable browser disk-backed gain; transaction and worker overhead dominate there.
