### PR TITLE
Use synchronous wa-sqlite for dedicated-worker OPFS

### DIFF
--- a/.changeset/quiet-spoons-sync.md
+++ b/.changeset/quiet-spoons-sync.md
@@ -1,0 +1,6 @@
+---
+'@treecrdt/wa-sqlite': patch
+---
+
+Use the synchronous wa-sqlite build for dedicated-worker OPFS and memory databases while retaining
+the Asyncify build for direct and shared-worker OPFS access.

--- a/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
+++ b/packages/treecrdt-wa-sqlite/e2e/src/App.tsx
@@ -16,7 +16,7 @@ export default function App() {
       (window as any).__createTreecrdtClient = async (
         storage: 'memory' | 'opfs',
         baseUrl?: string,
-        runtime: 'auto' | 'dedicated-worker' | 'shared-worker' = 'auto',
+        runtime: 'auto' | 'direct' | 'dedicated-worker' | 'shared-worker' = 'auto',
       ) => {
         const c = await createTreecrdtClient({
           storage: storage === 'opfs' ? { type: 'opfs' } : { type: 'memory' },

--- a/packages/treecrdt-wa-sqlite/e2e/tests/basepath.spec.ts
+++ b/packages/treecrdt-wa-sqlite/e2e/tests/basepath.spec.ts
@@ -17,26 +17,58 @@ test.describe.serial('non-root base path', () => {
     expect(summary.storage).toBe('memory');
   });
 
-  test('opfs client uses dedicated worker mode in preview build with base path', async ({
+  test('opfs client uses the synchronous build in a dedicated worker with a base path', async ({
     page,
   }, testInfo) => {
     if (testInfo.project.name !== 'chromium-basepath-preview') test.skip();
     const wasmRequests: string[] = [];
+    const moduleRequests: string[] = [];
     page.on('request', (request) => {
       const url = new URL(request.url());
       if (url.pathname.endsWith('.wasm')) wasmRequests.push(url.pathname);
+      if (url.pathname.endsWith('.mjs')) moduleRequests.push(url.pathname);
     });
     await page.goto('/base-path/');
     await page.waitForSelector('[data-testid="run-demo"]', { timeout: 30_000 });
     const summary = await page.evaluate(async () => {
       const fn = (window as any).__createTreecrdtClient;
       if (!fn) return null;
-      return await fn('opfs');
+      return await fn('opfs', undefined, 'dedicated-worker');
     });
     expect(summary).not.toBeNull();
     expect(summary.mode).toBe('worker');
     expect(summary.runtime).toBe('dedicated-worker');
     expect(summary.storage).toBe('opfs');
+    expect(moduleRequests).toContain('/base-path/wa-sqlite/wa-sqlite.mjs');
+    expect(wasmRequests).toContainEqual(
+      expect.stringMatching(/^\/base-path\/assets\/wa-sqlite-[A-Za-z0-9_-]+\.wasm$/),
+    );
+    expect(wasmRequests.some((path) => path.includes('/wa-sqlite-async-'))).toBe(false);
+  });
+
+  test('direct opfs uses the Asyncify build in preview with base path', async ({
+    page,
+  }, testInfo) => {
+    if (testInfo.project.name !== 'chromium-basepath-preview') test.skip();
+    const wasmRequests: string[] = [];
+    const moduleRequests: string[] = [];
+    page.on('request', (request) => {
+      const url = new URL(request.url());
+      if (url.pathname.endsWith('.wasm')) wasmRequests.push(url.pathname);
+      if (url.pathname.endsWith('.mjs')) moduleRequests.push(url.pathname);
+    });
+    await page.goto('/base-path/');
+    await page.waitForSelector('[data-testid="run-demo"]', { timeout: 30_000 });
+    const summary = await page.evaluate(async () => {
+      const fn = (window as any).__createTreecrdtClient;
+      if (!fn) return null;
+      return await fn('opfs', undefined, 'direct');
+    });
+    expect(summary).not.toBeNull();
+    expect(summary.mode).toBe('direct');
+    expect(summary.runtime).toBe('direct');
+    expect(summary.storage).toBe('opfs');
+    expect(moduleRequests).toContain('/base-path/wa-sqlite/wa-sqlite-async.mjs');
     expect(wasmRequests).toContainEqual(
       expect.stringMatching(/^\/base-path\/assets\/wa-sqlite-async-[A-Za-z0-9_-]+\.wasm$/),
     );

--- a/packages/treecrdt-wa-sqlite/src/load-wa-sqlite.browser.ts
+++ b/packages/treecrdt-wa-sqlite/src/load-wa-sqlite.browser.ts
@@ -1,8 +1,13 @@
+import waSqliteWasmUrl from './wa-sqlite/wa-sqlite.wasm?url';
 import waSqliteAsyncWasmUrl from './wa-sqlite/wa-sqlite-async.wasm?url';
+
+export type WaSqliteBuild = 'sync' | 'asyncify';
 
 export type LoadWaSqliteOptions = {
   /** Public URL prefix for wa-sqlite JS assets; Vite bundles the WASM with a content hash. */
   assetsDir?: string;
+  /** wa-sqlite build to load. Asyncify is required by VFS implementations that run async I/O. */
+  build?: WaSqliteBuild;
 };
 
 export type LoadWaSqliteResult = {
@@ -20,12 +25,13 @@ export async function loadWaSqliteBrowser(
 ): Promise<LoadWaSqliteResult> {
   const baseUrl = opts.assetsDir ?? defaultBrowserBaseUrl();
   const normalized = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
-  const sqliteModule = await import(
-    /* @vite-ignore */ `${normalized}wa-sqlite/wa-sqlite-async.mjs`
-  );
+  const build = opts.build ?? 'asyncify';
+  const moduleFilename = build === 'sync' ? 'wa-sqlite.mjs' : 'wa-sqlite-async.mjs';
+  const wasmUrl = build === 'sync' ? waSqliteWasmUrl : waSqliteAsyncWasmUrl;
+  const sqliteModule = await import(/* @vite-ignore */ `${normalized}wa-sqlite/${moduleFilename}`);
   const sqliteApi = await import(/* @vite-ignore */ `${normalized}wa-sqlite/sqlite-api.js`);
   const module = await sqliteModule.default({
-    locateFile: (file: string) => (file.endsWith('.wasm') ? waSqliteAsyncWasmUrl : file),
+    locateFile: (file: string) => (file.endsWith('.wasm') ? wasmUrl : file),
   });
   return { sqlite3: sqliteApi.Factory(module), module };
 }

--- a/packages/treecrdt-wa-sqlite/src/open-core.ts
+++ b/packages/treecrdt-wa-sqlite/src/open-core.ts
@@ -100,6 +100,7 @@ function closeDatabaseWithVfs(db: Database, vfs: { close?: () => Promise<void> |
 export async function openTreecrdtDbWithLoader(
   opts: OpenTreecrdtDbOptions,
   load: () => Promise<{ sqlite3: any; module: any }>,
+  loadMemoryFallback: () => Promise<{ sqlite3: any; module: any }> = load,
 ): Promise<OpenTreecrdtDbResult> {
   const loaded = await load();
   const { sqlite3, module } = loaded;
@@ -145,7 +146,7 @@ export async function openTreecrdtDbWithLoader(
   // A failed OPFS attempt leaves its registered VFS and callback state on the module even after
   // the VFS is closed. Isolate the memory fallback in a fresh module instead of reusing that state.
   try {
-    const memoryLoaded = opfsError !== undefined ? await load() : loaded;
+    const memoryLoaded = opfsError !== undefined ? await loadMemoryFallback() : loaded;
     const handle = await memoryLoaded.sqlite3.open_v2(':memory:');
     const opened = await initializeOpenedDatabase(
       memoryLoaded.sqlite3,

--- a/packages/treecrdt-wa-sqlite/src/open.ts
+++ b/packages/treecrdt-wa-sqlite/src/open.ts
@@ -9,5 +9,13 @@ export type { OpenTreecrdtDbOptions, OpenTreecrdtDbResult };
 
 /** Browser/worker entry: loads wa-sqlite assets from public URLs. */
 export async function openTreecrdtDb(opts: OpenTreecrdtDbOptions): Promise<OpenTreecrdtDbResult> {
-  return openTreecrdtDbWithLoader(opts, () => loadWaSqliteBrowser({ assetsDir: opts.baseUrl }));
+  const load = (build: 'sync' | 'asyncify') =>
+    loadWaSqliteBrowser({ assetsDir: opts.baseUrl, build });
+  return openTreecrdtDbWithLoader(
+    opts,
+    // OPFSAnyContextVFS performs async I/O and requires Asyncify. OPFSCoopSyncVFS and memory
+    // databases use the synchronous build.
+    () => load(opts.storage === 'opfs' && opts.opfsVfs === 'any-context' ? 'asyncify' : 'sync'),
+    () => load('sync'),
+  );
 }

--- a/packages/treecrdt-wa-sqlite/src/vite-plugin.ts
+++ b/packages/treecrdt-wa-sqlite/src/vite-plugin.ts
@@ -17,13 +17,18 @@ export type WaSqlitePluginOptions = {
   outDirs?: string[];
 };
 
-const defaultFiles = ['wa-sqlite-async.mjs', 'sqlite-api.js', 'sqlite-constants.js'];
+const defaultFiles = [
+  'wa-sqlite.mjs',
+  'wa-sqlite-async.mjs',
+  'sqlite-api.js',
+  'sqlite-constants.js',
+];
 
-const stalePublicAssets = ['wa-sqlite.mjs', 'wa-sqlite.wasm', 'wa-sqlite-async.wasm'];
+const stalePublicAssets = ['wa-sqlite.wasm', 'wa-sqlite-async.wasm'];
 
 /**
  * Copies wa-sqlite JS artifacts into the app's public folder.
- * WASM is imported through Vite's asset graph and emitted once with a content hash.
+ * WASM is imported through Vite's asset graph and emitted with content hashes.
  * This removes the need for ad-hoc copy scripts in example apps.
  */
 export function treecrdt(opts: WaSqlitePluginOptions = {}): Plugin {

--- a/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
+++ b/packages/treecrdt-wa-sqlite/tests/open-fallback.test.ts
@@ -79,6 +79,34 @@ test('falls back to memory when opening the OPFS database fails', async () => {
   expect(load).toHaveBeenCalledTimes(2);
 });
 
+test('uses a separate loader for memory fallback', async () => {
+  const vfs = { close: vi.fn() };
+  vi.mocked(createOpfsVfs).mockResolvedValue(vfs);
+  const opfsSqlite3 = createFakeSqlite({ failOpen: '/separate-loader.db' });
+  const memorySqlite3 = createFakeSqlite();
+  const load = vi.fn(async () => ({ sqlite3: opfsSqlite3, module: createFakeModule() }));
+  const loadMemoryFallback = vi.fn(async () => ({
+    sqlite3: memorySqlite3,
+    module: createFakeModule(),
+  }));
+
+  const opened = await openTreecrdtDbWithLoader(
+    {
+      storage: 'opfs',
+      filename: '/separate-loader.db',
+      docId: 'separate-loader',
+      requireOpfs: false,
+    },
+    load,
+    loadMemoryFallback,
+  );
+
+  expect(opened.storage).toBe('memory');
+  expect(load).toHaveBeenCalledOnce();
+  expect(loadMemoryFallback).toHaveBeenCalledOnce();
+  expect(memorySqlite3.open_v2).toHaveBeenCalledWith(':memory:');
+});
+
 test('falls back to memory when initializing the OPFS VFS fails', async () => {
   const vfsFailure = new Error('OPFS VFS unavailable');
   vi.mocked(createOpfsVfs).mockRejectedValue(vfsFailure);


### PR DESCRIPTION
## Summary

- use the synchronous wa-sqlite build for dedicated-worker OPFS and memory storage
- retain Asyncify for direct and shared-worker OPFS, where the any-context VFS requires asynchronous callbacks
- use a fresh synchronous module when OPFS falls back to memory
- verify the selected module and hashed WASM assets in the existing base-path browser suite

## Why

The browser loader previously used Asyncify for every runtime. On iOS 26, an em workload using dedicated-worker OPFS grew the WebContent process to about 1.47 GB before a high-water termination and reload. With the same database and workload on the synchronous build, memory stayed around 260–300 MB with no restart.

OPFSCoopSyncVFS runs inside the dedicated worker and does not require Asyncify. Direct and SharedWorker OPFS continue using OPFSAnyContextVFS and Asyncify.

This matches the native-memory behavior tracked in WebKit issue 304810: https://bugs.webkit.org/show_bug.cgi?id=304810
